### PR TITLE
fix: add .spectral.yml so spectral lint resolves spectral:oas ruleset

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Spectral — lint OpenAPI spec
         if: hashFiles('Subnet-Calculator/api/openapi.yaml') != ''
-        run: npx --yes @stoplight/spectral-cli@6 lint --ruleset spectral:oas Subnet-Calculator/api/openapi.yaml
+        run: npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,0 +1,2 @@
+extends:
+  - spectral:oas


### PR DESCRIPTION
The `spectral:oas` alias only resolves when declared inside a ruleset file — not as a `--ruleset` CLI flag value. Adds `.spectral.yml` at the repo root and reverts the `--ruleset` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenAPI specification linting configuration to use a dedicated configuration file instead of command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->