### PR TITLE
docs: custom homepage and theme for docs.subnetcalculator.app

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+template: home.html
+hide:
+  - navigation
+  - toc
+---
+
 # Subnet Calculator
 
 A self-hosted PHP tool for IPv4 and IPv6 subnetting, VLSM planning, and network analysis.

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -140,6 +140,7 @@
         <div>&nbsp;</div>
         <div><span class="comment"># Option 2 — Docker Compose</span></div>
         <div><span class="prompt">$ </span><span class="cmd">git clone https://github.com/seanmousseau/Subnet-Calculator.git</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">cd Subnet-Calculator</span></div>
         <div><span class="prompt">$ </span><span class="cmd">docker compose up app</span></div>
       </div>
     </div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -11,7 +11,7 @@
 
     <div class="sc-badge">
       <span class="sc-badge__dot"></span>
-      v2.8.1 &nbsp;·&nbsp; AGPL-3.0 &nbsp;·&nbsp; Self-hosted
+      v{{ config.extra.version }} &nbsp;·&nbsp; AGPL-3.0 &nbsp;·&nbsp; Self-hosted
     </div>
 
     <h1 class="sc-hero__title">Subnet<br><em>Calculator</em></h1>
@@ -134,8 +134,8 @@
       </div>
       <div class="sc-terminal__body">
         <div><span class="comment"># Option 1 — tarball (recommended)</span></div>
-        <div><span class="prompt">$ </span><span class="cmd">curl -LO </span><span class="path">https://github.com/seanmousseau/Subnet-Calculator/releases/latest/download/subnet-calculator-2.8.1.tar.gz</span></div>
-        <div><span class="prompt">$ </span><span class="cmd">tar -xzf subnet-calculator-2.8.1.tar.gz</span> <span class="flag">-C</span> <span class="path">/var/www/html/subnet-calculator/</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">curl -LO </span><span class="path">https://github.com/seanmousseau/Subnet-Calculator/releases/latest/download/subnet-calculator-{{ config.extra.version }}.tar.gz</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">tar -xzf subnet-calculator-{{ config.extra.version }}.tar.gz</span> <span class="flag">-C</span> <span class="path">/var/www/html/subnet-calculator/</span></div>
         <div>&nbsp;</div>
         <div><span class="comment"># Option 2 — Docker Compose</span></div>
         <div><span class="prompt">$ </span><span class="cmd">git clone https://github.com/seanmousseau/Subnet-Calculator.git</span></div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,0 +1,158 @@
+{% extends "main.html" %}
+
+{% block tabs %}{{ super() }}{% endblock %}
+
+{% block content %}
+<!-- ============================================================
+     HERO
+     ============================================================ -->
+<section class="sc-hero">
+  <div class="sc-hero__inner">
+
+    <div class="sc-badge">
+      <span class="sc-badge__dot"></span>
+      v2.8.1 &nbsp;·&nbsp; AGPL-3.0 &nbsp;·&nbsp; Self-hosted
+    </div>
+
+    <h1 class="sc-hero__title">Subnet<br><em>Calculator</em></h1>
+
+    <p class="sc-hero__tagline">
+      A self-hosted PHP tool for IPv4 &amp; IPv6 subnetting,
+      VLSM planning, overlap checking, and a full REST API.
+    </p>
+
+    <div class="sc-hero__actions">
+      <a href="ipv4/" class="sc-btn sc-btn--primary">Get Started →</a>
+      <a href="api/" class="sc-btn sc-btn--ghost">API Reference</a>
+      <a href="https://subnetcalculator.app" class="sc-btn sc-btn--ghost"
+         target="_blank" rel="noopener noreferrer">Live Demo ↗</a>
+    </div>
+
+    <div class="sc-hero__pills">
+      <span class="sc-pill">PHP 8.1+</span>
+      <span class="sc-pill">Apache · OpenLiteSpeed</span>
+      <span class="sc-pill">SQLite</span>
+      <span class="sc-pill">GMP</span>
+      <span class="sc-pill">OpenAPI 3.1</span>
+    </div>
+
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE CARDS
+     ============================================================ -->
+<section class="sc-features">
+
+  <p class="sc-section-label">What's included</p>
+  <h2 class="sc-section-title">Everything for IP planning</h2>
+
+  <div class="sc-grid">
+
+    <a href="ipv4/" class="sc-card">
+      <span class="sc-card__icon">🔢</span>
+      <p class="sc-card__title">IPv4 Calculator</p>
+      <p class="sc-card__desc">Subnet details, wildcard mask, broadcast address, host range, reverse-DNS zone, binary/hex representation, and route summarisation.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="ipv6/" class="sc-card">
+      <span class="sc-card__icon">🌐</span>
+      <p class="sc-card__title">IPv6 Calculator</p>
+      <p class="sc-card__desc">Full 128-bit arithmetic via GMP. Expanded and compressed forms, binary/hex panel, subnet splitter, ULA generator, and overlap checker.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="vlsm/" class="sc-card">
+      <span class="sc-card__icon">📐</span>
+      <p class="sc-card__title">VLSM Planner</p>
+      <p class="sc-card__desc">Allocate variable-length subnets from a parent block. Export to CSV, JSON, XLSX, or ASCII. Save and restore named sessions.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="api/" class="sc-card">
+      <span class="sc-card__icon">⚡</span>
+      <p class="sc-card__title">REST API</p>
+      <p class="sc-card__desc">Versioned JSON API for every calculator function. Optional Bearer-token auth, rate limiting, and a machine-readable OpenAPI 3.1 spec.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="overlap/" class="sc-card">
+      <span class="sc-card__icon">🔍</span>
+      <p class="sc-card__title">Overlap Checker</p>
+      <p class="sc-card__desc">Detect overlapping networks — two CIDRs side-by-side or up to 50 networks at once. Supports both IPv4 and IPv6.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="sharing/" class="sc-card">
+      <span class="sc-card__icon">🔗</span>
+      <p class="sc-card__title">Shareable URLs &amp; Embeds</p>
+      <p class="sc-card__desc">Every result is linkable via a GET-parameter URL. Embed the calculator in any page as a responsive <code>&lt;iframe&gt;</code> with auto-resize.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="tree/" class="sc-card">
+      <span class="sc-card__icon">🌲</span>
+      <p class="sc-card__title">Allocation Tree</p>
+      <p class="sc-card__desc">Visualise how subnets nest inside a parent block with gap detection, utilisation summary, and a collapsible tree view.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="client/" class="sc-card">
+      <span class="sc-card__icon">🐘</span>
+      <p class="sc-card__title">PHP Client Library</p>
+      <p class="sc-card__desc">A lightweight PHP wrapper for the REST API. Supports authenticated requests, VLSM sessions, bulk lookups, and PSR-friendly error handling.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+    <a href="config/" class="sc-card">
+      <span class="sc-card__icon">⚙️</span>
+      <p class="sc-card__title">Operator Config</p>
+      <p class="sc-card__desc">All tunable options — API auth, rate limits, Turnstile CAPTCHA, canonical URL, custom branding, and session TTLs — in one place.</p>
+      <span class="sc-card__cta">→ read the docs</span>
+    </a>
+
+  </div>
+
+</section>
+
+<!-- ============================================================
+     QUICK START
+     ============================================================ -->
+<section class="sc-quickstart">
+  <div class="sc-quickstart__inner">
+
+    <p class="sc-section-label">Installation</p>
+    <h2 class="sc-section-title">Up in 30 seconds</h2>
+
+    <div class="sc-terminal">
+      <div class="sc-terminal__bar">
+        <span class="sc-terminal__dot"></span>
+        <span class="sc-terminal__dot"></span>
+        <span class="sc-terminal__dot"></span>
+        <span class="sc-terminal__label">bash</span>
+      </div>
+      <div class="sc-terminal__body">
+        <div><span class="comment"># Option 1 — tarball (recommended)</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">curl -LO </span><span class="path">https://github.com/seanmousseau/Subnet-Calculator/releases/latest/download/subnet-calculator-2.8.1.tar.gz</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">tar -xzf subnet-calculator-2.8.1.tar.gz</span> <span class="flag">-C</span> <span class="path">/var/www/html/subnet-calculator/</span></div>
+        <div>&nbsp;</div>
+        <div><span class="comment"># Option 2 — Docker Compose</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">git clone https://github.com/seanmousseau/Subnet-Calculator.git</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">docker compose up app</span></div>
+      </div>
+    </div>
+
+    <div class="sc-quickstart__links">
+      <a href="ipv4/" class="sc-btn sc-btn--primary">Read the docs →</a>
+      <a href="https://github.com/seanmousseau/Subnet-Calculator/releases"
+         class="sc-btn sc-btn--ghost" target="_blank" rel="noopener noreferrer">GitHub Releases ↗</a>
+      <a href="https://subnetcalculator.app"
+         class="sc-btn sc-btn--ghost" target="_blank" rel="noopener noreferrer">Live Demo ↗</a>
+    </div>
+
+  </div>
+</section>
+{% endblock %}
+
+{% block footer %}{{ super() }}{% endblock %}

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -134,7 +134,8 @@
       </div>
       <div class="sc-terminal__body">
         <div><span class="comment"># Option 1 — tarball (recommended)</span></div>
-        <div><span class="prompt">$ </span><span class="cmd">curl -LO </span><span class="path">https://github.com/seanmousseau/Subnet-Calculator/releases/latest/download/subnet-calculator-{{ config.extra.version }}.tar.gz</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">curl -LO </span><span class="path">https://github.com/seanmousseau/Subnet-Calculator/releases/download/{{ config.extra.version }}/subnet-calculator-{{ config.extra.version }}.tar.gz</span></div>
+        <div><span class="prompt">$ </span><span class="cmd">mkdir -p </span><span class="path">/var/www/html/subnet-calculator</span></div>
         <div><span class="prompt">$ </span><span class="cmd">tar -xzf subnet-calculator-{{ config.extra.version }}.tar.gz</span> <span class="flag">-C</span> <span class="path">/var/www/html/subnet-calculator/</span></div>
         <div>&nbsp;</div>
         <div><span class="comment"># Option 2 — Docker Compose</span></div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,769 @@
+/* ================================================================
+   SUBNET CALCULATOR DOCS — CUSTOM THEME
+   Syne (headings) · Plus Jakarta Sans (body) · Fira Code (mono)
+   Primary accent: #06d6a0 electric teal
+   ================================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=Plus+Jakarta+Sans:wght@400;500;600&display=swap');
+
+/* ----------------------------------------------------------------
+   Custom colour tokens
+   ---------------------------------------------------------------- */
+:root {
+  --sc-teal:        #06d6a0;
+  --sc-teal-dim:    rgba(6, 214, 160, .10);
+  --sc-teal-border: rgba(6, 214, 160, .28);
+  --sc-navy:        #0d1117;
+  --sc-surface:     #161b22;
+  --sc-border:      #21262d;
+  --sc-text:        #e6edf3;
+  --sc-muted:       #8b949e;
+  --sc-faint:       #6e7681;
+}
+
+/* ----------------------------------------------------------------
+   Dark scheme overrides
+   ---------------------------------------------------------------- */
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:           var(--sc-navy);
+  --md-default-fg-color:           var(--sc-text);
+  --md-default-fg-color--light:    var(--sc-muted);
+  --md-default-fg-color--lighter:  var(--sc-faint);
+  --md-default-fg-color--lightest: #30363d;
+
+  --md-code-bg-color:  var(--sc-surface);
+  --md-code-fg-color:  #c9d1d9;
+
+  --md-typeset-a-color: var(--sc-teal);
+
+  --md-primary-fg-color:        var(--sc-teal);
+  --md-primary-fg-color--light: #4dffd8;
+  --md-primary-fg-color--dark:  #04b389;
+  --md-primary-bg-color:        var(--sc-navy);
+  --md-primary-bg-color--light: var(--sc-teal-dim);
+
+  --md-accent-fg-color: var(--sc-teal);
+
+  --md-admonition-bg-color: var(--sc-surface);
+
+  --md-footer-bg-color:       #0a0f16;
+  --md-footer-bg-color--dark: #070c12;
+  --md-footer-fg-color:       var(--sc-muted);
+}
+
+/* ----------------------------------------------------------------
+   Light scheme overrides
+   ---------------------------------------------------------------- */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:        #065f46;
+  --md-primary-fg-color--light: #047857;
+  --md-primary-fg-color--dark:  #064e3b;
+  --md-primary-bg-color:        #ffffff;
+  --md-accent-fg-color:         #06d6a0;
+  --md-typeset-a-color:         #065f46;
+}
+
+/* ================================================================
+   GLOBAL TYPOGRAPHY
+   ================================================================ */
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4 {
+  font-family: 'Syne', sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.md-typeset h1 {
+  font-weight: 800;
+  font-size: 2rem;
+  line-height: 1.15;
+}
+
+.md-typeset h2 {
+  font-size: 1.35rem;
+  margin-top: 2.25rem;
+  padding-bottom: .35rem;
+  border-bottom: 1px solid var(--sc-border);
+}
+
+[data-md-color-scheme="default"] .md-typeset h2 {
+  border-bottom-color: #e5e7eb;
+}
+
+/* Inline code */
+[data-md-color-scheme="slate"] .md-typeset code:not(pre code) {
+  background: rgba(110, 118, 129, .12);
+  color: var(--sc-teal);
+  border-radius: 4px;
+  padding: .1em .4em;
+  font-size: .85em;
+}
+
+/* ================================================================
+   HEADER & TABS
+   ================================================================ */
+
+.md-header {
+  background: #0a0f16;
+  border-bottom: 1px solid var(--sc-border);
+  box-shadow: none;
+}
+
+[data-md-color-scheme="default"] .md-header {
+  background: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+  box-shadow: none;
+}
+
+.md-header__title {
+  font-family: 'Syne', sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.md-tabs {
+  background: #0a0f16;
+  border-bottom: 1px solid var(--sc-border);
+}
+
+[data-md-color-scheme="default"] .md-tabs {
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+[data-md-color-scheme="slate"] .md-tabs__link {
+  color: var(--sc-muted);
+  opacity: 1;
+}
+
+.md-tabs__link--active,
+.md-tabs__link:hover {
+  color: var(--sc-teal) !important;
+  opacity: 1 !important;
+}
+
+[data-md-color-scheme="default"] .md-tabs__link--active,
+[data-md-color-scheme="default"] .md-tabs__link:hover {
+  color: #065f46 !important;
+}
+
+/* ================================================================
+   SIDEBAR NAVIGATION
+   ================================================================ */
+
+[data-md-color-scheme="slate"] .md-nav__link {
+  color: var(--sc-muted);
+  transition: color .15s;
+}
+
+[data-md-color-scheme="slate"] .md-nav__link:hover,
+[data-md-color-scheme="slate"] .md-nav__link:focus {
+  color: var(--sc-text);
+}
+
+[data-md-color-scheme="slate"] .md-nav__link--active {
+  color: var(--sc-teal);
+  font-weight: 600;
+}
+
+[data-md-color-scheme="slate"] .md-nav__title {
+  font-family: 'Syne', sans-serif;
+  font-weight: 700;
+  font-size: .68rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--sc-faint);
+}
+
+[data-md-color-scheme="slate"] .md-sidebar {
+  background: var(--sc-navy);
+  border-right: 1px solid var(--sc-border);
+}
+
+/* ================================================================
+   CODE BLOCKS
+   ================================================================ */
+
+[data-md-color-scheme="slate"] .md-typeset pre {
+  background: var(--sc-surface);
+  border: 1px solid var(--sc-border);
+  border-radius: 8px;
+}
+
+[data-md-color-scheme="slate"] .md-typeset pre > code {
+  background: transparent;
+}
+
+[data-md-color-scheme="slate"] .highlight .filename {
+  background: #0d1117;
+  border-bottom: 1px solid var(--sc-border);
+  color: var(--sc-faint);
+  font-size: .75rem;
+  border-radius: 8px 8px 0 0;
+}
+
+/* ================================================================
+   ADMONITIONS
+   ================================================================ */
+
+[data-md-color-scheme="slate"] .md-typeset .admonition,
+[data-md-color-scheme="slate"] .md-typeset details {
+  background: var(--sc-surface);
+  border-color: var(--sc-border);
+  border-radius: 8px;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .note > .admonition-title,
+[data-md-color-scheme="slate"] .md-typeset .info > .admonition-title,
+[data-md-color-scheme="slate"] .md-typeset .tip > .admonition-title {
+  background: var(--sc-teal-dim);
+}
+
+/* ================================================================
+   TABLES
+   ================================================================ */
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) {
+  border: 1px solid var(--sc-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background: var(--sc-surface);
+  color: var(--sc-text);
+  font-family: 'Syne', sans-serif;
+  font-size: .75rem;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--sc-border);
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) td {
+  border-bottom: 1px solid #1c2128;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) tr:last-child td {
+  border-bottom: none;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) tr:hover td {
+  background: rgba(6, 214, 160, .03);
+}
+
+/* ================================================================
+   SEARCH
+   ================================================================ */
+
+[data-md-color-scheme="slate"] .md-search__form {
+  background: var(--sc-surface);
+  border: 1px solid var(--sc-border);
+  border-radius: 8px;
+}
+
+[data-md-color-scheme="slate"] .md-search__input {
+  color: var(--sc-text);
+}
+
+[data-md-color-scheme="slate"] .md-search__input::placeholder {
+  color: var(--sc-faint);
+}
+
+/* ================================================================
+   FOOTER
+   ================================================================ */
+
+[data-md-color-scheme="slate"] .md-footer {
+  background: #0a0f16;
+  border-top: 1px solid var(--sc-border);
+}
+
+/* ================================================================
+   SCROLLBAR
+   ================================================================ */
+
+[data-md-color-scheme="slate"] ::-webkit-scrollbar       { width: 5px; height: 5px; }
+[data-md-color-scheme="slate"] ::-webkit-scrollbar-track  { background: var(--sc-navy); }
+[data-md-color-scheme="slate"] ::-webkit-scrollbar-thumb  { background: #30363d; border-radius: 3px; }
+[data-md-color-scheme="slate"] ::-webkit-scrollbar-thumb:hover { background: var(--sc-faint); }
+
+/* ================================================================
+   HOMEPAGE — HERO
+   ================================================================ */
+
+.sc-hero {
+  position: relative;
+  padding: 7rem 2rem 5.5rem;
+  text-align: center;
+  overflow: hidden;
+  background: var(--sc-navy);
+  border-bottom: 1px solid var(--sc-border);
+}
+
+/* Scrolling grid */
+.sc-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(6, 214, 160, .055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(6, 214, 160, .055) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(ellipse 90% 85% at 50% 0%, black 20%, transparent 100%);
+  animation: sc-grid 24s linear infinite;
+}
+
+@keyframes sc-grid {
+  from { background-position: 0 0; }
+  to   { background-position: 48px 48px; }
+}
+
+/* Radial glow behind title */
+.sc-hero::after {
+  content: '';
+  position: absolute;
+  top: -10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 55%;
+  height: 50%;
+  background: radial-gradient(ellipse, rgba(6, 214, 160, .10) 0%, transparent 65%);
+  pointer-events: none;
+}
+
+.sc-hero__inner {
+  position: relative;
+  z-index: 1;
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+/* Version badge */
+.sc-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  background: var(--sc-teal-dim);
+  border: 1px solid var(--sc-teal-border);
+  color: var(--sc-teal);
+  font-family: 'Fira Code', 'JetBrains Mono', monospace;
+  font-size: .72rem;
+  padding: .28rem .8rem;
+  border-radius: 999px;
+  margin-bottom: 1.75rem;
+  animation: sc-fade-in .4s ease both;
+  letter-spacing: .03em;
+}
+
+.sc-badge__dot {
+  width: 6px;
+  height: 6px;
+  background: var(--sc-teal);
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: sc-pulse 2.4s ease infinite;
+}
+
+@keyframes sc-pulse {
+  0%, 100% { opacity: 1;  transform: scale(1); }
+  50%       { opacity: .4; transform: scale(.75); }
+}
+
+/* Main title */
+.sc-hero__title {
+  font-family: 'Syne', sans-serif !important;
+  font-size: clamp(3.2rem, 9vw, 5.75rem) !important;
+  font-weight: 800 !important;
+  letter-spacing: -0.045em !important;
+  line-height: .97 !important;
+  color: var(--sc-text) !important;
+  margin: 0 0 1.4rem !important;
+  padding: 0 !important;
+  border: none !important;
+  animation: sc-fade-up .5s ease .08s both;
+}
+
+.sc-hero__title em {
+  font-style: normal;
+  color: var(--sc-teal);
+}
+
+/* Tagline */
+.sc-hero__tagline {
+  font-size: 1.05rem;
+  color: var(--sc-muted);
+  max-width: 500px;
+  margin: 0 auto 2.75rem;
+  line-height: 1.65;
+  animation: sc-fade-up .5s ease .18s both;
+}
+
+/* CTA row */
+.sc-hero__actions {
+  display: flex;
+  gap: .75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  animation: sc-fade-up .5s ease .28s both;
+}
+
+/* Tech pills */
+.sc-hero__pills {
+  display: flex;
+  gap: .6rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 2.5rem;
+  animation: sc-fade-up .5s ease .38s both;
+}
+
+.sc-pill {
+  background: rgba(255, 255, 255, .04);
+  border: 1px solid var(--sc-border);
+  color: var(--sc-faint);
+  font-family: 'Fira Code', monospace;
+  font-size: .72rem;
+  padding: .28rem .8rem;
+  border-radius: 999px;
+  letter-spacing: .02em;
+}
+
+/* ================================================================
+   BUTTONS
+   ================================================================ */
+
+.sc-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  padding: .72rem 1.6rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: .875rem;
+  text-decoration: none !important;
+  transition: all .15s ease;
+  letter-spacing: -.01em;
+  line-height: 1;
+}
+
+.sc-btn--primary {
+  background: var(--sc-teal);
+  color: #0a1a12 !important;
+}
+
+.sc-btn--primary:hover {
+  background: #4dffd8;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(6, 214, 160, .3);
+}
+
+.sc-btn--ghost {
+  background: transparent;
+  color: var(--sc-text) !important;
+  border: 1px solid #30363d;
+}
+
+.sc-btn--ghost:hover {
+  border-color: var(--sc-teal-border);
+  color: var(--sc-teal) !important;
+  transform: translateY(-1px);
+}
+
+/* ================================================================
+   HOMEPAGE — FEATURE SECTION
+   ================================================================ */
+
+.sc-features {
+  padding: 5.5rem 2rem;
+  max-width: 1160px;
+  margin: 0 auto;
+}
+
+.sc-section-label {
+  font-family: 'Syne', sans-serif;
+  font-size: .68rem;
+  font-weight: 700;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--sc-teal);
+  margin: 0 0 .6rem;
+}
+
+.sc-section-title {
+  font-family: 'Syne', sans-serif;
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: -.035em;
+  color: var(--sc-text);
+  margin: 0 0 3rem;
+  line-height: 1.12;
+}
+
+.sc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
+  gap: 1.1rem;
+}
+
+.sc-card {
+  background: var(--sc-surface);
+  border: 1px solid var(--sc-border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  transition: border-color .15s, transform .15s, box-shadow .15s;
+  text-decoration: none !important;
+  color: inherit;
+  display: block;
+  position: relative;
+  overflow: hidden;
+}
+
+.sc-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse 60% 60% at 10% 0%, rgba(6, 214, 160, .07), transparent);
+  opacity: 0;
+  transition: opacity .2s;
+}
+
+.sc-card:hover {
+  border-color: var(--sc-teal-border);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 36px rgba(0, 0, 0, .35);
+}
+
+.sc-card:hover::before {
+  opacity: 1;
+}
+
+.sc-card__icon {
+  font-size: 1.65rem;
+  margin-bottom: 1rem;
+  display: block;
+  position: relative;
+}
+
+.sc-card__title {
+  font-family: 'Syne', sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--sc-text);
+  margin: 0 0 .5rem;
+  position: relative;
+}
+
+.sc-card__desc {
+  font-size: .865rem;
+  color: var(--sc-muted);
+  line-height: 1.55;
+  margin: 0;
+  position: relative;
+}
+
+.sc-card__cta {
+  display: inline-block;
+  margin-top: 1.1rem;
+  font-size: .78rem;
+  color: var(--sc-teal);
+  font-family: 'Fira Code', monospace;
+  opacity: 0;
+  transform: translateX(-6px);
+  transition: all .15s;
+  position: relative;
+}
+
+.sc-card:hover .sc-card__cta {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* ================================================================
+   HOMEPAGE — QUICK-START
+   ================================================================ */
+
+.sc-quickstart {
+  background: var(--sc-navy);
+  border-top: 1px solid var(--sc-border);
+  border-bottom: 1px solid var(--sc-border);
+  padding: 5rem 2rem;
+}
+
+.sc-quickstart__inner {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.sc-terminal {
+  background: #080d13;
+  border: 1px solid var(--sc-border);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-top: 2rem;
+  font-family: 'Fira Code', 'JetBrains Mono', monospace;
+  font-size: .82rem;
+}
+
+.sc-terminal__bar {
+  background: var(--sc-surface);
+  border-bottom: 1px solid var(--sc-border);
+  padding: .6rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+
+.sc-terminal__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.sc-terminal__dot:nth-child(1) { background: #ff5f57; }
+.sc-terminal__dot:nth-child(2) { background: #febc2e; }
+.sc-terminal__dot:nth-child(3) { background: #28c840; }
+
+.sc-terminal__label {
+  font-size: .7rem;
+  color: var(--sc-faint);
+  margin-left: auto;
+  letter-spacing: .04em;
+}
+
+.sc-terminal__body {
+  padding: 1.25rem 1.5rem;
+  line-height: 2;
+  color: #c9d1d9;
+}
+
+.sc-terminal__body .prompt { color: var(--sc-teal); user-select: none; }
+.sc-terminal__body .comment { color: var(--sc-faint); font-style: italic; }
+.sc-terminal__body .cmd { color: #c9d1d9; }
+.sc-terminal__body .flag { color: #79c0ff; }
+.sc-terminal__body .path { color: #ffa657; }
+.sc-terminal__body br + br { display: none; }
+
+.sc-quickstart__links {
+  display: flex;
+  gap: .75rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+/* ================================================================
+   LIGHT-MODE HOMEPAGE OVERRIDES
+   ================================================================ */
+
+[data-md-color-scheme="default"] .sc-hero {
+  background: #f8fafc;
+  border-bottom-color: #e2e8f0;
+}
+
+[data-md-color-scheme="default"] .sc-hero::before {
+  background-image:
+    linear-gradient(rgba(6, 214, 160, .08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(6, 214, 160, .08) 1px, transparent 1px);
+}
+
+[data-md-color-scheme="default"] .sc-hero::after {
+  background: radial-gradient(ellipse, rgba(6, 196, 148, .08) 0%, transparent 65%);
+}
+
+[data-md-color-scheme="default"] .sc-hero__title { color: #0f172a !important; }
+[data-md-color-scheme="default"] .sc-hero__tagline { color: #64748b; }
+
+[data-md-color-scheme="default"] .sc-badge {
+  background: rgba(6, 196, 148, .1);
+  border-color: rgba(6, 196, 148, .3);
+  color: #065f46;
+}
+
+[data-md-color-scheme="default"] .sc-badge__dot { background: #065f46; }
+[data-md-color-scheme="default"] .sc-hero__title em { color: #06b789; }
+
+[data-md-color-scheme="default"] .sc-pill {
+  background: rgba(0,0,0,.04);
+  border-color: #d1d5db;
+  color: #6b7280;
+}
+
+[data-md-color-scheme="default"] .sc-btn--primary {
+  background: #065f46;
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="default"] .sc-btn--primary:hover { background: #047857; }
+
+[data-md-color-scheme="default"] .sc-btn--ghost {
+  border-color: #d1d5db;
+  color: #111827 !important;
+}
+
+[data-md-color-scheme="default"] .sc-btn--ghost:hover {
+  border-color: #059669;
+  color: #065f46 !important;
+}
+
+[data-md-color-scheme="default"] .sc-card {
+  background: #ffffff;
+  border-color: #e2e8f0;
+}
+
+[data-md-color-scheme="default"] .sc-card::before {
+  background: radial-gradient(ellipse 60% 60% at 10% 0%, rgba(6, 196, 148, .06), transparent);
+}
+
+[data-md-color-scheme="default"] .sc-card:hover { box-shadow: 0 8px 30px rgba(0,0,0,.08); }
+[data-md-color-scheme="default"] .sc-card__title { color: #0f172a; }
+[data-md-color-scheme="default"] .sc-card__desc  { color: #6b7280; }
+[data-md-color-scheme="default"] .sc-card__cta   { color: #065f46; }
+
+[data-md-color-scheme="default"] .sc-section-label { color: #065f46; }
+[data-md-color-scheme="default"] .sc-section-title { color: #0f172a; }
+
+[data-md-color-scheme="default"] .sc-quickstart {
+  background: #f8fafc;
+  border-color: #e2e8f0;
+}
+
+[data-md-color-scheme="default"] .sc-terminal {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+[data-md-color-scheme="default"] .sc-terminal__bar {
+  background: #273549;
+  border-bottom-color: #334155;
+}
+
+/* ================================================================
+   ANIMATIONS
+   ================================================================ */
+
+@keyframes sc-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes sc-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ================================================================
+   RESPONSIVE
+   ================================================================ */
+
+@media (max-width: 768px) {
+  .sc-hero      { padding: 5rem 1.25rem 4rem; }
+  .sc-features  { padding: 3.5rem 1.25rem; }
+  .sc-quickstart { padding: 3.5rem 1.25rem; }
+  .sc-grid      { grid-template-columns: 1fr; }
+
+  .sc-hero__actions  { flex-direction: column; align-items: center; }
+  .sc-btn            { width: 100%; justify-content: center; }
+  .sc-quickstart__links { flex-direction: column; }
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -11,8 +11,8 @@
    ---------------------------------------------------------------- */
 :root {
   --sc-teal:        #06d6a0;
-  --sc-teal-dim:    rgba(6, 214, 160, .10);
-  --sc-teal-border: rgba(6, 214, 160, .28);
+  --sc-teal-dim:    rgb(6 214 160 / 10%);
+  --sc-teal-border: rgb(6 214 160 / 28%);
   --sc-navy:        #0d1117;
   --sc-surface:     #161b22;
   --sc-border:      #21262d;
@@ -95,7 +95,7 @@
 
 /* Inline code */
 [data-md-color-scheme="slate"] .md-typeset code:not(pre code) {
-  background: rgba(110, 118, 129, .12);
+  background: rgb(110 118 129 / 12%);
   color: var(--sc-teal);
   border-radius: 4px;
   padding: .1em .4em;
@@ -251,7 +251,7 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset table:not([class]) tr:hover td {
-  background: rgba(6, 214, 160, .03);
+  background: rgb(6 214 160 / 3%);
 }
 
 /* ================================================================
@@ -309,8 +309,8 @@
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(rgba(6, 214, 160, .055) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(6, 214, 160, .055) 1px, transparent 1px);
+    linear-gradient(rgb(6 214 160 / 5.5%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(6 214 160 / 5.5%) 1px, transparent 1px);
   background-size: 48px 48px;
   mask-image: radial-gradient(ellipse 90% 85% at 50% 0%, black 20%, transparent 100%);
   animation: sc-grid 24s linear infinite;
@@ -330,7 +330,7 @@
   transform: translateX(-50%);
   width: 55%;
   height: 50%;
-  background: radial-gradient(ellipse, rgba(6, 214, 160, .10) 0%, transparent 65%);
+  background: radial-gradient(ellipse, rgb(6 214 160 / 10%) 0%, transparent 65%);
   pointer-events: none;
 }
 
@@ -421,7 +421,7 @@
 }
 
 .sc-pill {
-  background: rgba(255, 255, 255, .04);
+  background: rgb(255 255 255 / 4%);
   border: 1px solid var(--sc-border);
   color: var(--sc-faint);
   font-family: 'Fira Code', monospace;
@@ -457,7 +457,7 @@
 .sc-btn--primary:hover {
   background: #4dffd8;
   transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(6, 214, 160, .3);
+  box-shadow: 0 6px 20px rgb(6 214 160 / 30%);
 }
 
 .sc-btn--ghost {
@@ -525,7 +525,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(ellipse 60% 60% at 10% 0%, rgba(6, 214, 160, .07), transparent);
+  background: radial-gradient(ellipse 60% 60% at 10% 0%, rgb(6 214 160 / 7%), transparent);
   opacity: 0;
   transition: opacity .2s;
 }
@@ -533,7 +533,7 @@
 .sc-card:hover {
   border-color: var(--sc-teal-border);
   transform: translateY(-2px);
-  box-shadow: 0 10px 36px rgba(0, 0, 0, .35);
+  box-shadow: 0 10px 36px rgb(0 0 0 / 35%);
 }
 
 .sc-card:hover::before {
@@ -664,20 +664,20 @@
 
 [data-md-color-scheme="default"] .sc-hero::before {
   background-image:
-    linear-gradient(rgba(6, 214, 160, .08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(6, 214, 160, .08) 1px, transparent 1px);
+    linear-gradient(rgb(6 214 160 / 8%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(6 214 160 / 8%) 1px, transparent 1px);
 }
 
 [data-md-color-scheme="default"] .sc-hero::after {
-  background: radial-gradient(ellipse, rgba(6, 196, 148, .08) 0%, transparent 65%);
+  background: radial-gradient(ellipse, rgb(6 196 148 / 8%) 0%, transparent 65%);
 }
 
 [data-md-color-scheme="default"] .sc-hero__title { color: #0f172a !important; }
 [data-md-color-scheme="default"] .sc-hero__tagline { color: #64748b; }
 
 [data-md-color-scheme="default"] .sc-badge {
-  background: rgba(6, 196, 148, .1);
-  border-color: rgba(6, 196, 148, .3);
+  background: rgb(6 196 148 / 10%);
+  border-color: rgb(6 196 148 / 30%);
   color: #065f46;
 }
 
@@ -685,7 +685,7 @@
 [data-md-color-scheme="default"] .sc-hero__title em { color: #06b789; }
 
 [data-md-color-scheme="default"] .sc-pill {
-  background: rgba(0,0,0,.04);
+  background: rgb(0 0 0 / 4%);
   border-color: #d1d5db;
   color: #6b7280;
 }
@@ -713,10 +713,10 @@
 }
 
 [data-md-color-scheme="default"] .sc-card::before {
-  background: radial-gradient(ellipse 60% 60% at 10% 0%, rgba(6, 196, 148, .06), transparent);
+  background: radial-gradient(ellipse 60% 60% at 10% 0%, rgb(6 196 148 / 6%), transparent);
 }
 
-[data-md-color-scheme="default"] .sc-card:hover { box-shadow: 0 8px 30px rgba(0,0,0,.08); }
+[data-md-color-scheme="default"] .sc-card:hover { box-shadow: 0 8px 30px rgb(0 0 0 / 8%); }
 [data-md-color-scheme="default"] .sc-card__title { color: #0f172a; }
 [data-md-color-scheme="default"] .sc-card__desc  { color: #6b7280; }
 [data-md-color-scheme="default"] .sc-card__cta   { color: #065f46; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,16 +7,20 @@ repo_name: seanmousseau/Subnet-Calculator
 
 theme:
   name: material
+  custom_dir: docs/overrides
+  font:
+    text: Plus Jakarta Sans
+    code: Fira Code
   palette:
     - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-night
         name: Switch to light mode
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-sunny
         name: Switch to dark mode
@@ -26,6 +30,9 @@ theme:
     - navigation.top
     - search.suggest
     - content.code.copy
+
+exclude_docs: |
+  superpowers/
 
 plugins:
   - search
@@ -50,6 +57,9 @@ nav:
     - REST API: api.md
     - PHP Client Library: client.md
     - Operator Config: config.md
+
+extra_css:
+  - stylesheets/extra.css
 
 markdown_extensions:
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,9 @@ nav:
     - PHP Client Library: client.md
     - Operator Config: config.md
 
+extra:
+  version: "2.8.1"
+
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
## Summary

- **Custom homepage** (`docs/overrides/home.html`) — animated hero with scrolling grid, feature cards, terminal quick-start section
- **Custom theme** (`docs/stylesheets/extra.css`) — electric teal `#06d6a0` accent, dark navy base, full light-mode variants
- **Fonts** — Syne (display/headings) + Plus Jakarta Sans (body) + Fira Code (code)
- **mkdocs.yml wired up** — `custom_dir`, `extra_css`, font config, `exclude_docs` for internal superpowers planning files

## Test plan

- [ ] Verify GitHub Pages deploys cleanly via Actions (`docs.yml` workflow)
- [ ] Visit https://docs.subnetcalculator.app — confirm custom hero renders
- [ ] Toggle dark/light mode — confirm both themes look correct
- [ ] Navigate to any inner page — confirm nav tabs, sidebar, code blocks use new theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New homepage showcasing the current release version, licensing/self‑hosted messaging, primary actions (Docs, API, Live Demo) and tech badges.
  * “What’s included” feature grid linking key tools (IPv4/IPv6/VLSM calculators, REST/OpenAPI, overlap checker, sharing/embeds, allocation tree, client library, operator config).
  * Added quick-start installation panel (tarball + Docker Compose), prominent quick links, and suppressed site nav/TOC on the home page.
  * Global version value added and comprehensive custom styling, typography and theme tweaks across the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->