### PR TITLE
docs: unify style guide to cover app and docs site assets

### DIFF
--- a/docs/superpowers/style-guide.md
+++ b/docs/superpowers/style-guide.md
@@ -49,7 +49,7 @@ The app uses the same mark system as the docs site:
 |------|------|-------|
 | `Subnet-Calculator/assets/favicon-32.png/webp` | 32×32 | Browser tab favicon |
 | `Subnet-Calculator/assets/apple-touch-icon.png/webp` | 180×180 | iOS home screen |
-| `Subnet-Calculator/assets/logo.png/webp` | 512×512 | OG/Twitter image, README |
+| `Subnet-Calculator/assets/logo.png/webp` | 512×512 | App header UI (`<picture class="logo">`), OG/Twitter image, README |
 
 The old skeuomorphic calculator icon is preserved at `Subnet-Calculator/assets/old/` but is no longer used.
 

--- a/docs/superpowers/style-guide.md
+++ b/docs/superpowers/style-guide.md
@@ -1,6 +1,6 @@
-# Subnet Calculator Docs — Style Guide
+# Subnet Calculator — Style Guide
 
-> Source of truth for the docs site visual design (`docs/stylesheets/extra.css` + `docs/overrides/home.html`).  
+> Source of truth for the visual identity across both sites: docs (`docs/stylesheets/extra.css` + `docs/overrides/home.html`) and app (`Subnet-Calculator/assets/`).  
 > This file lives in `docs/superpowers/` and is excluded from the MkDocs build.
 
 ---
@@ -41,17 +41,25 @@ A parent network block splitting into two child subnets — literally what the c
 └───┘ └───┘
 ```
 
-### What the existing app logo is for
+### App assets (subnetcalculator.app)
 
-The skeuomorphic calculator icon (`Subnet-Calculator/assets/logo.webp`, 520×600px) remains the correct asset for `subnetcalculator.app` (browser tab, OG/Twitter image, README). The blue LED-border style suits the app context. Do not use it on the docs site.
+The app uses the same mark system as the docs site:
+
+| File | Size | Usage |
+|------|------|-------|
+| `Subnet-Calculator/assets/favicon-32.png/webp` | 32×32 | Browser tab favicon |
+| `Subnet-Calculator/assets/apple-touch-icon.png/webp` | 180×180 | iOS home screen |
+| `Subnet-Calculator/assets/logo.png/webp` | 512×512 | OG/Twitter image, README |
+
+The old skeuomorphic calculator icon is preserved at `Subnet-Calculator/assets/old/` but is no longer used.
 
 ### Decision rationale
 
 | Asset | Docs site | App (subnetcalculator.app) |
 |-------|-----------|---------------------------|
-| SC monogram (teal, Space Grotesk) | ✅ header logo | — |
-| Network hierarchy SVG | ✅ favicon | — |
-| Skeuomorphic calculator PNG | — | ✅ favicon, OG image, README |
+| SC monogram on dark square (B1) | ✅ header logo | ✅ logo, apple-touch-icon |
+| Network hierarchy (A) | ✅ favicon | ✅ favicon-32 |
+| Skeuomorphic calculator (retired) | — | `assets/old/` |
 
 ---
 


### PR DESCRIPTION
## Summary

- Retitle style guide as project-wide (covers both `subnetcalculator.app` and `docs.subnetcalculator.app`)
- Replace stale skeuomorphic app logo section with accurate app asset table (favicon-32, apple-touch-icon, logo)
- Update decision rationale table to reflect the unified A/B1 mark system across both sites
- Note old assets preserved in `assets/old/`

## Test plan
- [ ] Style guide accurately reflects current asset files in `Subnet-Calculator/assets/`
- [ ] Decision table matches what was shipped in PR #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed top heading and expanded the style guide’s "source of truth" to explicitly include visual identity assets.
  * Replaced prior logo guidance with a new "App assets" section enumerating favicons, touch icons, and webp logos with specified sizes.
  * Marked the skeuomorphic calculator icon as retired and archived for reference.
  * Updated the decision rationale to reference the new mark system (B1 monogram, network hierarchy A).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->