### PR TITLE
docs: bump version to v2.9.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Switch to the **IPv6** tab for IPv6 calculations, and to the **VLSM** tab to pla
 Download the latest release tarball from the [GitHub releases page](https://github.com/seanmousseau/Subnet-Calculator/releases) and extract it into your web root:
 
 ```bash
-tar -xzf subnet-calculator-2.8.1.tar.gz -C /var/www/html/subnet-calculator/
+tar -xzf subnet-calculator-2.9.0.tar.gz -C /var/www/html/subnet-calculator/
 ```
 
 ### Option 2 — Docker

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,7 @@ nav:
     - Operator Config: config.md
 
 extra:
-  version: "2.8.1"
+  version: "2.9.0"
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
Updates version references in docs following the v2.9.0 release.

- `mkdocs.yml` `extra.version`: `2.8.1` → `2.9.0` (version badge on homepage, install snippet)
- `docs/index.md`: tarball filename in install example `2.8.1` → `2.9.0`

Triggers GitHub Pages rebuild so the docs site reflects the new release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reference version 2.9.0, guiding users to download and set up the latest product release.
  * Updated documentation version metadata to 2.9.0, ensuring all documentation materials consistently reflect the current release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->