### PR TITLE
Add SVG logo and favicon

### DIFF
--- a/index.php
+++ b/index.php
@@ -78,6 +78,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Subnet Calculator</title>
+    <link rel="icon" type="image/svg+xml" href="logo.svg">
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -103,9 +104,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         .title-row {
             display: flex;
-            align-items: baseline;
+            align-items: center;
             gap: 0.6rem;
             margin-bottom: 0.25rem;
+        }
+
+        .logo {
+            width: 32px;
+            height: 32px;
+            flex-shrink: 0;
         }
 
         h1 {
@@ -253,6 +260,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body>
 <div class="card">
     <div class="title-row">
+        <img src="logo.svg" alt="Subnet Calculator logo" class="logo">
         <h1>Subnet Calculator</h1>
         <span class="version">v0.1</span>
     </div>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e40af"/>
+      <stop offset="100%" style="stop-color:#0ea5e9"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background rounded square -->
+  <rect width="64" height="64" rx="12" fill="url(#bg)"/>
+
+  <!-- Network nodes -->
+  <circle cx="32" cy="14" r="5" fill="#fff" opacity="0.95"/>
+  <circle cx="14" cy="42" r="5" fill="#fff" opacity="0.95"/>
+  <circle cx="50" cy="42" r="5" fill="#fff" opacity="0.95"/>
+
+  <!-- Network lines -->
+  <line x1="32" y1="19" x2="17" y2="38" stroke="#fff" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="32" y1="19" x2="47" y2="38" stroke="#fff" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="19"  y1="42" x2="45" y2="42" stroke="#fff" stroke-width="2" stroke-opacity="0.6"/>
+
+  <!-- Slash (CIDR notation hint) -->
+  <line x1="28" y1="54" x2="36" y2="46" stroke="#7dd3fc" stroke-width="2.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary

- Added `logo.svg` — network topology icon with blue gradient background, connected nodes, and a CIDR `/` slash motif
- Wired as browser favicon via `<link rel="icon" type="image/svg+xml">`
- Displayed inline next to the title in the UI header (32px)

## Test plan

- [ ] Favicon appears in browser tab
- [ ] Logo displays correctly next to "Subnet Calculator v0.1" heading
- [ ] SVG renders correctly in light and dark contexts

https://claude.ai/code/session_016FArzdXhqaHaB2RXn1d3Vg