### PR TITLE
Add Claude Code session initialization hooks

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+cd "$PROJECT_DIR"
+
+# Install Node.js dependencies if package.json exists
+if [ -f "package.json" ]; then
+  echo "Installing Node.js dependencies..."
+  npm install
+fi
+
+# Install Python dependencies if requirements.txt exists
+if [ -f "requirements.txt" ]; then
+  echo "Installing Python dependencies..."
+  pip install -r requirements.txt
+fi
+
+# Install Python dependencies if pyproject.toml exists
+if [ -f "pyproject.toml" ]; then
+  echo "Installing Python dependencies (pyproject.toml)..."
+  pip install -e .
+fi
+
+echo "Session start hook completed."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds automatic dependency installation on Claude Code session start in remote environments. It introduces a session initialization hook system that automatically installs Node.js and Python dependencies when opening a project.

## Key Changes
- **`.claude/hooks/session-start.sh`**: New bash script that runs on session start in remote Claude Code environments
  - Automatically installs Node.js dependencies via `npm install` if `package.json` exists
  - Automatically installs Python dependencies via `pip install -r requirements.txt` if `requirements.txt` exists
  - Automatically installs Python dependencies via `pip install -e .` if `pyproject.toml` exists
  - Only executes in remote environments (checks `CLAUDE_CODE_REMOTE` environment variable)

- **`.claude/settings.json`**: New configuration file that registers the session start hook
  - Defines the `SessionStart` hook to execute the initialization script
  - Uses the standard Claude Code hooks configuration format

## Implementation Details
- The session start script uses `set -euo pipefail` for safe bash execution
- Project directory is determined dynamically using git or environment variables
- Each dependency installation step is conditional, allowing projects to use any combination of Node.js and Python dependencies
- The script gracefully exits early if not in a remote environment, preventing unnecessary execution in local setups

https://claude.ai/code/session_016FArzdXhqaHaB2RXn1d3Vg