### PR TITLE
v0.4–v0.6: wildcard mask, theming, IPv6 types, subnet splitter, share URL, bug fixes

### DIFF
--- a/index.php
+++ b/index.php
@@ -809,7 +809,7 @@ if ($result) {
             .split-list { grid-template-columns: 1fr; }
         }
     </style>
-    <?php if ($bg_override_style): ?><style><?= $bg_override_style ?></style><?php endif; ?>
+    <?php if ($bg_override_style) echo '<style>' . $bg_override_style . '</style>'; ?>
 </head>
 <body>
 <div class="card">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **v0.4**: Wildcard mask output, click-to-copy on result rows, CSS custom property theming (`--color-bg`, `--color-input-bg`), CIDR paste auto-split on blur
- **v0.5**: Light/dark mode toggle with `localStorage` persistence, IPv4 address type badges (Private, Loopback, Link-local, etc.), IPv6 address type badges, shareable URL bar
- **v0.6**: Subnet splitter (split IPv4 subnet into up to 16 equal subnets), fixed background colour override (`$fixed_bg_color`), full absolute share URL display, server-side CIDR-on-submit fix (closes #27)
- **Bug fix**: HTTP 500 when `$fixed_bg_color` is set — replaced short echo tag inside `<style>` with pure PHP `echo` (closes #32)

## Issues closed

#15 #21 #22 #27 #28 #29 #30 #32

## Test plan

- [ ] Calculate `192.168.1.0/24` → all IPv4 fields correct, address type badge shows "Private"
- [ ] Enter `192.168.1.0/24` in IP field and press Enter → splits correctly, results shown
- [ ] Share bar shows full URL; Copy button copies to clipboard
- [ ] Load share URL directly → inputs populated, calculation runs automatically
- [ ] Subnet splitter: enter `/26` → four subnets listed
- [ ] Set `$fixed_bg_color = '#1a1a2e'` → background pinned in both light and dark mode, no 500 error
- [ ] Light/dark toggle persists across page reload
- [ ] IPv6 tab: calculate `2001:db8::1/64` → correct results, type badge shows "Documentation"

https://claude.ai/code/session_016FArzdXhqaHaB2RXn1d3Vg
EOF
)