### PR TITLE
fix: iframe height sizing — remove min-height/centering from body in iframe mode

### DIFF
--- a/index.php
+++ b/index.php
@@ -327,7 +327,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Build iframe style override
-$iframe_style = $iframe_mode ? 'html,body{margin:0;padding:0;overflow:hidden}' : '';
+$iframe_style = $iframe_mode ? 'html,body{margin:0;padding:0;overflow:hidden}body{min-height:0!important;align-items:flex-start!important}' : '';
 
 // Build fixed background override style (avoids inline PHP inside CSS block — #32)
 $bg_override_style = '';
@@ -1118,16 +1118,12 @@ autoFocusActive();
 // ── iframe: report height to parent via postMessage ──────────────────────────
 (function () {
     function postHeight() {
-        var card = document.querySelector('.card');
-        if (!card) return;
-        var rect  = card.getBoundingClientRect();
-        var style = window.getComputedStyle(card);
-        var h = Math.ceil(rect.bottom + parseFloat(style.marginBottom || 0));
+        var h = Math.ceil(document.body.getBoundingClientRect().height);
         window.parent.postMessage({ type: 'sc-resize', height: h }, '*');
     }
     postHeight();
     if (window.ResizeObserver) {
-        new ResizeObserver(postHeight).observe(document.querySelector('.card') || document.documentElement);
+        new ResizeObserver(postHeight).observe(document.body);
     }
 })();
 <?php endif; ?>


### PR DESCRIPTION
## Summary

- Fix iframe rendering: card was vertically centred inside a `min-height: 100vh` body, causing the reported height to track the card's midpoint rather than the full content area — leaving dead space above and below
- Override `min-height` and `align-items` on body in iframe mode so the body shrinks to fit its content
- Switch height measurement from `card.getBoundingClientRect().bottom` to `body.getBoundingClientRect().height`, which correctly reflects content on both grow and shrink

## Changes

- `index.php`: expanded `$iframe_style` to also override `body { min-height: 0; align-items: flex-start }`
- `index.php`: `postHeight()` now observes and measures `document.body` instead of `.card`

## Test plan

- [ ] Set `$iframe_mode = true;`, embed with the README snippet
- [ ] Page loads — iframe fits form with no white space above or below
- [ ] Submit a calculation — iframe grows to fit results, no gap
- [ ] Click reset — iframe shrinks back to form-only height
- [ ] Switch tabs — iframe adjusts correctly

https://claude.ai/code/session_016FArzdXhqaHaB2RXn1d3Vg