### PR TITLE
fix: pass --ruleset spectral:oas to spectral lint

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Spectral — lint OpenAPI spec
         if: hashFiles('Subnet-Calculator/api/openapi.yaml') != ''
-        run: npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+        run: npx --yes @stoplight/spectral-cli@6 lint --ruleset spectral:oas Subnet-Calculator/api/openapi.yaml


### PR DESCRIPTION
Spectral exits with code 2 when no `.spectral.yml` exists and no `--ruleset` flag is provided. Pass the built-in `spectral:oas` ruleset explicitly so the CI step passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API specification linting configuration in CI/CD pipeline to explicitly use the OpenAPI ruleset for validation, improving consistency in automated spec checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->