### PR TITLE
fix: bust Cloudflare edge cache for logo assets

### DIFF
--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -65,8 +65,8 @@
 <main class="card" id="main-content">
     <div class="title-row">
         <picture>
-            <source srcset="assets/logo.webp" type="image/webp">
-            <img src="assets/logo.png" alt="Subnet Calculator logo" class="logo">
+            <source srcset="assets/logo.webp?v=<?= htmlspecialchars($app_version) ?>" type="image/webp">
+            <img src="assets/logo.png?v=<?= htmlspecialchars($app_version) ?>" alt="Subnet Calculator logo" class="logo">
         </picture>
         <h1><?= htmlspecialchars($page_title) ?></h1>
         <span class="version">v<?= htmlspecialchars($app_version) ?></span>


### PR DESCRIPTION
Adds `?v=$app_version` to `logo.webp` and `logo.png` src/srcset in `layout.php`. The YYZ Cloudflare PoP has a stale 28 KB copy of the old calculator logo (from April 21) that cannot be evicted via the Cache Purge API. The versioned URL forces CF to treat it as a new asset and fetch from origin immediately. The version param is dynamic so it auto-updates on every release.