### PR TITLE
Fix footer link position

### DIFF
--- a/index.php
+++ b/index.php
@@ -481,11 +481,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </div>
         <?php endif; ?>
     </div>
+    <footer>
+        <a href="https://github.com/seanmousseau/Subnet-Calculator" target="_blank" rel="noopener">github.com/seanmousseau/Subnet-Calculator</a>
+    </footer>
 </div>
-
-<footer>
-    <a href="https://github.com/seanmousseau/Subnet-Calculator" target="_blank" rel="noopener">github.com/seanmousseau/Subnet-Calculator</a>
-</footer>
 
 <script>
 document.querySelectorAll('.tab-btn').forEach(btn => {


### PR DESCRIPTION
## Summary

Fixes the GitHub repo link appearing outside/beside the card instead of at the bottom of it. The `<footer>` element was placed outside the `.card` div, causing flexbox to render it horizontally next to the card.

## Test plan

- [ ] GitHub link appears at the bottom of the card
- [ ] Link opens github.com/seanmousseau/Subnet-Calculator in a new tab

https://claude.ai/code/session_016FArzdXhqaHaB2RXn1d3Vg