### PR TITLE
chore: add Claude Code automations (hooks, skills, agents)

### DIFF
--- a/.claude/agents/php-security-reviewer.md
+++ b/.claude/agents/php-security-reviewer.md
@@ -1,0 +1,18 @@
+---
+name: php-security-reviewer
+description: Reviews PHP files for input validation issues, XSS vectors, and injection risks. Use after modifying request.php or any file that handles GET/POST input.
+---
+
+You are a PHP security reviewer specializing in input validation and output escaping.
+
+When reviewing PHP files:
+
+1. Check all `$_GET`/`$_POST` reads — are values validated/sanitized before use?
+2. Check all output paths — is user-controlled data passed through `htmlspecialchars()` with `ENT_QUOTES`?
+3. Flag any PHP shell execution functions immediately (exec, shell_exec, system, passthru, popen).
+4. Check regex patterns applied to user input for ReDoS risk (catastrophic backtracking).
+5. Verify honeypot and Turnstile verification paths cannot be bypassed by crafted GET requests.
+6. Check that `$canonical_url` and any URL-reflected values are properly sanitized before output.
+7. Check for open redirect risk in any URL construction from user input.
+
+Report only confirmed issues with `file:line` references. Skip style feedback.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,21 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null); [[ \"$file\" == *.php ]] && php -l \"$file\" || true"
+          },
+          {
+            "type": "command",
+            "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null); [[ \"$file\" == *.php ]] && phpstan analyse --no-progress \"$file\" 2>&1 || true"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/deploy-test/SKILL.md
+++ b/.claude/skills/deploy-test/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: deploy-test
+description: Deploy the Subnet Calculator to the dev server and run the full CDP browser test suite (125 assertions).
+disable-model-invocation: true
+---
+
+Deploy and test the Subnet Calculator on the dev server:
+
+1. Run the rsync deploy and copy the iframe fixture:
+   ```
+   rsync -a --delete Subnet-Calculator/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/claude/subnet-calculator/
+   scp testing/fixtures/iframe-test.html root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/claude/subnet-calculator/
+   ```
+2. Run the CDP browser test suite:
+   ```
+   bash -c 'set -a; source ~/.claude/dev-secrets.env; set +a; python3 testing/scripts/cdp_test.py'
+   ```
+3. Report results: total pass/fail count and details of any failed assertions.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: release
+description: Run the full release checklist for Subnet Calculator — bump version, update changelog, build tarball, commit, push, and open a PR.
+disable-model-invocation: true
+---
+
+Run the full Subnet Calculator release workflow:
+
+1. Ask the user for the new version number (e.g. "1.3.0") if not already provided.
+2. Bump `$app_version` in `Subnet-Calculator/includes/config.php`.
+3. Update the version string in `Subnet-Calculator/templates/layout.php`.
+4. Add a new release section to `CHANGELOG.md` (summarize changes since last release from `git log --oneline` since the last tag).
+5. Add a row to the downloads table in `README.md`.
+6. Build the release tarball: `tar -czf releases/subnet-calculator-X.Y.Z.tar.gz -C Subnet-Calculator .`
+7. Commit all changes with message: `release: vX.Y.Z`
+8. Confirm with user before pushing and opening a PR from `dev → main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,11 @@ tar -czf releases/subnet-calculator-X.Y.Z.tar.gz -C Subnet-Calculator .
 2. Update version string in `Subnet-Calculator/templates/layout.php`
 3. Update `CHANGELOG.md` with new release section
 4. Add row to `README.md` downloads table
-5. Build tarball: `tar -czf releases/subnet-calculator-X.Y.Z.tar.gz -C Subnet-Calculator .`
+5. Build tarball (see Development block above)
 6. Commit, push, verify on GitHub
 7. Create PR `dev → main`
+
+(Or run `/release` to automate steps 1–7.)
 
 PHP unit tests: `testing/unit/` (61 tests, 87 assertions on platforms without GMP; 15 additional IPv6/split tests on platforms with GMP). CDP browser tests: `testing/scripts/cdp_test.py` (28 test groups, 125 assertions) covers page load, security headers, Permissions-Policy, CSP nonce integrity, IPv4/IPv6 calculation, reverse DNS zones, edge cases, address type badges, subnet splitters, copy buttons, splitter shareable URLs, binary representation, VLSM planner, overlap checker, shareable GET URLs, iframe integration, and UI interactions.
 
@@ -110,6 +112,14 @@ The local git remote (`origin`) points to a session-scoped proxy at `127.0.0.1`.
 
 To write files to GitHub from a Claude Code session, prefer `mcp__github__push_files` for small files (works up to ~20 KB per file). For larger files (e.g. `index.php` at ~64 KB, release tarballs at ~600 KB), instruct the user to push from their own machine.
 
-## Session start hook
+## Claude automations
 
-`.claude/hooks/session-start.sh` runs automatically in remote Claude Code sessions. It installs `php-gmp` if the GMP extension is not loaded (required for IPv6 calculation).
+**Skills** (invoke with `/skill-name`):
+- `/deploy-test` — rsync to dev server + run CDP browser suite
+- `/release` — full release checklist (bump version, changelog, tarball, PR)
+
+**Hooks** (PostToolUse, auto-run on every PHP edit):
+- `php -l` — syntax check (~50ms)
+- `phpstan analyse` — level 9 static analysis (~2s)
+
+**Session start hook**: `.claude/hooks/session-start.sh` — installs `php-gmp` in remote sessions if missing.


### PR DESCRIPTION
## Summary

- **PostToolUse hooks**: `php -l` + `phpstan analyse` auto-run on every PHP file edit for instant feedback
- **Skills**: `/deploy-test` (rsync to dev + run CDP browser suite) and `/release` (full 7-step release checklist)
- **Agent**: `php-security-reviewer` for auditing input validation and XSS risks in PHP files
- **CLAUDE.md**: document new automations, trim stale session-start section, clean up release checklist

## Test plan

- [ ] Edit a PHP file and confirm `php -l` and `phpstan` hooks fire automatically
- [ ] Run `/deploy-test` and confirm it deploys + runs CDP suite
- [ ] Run `/release` and confirm it walks through the release checklist steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added PHP security reviewer agent configuration for code quality checks
  * Implemented automated PHP syntax validation and static analysis hooks
  * Added deploy-test automation skill for browser test suite execution
  * Added release automation skill for streamlined version management and deployment workflows
  * Updated documentation to reference new automation capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->