### PR TITLE
docs: add CNAME and update site_url for custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.subnetcalculator.app

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Subnet Calculator
-site_url: https://seanmousseau.github.io/Subnet-Calculator/
+site_url: https://docs.subnetcalculator.app/
 site_author: Sean Mousseau
 site_description: Documentation for the Subnet Calculator — a self-hosted PHP tool for IPv4/IPv6 subnetting, VLSM planning, and network analysis.
 repo_url: https://github.com/seanmousseau/Subnet-Calculator


### PR DESCRIPTION
## Summary

- Adds `docs/CNAME` containing `docs.subnetcalculator.app` so GitHub Pages retains the custom domain after every deploy (without this file the domain is reset on each push)
- Updates `site_url` in `mkdocs.yml` from `seanmousseau.github.io/Subnet-Calculator/` to `https://docs.subnetcalculator.app/` so canonical URLs and sitemap entries are correct

DNS is already configured (`docs.subnetcalculator.app CNAME seanmousseau.github.io`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site configuration to use custom domain `docs.subnetcalculator.app` for improved accessibility and branding. The documentation is now hosted at a dedicated custom domain instead of the default platform URL. All internal links, site metadata, and canonical URLs have been updated accordingly to ensure proper navigation and search engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->