### PR TITLE
feat: auto-detect iframe — remove $iframe_mode config requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,18 @@ All tuneable values are declared at the top of `index.php` under the `// ──�
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `$fixed_bg_color` | `'null'` | Pin the page background to a hex colour (e.g. `'#1a1a2e'`) regardless of light/dark mode. Leave as `'null'` to use the theme default. |
-| `$iframe_mode` | `false` | Set to `true` when embedding in an iframe (see [Embedding](#embedding)). |
 | `$default_tab` | `'ipv4'` | Active tab on page load: `'ipv4'` or `'ipv6'`. |
 | `$split_max_subnets` | `16` | Maximum number of subnets shown in the subnet splitter results list. |
 
 ## Embedding
 
-The calculator can be embedded in an iframe with automatic height adjustment.
+The calculator automatically detects when it is running inside an iframe. No configuration is required — just embed it and add the host-side resize listener.
 
-**1. Set `$iframe_mode = true;` in `index.php`.**
+When loaded in an iframe the page:
+- Removes body margins, padding, and overflow
+- Broadcasts its height to the parent window via `postMessage` whenever the content changes (form submit, tab switch, results shown/cleared)
 
-This removes body margins/padding and makes the page broadcast its own height to the parent via `postMessage` whenever the content changes.
-
-**2. Add this to your host page:**
+**Add this to your host page:**
 
 ```html
 <div style="width:100%; max-width:1200px; margin:0 auto;">

--- a/index.php
+++ b/index.php
@@ -6,11 +6,6 @@
 // regardless of light/dark mode. Leave as 'null' to use the theme default.
 $fixed_bg_color = 'null';
 
-// Set to true when embedding the calculator in an iframe.
-// Removes body margins/padding and sends height via postMessage so the host
-// page can resize the iframe automatically with a simple one-liner script.
-$iframe_mode = false;
-
 // Default active tab on page load: 'ipv4' or 'ipv6'.
 $default_tab = 'ipv4';
 
@@ -325,9 +320,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
-
-// Build iframe style override
-$iframe_style = $iframe_mode ? 'html,body{margin:0;padding:0;overflow:hidden}body{min-height:0!important;align-items:flex-start!important}' : '';
 
 // Build fixed background override style (avoids inline PHP inside CSS block — #32)
 $bg_override_style = '';
@@ -822,9 +814,19 @@ if ($result) {
             .form-row { flex-direction: column; }
             .split-list { grid-template-columns: 1fr; }
         }
+
+        html.in-iframe,
+        html.in-iframe body {
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+        }
+        html.in-iframe body {
+            min-height: 0;
+            align-items: flex-start;
+        }
     </style>
     <?php if ($bg_override_style) echo '<style>' . $bg_override_style . '</style>'; ?>
-    <?php if ($iframe_style) echo '<style>' . $iframe_style . '</style>'; ?>
 </head>
 <body>
 <div class="card">
@@ -1114,19 +1116,20 @@ function autoFocusActive() {
 
 autoFocusActive();
 
-<?php if ($iframe_mode): ?>
-// ── iframe: report height to parent via postMessage ──────────────────────────
-(function () {
-    function postHeight() {
-        var h = Math.ceil(document.body.getBoundingClientRect().height);
-        window.parent.postMessage({ type: 'sc-resize', height: h }, '*');
-    }
-    postHeight();
-    if (window.ResizeObserver) {
-        new ResizeObserver(postHeight).observe(document.body);
-    }
-})();
-<?php endif; ?>
+// ── iframe: auto-detect and report height to parent via postMessage ───────────
+if (window.self !== window.top) {
+    document.documentElement.classList.add('in-iframe');
+    (function () {
+        function postHeight() {
+            var h = Math.ceil(document.body.getBoundingClientRect().height);
+            window.parent.postMessage({ type: 'sc-resize', height: h }, '*');
+        }
+        postHeight();
+        if (window.ResizeObserver) {
+            new ResizeObserver(postHeight).observe(document.body);
+        }
+    })();
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- The page now detects iframe embedding automatically via `window.self !== window.top` — no PHP config change required
- Adds `in-iframe` class to `<html>`, triggering CSS layout overrides (removes margins/padding, disables vertical centering)
- `postMessage` height reporter starts automatically when embedded
- Removes `$iframe_mode` config variable entirely

## Changes

- `index.php`: removed `$iframe_mode` and all PHP conditionals; added `html.in-iframe` CSS rules; JS detection always present
- `README.md`: removed `$iframe_mode` config row; simplified Embedding section — no setup step needed

## Test plan

- [ ] Embed with the README snippet — iframe sizes correctly with no config change to `index.php`
- [ ] Standalone page loads normally — no layout changes
- [ ] Submit a calculation — iframe grows
- [ ] Click reset — iframe shrinks
- [ ] Switch tabs — iframe adjusts

https://claude.ai/code/session_016FArzdXhqaHaB2RXn1d3Vg