### PR TITLE
fix: tablet breakpoint — 2-column grid and inline CTA buttons at 768px

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -782,10 +782,11 @@
   .sc-hero        { padding: 3rem 1.25rem 3rem; }
   .sc-features    { padding: 3.5rem 1.25rem; }
   .sc-quickstart  { padding: 3.5rem 1.25rem; }
-  .sc-grid        { grid-template-columns: 1fr; }
-
   .sc-hero__title { font-size: clamp(2rem, 10vw, 2.6rem) !important; }
+}
 
+@media (max-width: 540px) {
+  .sc-grid        { grid-template-columns: 1fr; }
   .sc-hero__actions  { flex-direction: column; align-items: center; }
   .sc-btn            { width: 100%; justify-content: center; }
   .sc-quickstart__links { flex-direction: column; }


### PR DESCRIPTION
## Summary

- Found during full visual inspection: at 768px (iPad portrait), the `max-width: 768px` breakpoint was collapsing the feature card grid to single-column and stacking the CTA buttons vertically
- The grid uses `repeat(auto-fill, minmax(310px, 1fr))` which naturally collapses to 1 column around 640px — the explicit override at 768px was fighting this
- Moved `grid-template-columns: 1fr`, `flex-direction: column` (actions + quickstart links), and `width: 100%` (buttons) to a new `max-width: 540px` breakpoint where single-column layout is actually appropriate

## Test plan

- [ ] Verify 768px (tablet): feature cards show 2 columns, CTA buttons inline
- [ ] Verify 540px (mobile S): feature cards collapse to 1 column, buttons stack vertically
- [ ] Verify 375px: no horizontal overflow, single-column, stacked buttons
- [ ] Verify desktop 1440px: 3-column grid unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated grid layout breakpoint for improved responsive display on medium-sized screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->