### PR TITLE
v3.0.0 PR1: foundations — audit log + per-key RPM + IPv6 sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,18 @@ WORKDIR /var/www/html
 COPY Subnet-Calculator/ /var/www/html/
 COPY testing/fixtures/iframe-test.html /var/www/html/
 
+# Test-rig configuration. Generated at build time so no bcrypt hash is
+# committed to source — the plaintext "test-admin-password" is hashed
+# fresh each build. This config is ONLY present in the test image; release
+# tarballs ship without it (config.php.example shows the production shape).
+#
+# Enables:
+#   - $session_enabled  : powers Playwright IPv4 + IPv6 VLSM session save/load tests
+#   - $admin_ui_enabled : powers /admin/keys.php and /admin/audit.php tests
+RUN HASH=$(php -r "echo password_hash('test-admin-password', PASSWORD_BCRYPT);") \
+    && printf '<?php\n\$session_enabled=true;\n\$session_ttl_days=1;\n\$admin_ui_enabled=true;\n\$admin_user="testadmin";\n\$admin_pass_hash=%s;\n\$admin_audit_retention_days=1;\n' \
+        "'$HASH'" > /var/www/html/config.php
+
 # www-data already owns /var/www/html inside the base image; no chown needed.
 USER www-data
 

--- a/Subnet-Calculator/admin/audit.php
+++ b/Subnet-Calculator/admin/audit.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+// /admin/audit.php — admin audit log viewer (v3.0.0, #306).
+//
+// Read-only paginated table of `admin_audit` rows. Uses the same Basic
+// Auth + cache headers as /admin/keys.php and shares the same SQLite file
+// (resolved through admin_apikey_db_path()). No POST actions — this page
+// never mutates state, so no CSRF token is needed.
+
+require __DIR__ . '/../includes/config.php';
+require __DIR__ . '/../includes/functions-admin-auth.php';
+require __DIR__ . '/../includes/functions-audit.php';
+
+admin_authenticate();
+
+header('Cache-Control: no-store, no-cache, must-revalidate, private, max-age=0');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+const AUDIT_PAGE_SIZE = 50;
+
+$page = max(1, (int)($_GET['page'] ?? 1));
+$offset = ($page - 1) * AUDIT_PAGE_SIZE;
+
+$filterRaw = (string)($_GET['filter'] ?? '');
+// Allow only well-known prefixes — defensive against arbitrary LIKE input
+$allowedPrefixes = ['', 'login.', 'key.', 'wizard.', 'totp.'];
+$filter = in_array($filterRaw, $allowedPrefixes, true) ? $filterRaw : '';
+
+$rows  = [];
+$total = 0;
+$error = null;
+
+try {
+    $db = new \SQLite3(admin_apikey_db_path());
+    $db->enableExceptions(true);
+    $db->busyTimeout(3000);
+    audit_db_init($db);
+
+    $rows  = audit_list($db, AUDIT_PAGE_SIZE, $offset, $filter !== '' ? $filter : null);
+    $total = audit_count($db, $filter !== '' ? $filter : null);
+    $db->close();
+} catch (\Throwable $e) {
+    error_log('sc admin audit page error: ' . $e->getMessage());
+    $error = 'Failed to read the audit log. Operator should check the server log.';
+}
+
+$totalPages = max(1, (int)ceil($total / AUDIT_PAGE_SIZE));
+
+$h = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+$fmt = static function (?int $ts): string {
+    if ($ts === null) {
+        return '—';
+    }
+    return gmdate('Y-m-d H:i:s', $ts) . ' UTC';
+};
+
+?><!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Audit Log — Subnet Calculator Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<style>
+  :root { color-scheme: dark; }
+  body { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; background:#0a1a12; color:#e5e7eb; margin:0; padding:2rem; }
+  h1 { font-size:1.5rem; margin:0 0 1rem; }
+  main { max-width: 1200px; margin:0 auto; }
+  .card { background:#0f2419; border:1px solid #1e3a2a; border-radius:8px; padding:1.5rem; margin-bottom:1.5rem; }
+  .alert-err { background:#3b0606; border:1px solid #ef4444; color:#fecaca; padding:0.75rem 1rem; border-radius:6px; margin-bottom:1rem; }
+  table { width:100%; border-collapse:collapse; margin-top:1rem; }
+  th, td { padding:0.5rem; text-align:left; border-bottom:1px solid #1e3a2a; vertical-align:top; }
+  th { font-size:0.85rem; text-transform:uppercase; color:#6ee7b7; letter-spacing:0.05em; }
+  td.mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size:0.9rem; }
+  td.meta { font-family: ui-monospace, monospace; font-size:0.8rem; color:#9ca3af; max-width:24rem; word-break:break-word; }
+  .badge { display:inline-block; padding:0.1rem 0.5rem; border-radius:3px; font-size:0.75rem; font-weight:600; }
+  .badge-ok { background:#063b25; color:#a7f3d0; }
+  .badge-fail { background:#3b0606; color:#fecaca; }
+  .badge-info { background:#1e3a2a; color:#a7f3d0; }
+  .filters a { display:inline-block; margin-right:0.5rem; padding:0.25rem 0.6rem; border:1px solid #1e3a2a; border-radius:4px; color:#a7f3d0; text-decoration:none; }
+  .filters a.active { background:#063b25; border-color:#06d6a0; }
+  .pager { margin-top:1rem; color:#9ca3af; }
+  .pager a { color:#06d6a0; text-decoration:none; padding:0 0.4rem; }
+  .pager a.disabled { color:#374151; pointer-events:none; }
+  footer { margin-top:2rem; color:#6b7280; font-size:0.85rem; }
+  a { color:#06d6a0; }
+</style>
+</head>
+<body>
+<main>
+<h1>Admin Audit Log</h1>
+
+<?php if ($error !== null) : ?>
+  <div class="alert-err"><?= $h($error) ?></div>
+<?php endif; ?>
+
+<div class="card">
+  <div class="filters">
+    Filter:
+    <?php foreach (['' => 'all', 'login.' => 'login', 'key.' => 'key', 'wizard.' => 'wizard', 'totp.' => 'totp'] as $val => $label) : ?>
+      <a href="?<?= $val === '' ? '' : 'filter=' . urlencode($val) ?>"
+         class="<?= $filter === $val ? 'active' : '' ?>"><?= $h($label) ?></a>
+    <?php endforeach; ?>
+    &nbsp;<span style="color:#6b7280;font-size:0.85rem">(<?= $total ?> total)</span>
+  </div>
+
+  <?php if ($rows === []) : ?>
+    <p>No audit entries.</p>
+  <?php else : ?>
+    <table>
+      <thead>
+        <tr><th>Time (UTC)</th><th>Action</th><th>Actor</th><th>IP</th><th>Target</th><th>Meta</th></tr>
+      </thead>
+      <tbody>
+      <?php foreach ($rows as $r) :
+        $action = $r['action'];
+        $badge  = 'badge-info';
+        if (str_ends_with($action, '.fail')) {
+            $badge = 'badge-fail';
+        } elseif (str_ends_with($action, '.ok')) {
+            $badge = 'badge-ok';
+        }
+      ?>
+        <tr>
+          <td class="mono"><?= $h($fmt($r['ts'])) ?></td>
+          <td><span class="badge <?= $badge ?>"><?= $h($action) ?></span></td>
+          <td class="mono"><?= $h($r['actor'] ?? '—') ?></td>
+          <td class="mono"><?= $h($r['ip']    ?? '—') ?></td>
+          <td class="mono"><?= $r['target_id'] !== null ? (int)$r['target_id'] : '—' ?></td>
+          <td class="meta"><?= $h($r['meta']  ?? '—') ?></td>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+
+    <div class="pager">
+      <?php
+      $qs = static function (int $p) use ($filter): string {
+          $parts = ['page=' . $p];
+          if ($filter !== '') {
+              $parts[] = 'filter=' . urlencode($filter);
+          }
+          return '?' . implode('&', $parts);
+      };
+      ?>
+      Page <?= $page ?> of <?= $totalPages ?>
+      <a href="<?= $h($qs(max(1, $page - 1))) ?>" class="<?= $page <= 1 ? 'disabled' : '' ?>">← prev</a>
+      <a href="<?= $h($qs(min($totalPages, $page + 1))) ?>" class="<?= $page >= $totalPages ? 'disabled' : '' ?>">next →</a>
+    </div>
+  <?php endif; ?>
+</div>
+
+<footer>
+  Retention: rows older than <code><?= (int)($admin_audit_retention_days ?? 90) ?></code> days
+  are purged automatically on every audit write.
+  <a href="keys.php">← back to API keys</a>
+</footer>
+</main>
+</body>
+</html>

--- a/Subnet-Calculator/admin/keys.php
+++ b/Subnet-Calculator/admin/keys.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 require __DIR__ . '/../includes/config.php';
 require __DIR__ . '/../includes/functions-admin-auth.php';
 require __DIR__ . '/../includes/functions-apikeys.php';
+require __DIR__ . '/../includes/functions-audit.php';
 
 admin_authenticate();
 
@@ -68,13 +69,60 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
         try {
             if ($action === 'create') {
                 $name    = (string)($_POST['name'] ?? '');
-                $created = apikey_create($db, $name);
+                $rpmRaw  = trim((string)($_POST['rate_limit_rpm'] ?? ''));
+                $rpm     = $rpmRaw === '' ? null : (int)$rpmRaw;
+                if ($rpm !== null && (!ctype_digit($rpmRaw) || $rpm < 0)) {
+                    throw new InvalidArgumentException('Rate limit (RPM) must be empty, 0 (unlimited), or a positive integer.');
+                }
+                $created = apikey_create($db, $name, $rpm);
+                audit_log(
+                    $db,
+                    'key.mint',
+                    audit_actor_from_request(),
+                    audit_ip_from_request(),
+                    (int)$created['id'],
+                    [
+                        'name'           => $created['name'],
+                        'prefix'         => $created['prefix'],
+                        'rate_limit_rpm' => $rpm,
+                    ]
+                );
                 $flash_token = $created['token'];
                 $flash_msg   = 'Key "' . $created['name']
                              . '" created. Copy the token now — it is not shown again.';
+            } elseif ($action === 'set_rpm') {
+                $id     = (int)($_POST['id'] ?? 0);
+                $rpmRaw = trim((string)($_POST['rate_limit_rpm'] ?? ''));
+                $rpm    = $rpmRaw === '' ? null : (int)$rpmRaw;
+                if ($rpm !== null && (!ctype_digit($rpmRaw) || $rpm < 0)) {
+                    throw new InvalidArgumentException('Rate limit (RPM) must be empty, 0 (unlimited), or a positive integer.');
+                }
+                if ($id > 0 && apikey_set_rate_limit($db, $id, $rpm)) {
+                    audit_log(
+                        $db,
+                        'key.rate_limit',
+                        audit_actor_from_request(),
+                        audit_ip_from_request(),
+                        $id,
+                        ['rate_limit_rpm' => $rpm]
+                    );
+                    $flash_msg = $rpm === null
+                        ? 'Rate-limit override cleared (key inherits global default).'
+                        : 'Rate limit set to ' . ($rpm === 0 ? 'unlimited' : $rpm . ' RPM') . '.';
+                } else {
+                    $flash_error = 'Key not found, already revoked, or RPM unchanged.';
+                }
             } elseif ($action === 'revoke') {
                 $id = (int)($_POST['id'] ?? 0);
                 if ($id > 0 && apikey_revoke($db, $id)) {
+                    audit_log(
+                        $db,
+                        'key.revoke',
+                        audit_actor_from_request(),
+                        audit_ip_from_request(),
+                        $id,
+                        null
+                    );
                     $flash_msg = 'Key revoked.';
                 } else {
                     $flash_error = 'Key not found or already revoked.';
@@ -198,8 +246,10 @@ $h = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
     <input type="hidden" name="_csrf" value="<?= $h($csrf_expect) ?>">
     <input type="hidden" name="action" value="create">
     <label>Name <input type="text" name="name" required maxlength="128" placeholder="production"></label>
+    <label>RPM <input type="number" name="rate_limit_rpm" min="0" step="1" placeholder="(default)" style="width:7rem" title="Per-key rate limit. Leave blank to inherit global. 0 = unlimited."></label>
     <button class="btn" type="submit">Mint key</button>
   </form>
+  <p style="font-size:0.85rem;color:#9ca3af;margin-top:0.5rem">RPM blank = inherit global default (<code><?= (int)($api_rate_limit_rpm ?? 60) ?></code>); <code>0</code> = unlimited.</p>
 </div>
 
 <div class="card">
@@ -210,17 +260,35 @@ $h = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
     <table>
       <thead>
         <tr>
-          <th>Name</th><th>Prefix</th><th>Created</th><th>Last used</th><th>Status</th><th></th>
+          <th>Name</th><th>Prefix</th><th>Created</th><th>Last used</th><th>RPM</th><th>Status</th><th></th>
         </tr>
       </thead>
       <tbody>
       <?php foreach ($keys as $k) :
-            $is_revoked = $k['revoked_at'] !== null; ?>
+            $is_revoked = $k['revoked_at'] !== null;
+            $rpm        = $k['rate_limit_rpm']; ?>
         <tr<?= $is_revoked ? ' class="revoked"' : '' ?>>
           <td><?= $h($k['name']) ?></td>
           <td class="prefix">sk_live_<?= $h($k['prefix']) ?>…</td>
           <td><?= $h($fmt($k['created_at'])) ?></td>
           <td><?= $h($fmt($k['last_used_at'])) ?></td>
+          <td>
+            <?php if ($is_revoked) : ?>
+              <span class="badge badge-revoked">—</span>
+            <?php else : ?>
+              <form method="post" action="" class="inline">
+                <input type="hidden" name="_csrf" value="<?= $h($csrf_expect) ?>">
+                <input type="hidden" name="action" value="set_rpm">
+                <input type="hidden" name="id" value="<?= (int)$k['id'] ?>">
+                <input type="number" name="rate_limit_rpm" min="0" step="1"
+                       value="<?= $rpm === null ? '' : (int)$rpm ?>"
+                       placeholder="default"
+                       style="width:5rem"
+                       title="0 = unlimited; blank = inherit global default">
+                <button type="submit" class="btn" style="padding:0.25rem 0.6rem;font-size:0.85rem">Save</button>
+              </form>
+            <?php endif; ?>
+          </td>
           <td>
             <?php if ($is_revoked) : ?>
               <span class="badge badge-revoked">revoked <?= $h($fmt($k['revoked_at'])) ?></span>
@@ -248,6 +316,7 @@ $h = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
 <footer>
   Keys authenticate against <code>POST/GET /api/v1/*</code> via <code>Authorization: Bearer &lt;token&gt;</code>.
   Plain-string entries in <code>$api_tokens</code> still work alongside SQLite-stored keys.
+  <br><a href="audit.php">View audit log →</a>
 </footer>
 </main>
 </body>

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -1971,12 +1971,13 @@ paths:
                               type: object
                               required: [id, name, prefix, created_at]
                               properties:
-                                id:           { type: integer }
-                                name:         { type: string }
-                                prefix:       { type: string, description: "First 8 hex chars of the token (non-secret)." }
-                                created_at:   { type: integer, description: "UNIX epoch seconds." }
-                                last_used_at: { type: [integer, "null"] }
-                                revoked_at:   { type: [integer, "null"] }
+                                id:             { type: integer }
+                                name:           { type: string }
+                                prefix:         { type: string, description: "First 8 hex chars of the token (non-secret)." }
+                                created_at:     { type: integer, description: "UNIX epoch seconds." }
+                                last_used_at:   { type: [integer, "null"] }
+                                revoked_at:     { type: [integer, "null"] }
+                                rate_limit_rpm: { type: [integer, "null"], description: "Per-key RPM override (v3.0.0+, #312). null = inherit global; 0 = unlimited." }
         "401":
           description: Missing or invalid admin credentials
           headers:
@@ -2021,6 +2022,12 @@ paths:
                   minLength: 1
                   maxLength: 128
                   example: "production"
+                rate_limit_rpm:
+                  description: "Per-key RPM override (v3.0.0+, #312). Omit or null to inherit the global default. 0 = unlimited."
+                  oneOf:
+                    - type: integer
+                      minimum: 0
+                    - type: "null"
       responses:
         "201":
           description: Key created
@@ -2035,11 +2042,12 @@ paths:
                         type: object
                         required: [id, token, prefix, name, created_at]
                         properties:
-                          id:         { type: integer, example: 1 }
-                          token:      { type: string,  example: "sk_live_a1b2c3d4e5f6...", description: "Returned exactly once — store securely." }
-                          prefix:     { type: string,  example: "a1b2c3d4" }
-                          name:       { type: string,  example: "production" }
-                          created_at: { type: integer, example: 1714742400 }
+                          id:             { type: integer, example: 1 }
+                          token:          { type: string,  example: "sk_live_a1b2c3d4e5f6...", description: "Returned exactly once — store securely." }
+                          prefix:         { type: string,  example: "a1b2c3d4" }
+                          name:           { type: string,  example: "production" }
+                          created_at:     { type: integer, example: 1714742400 }
+                          rate_limit_rpm: { type: [integer, "null"], description: "Echo of the per-key RPM override, if set." }
         "400":
           description: Missing or oversized name
           headers:
@@ -2067,6 +2075,62 @@ paths:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
             X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /admin/keys/{id}/rate-limit:
+    patch:
+      operationId: setAdminKeyRateLimit
+      tags: [Admin]
+      security:
+        - adminBasic: []
+      summary: Set or clear a per-key rate-limit override (v3.0.0+, #312)
+      description: |
+        Updates the `rate_limit_rpm` column on a single API key. Lookup
+        order in `api_rate_limit()` is: static `$api_rate_limit_tokens`
+        override → SQLite per-key override → global `$api_rate_limit_rpm`.
+        Authentication: HTTP Basic Auth.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer, minimum: 1 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [rate_limit_rpm]
+              properties:
+                rate_limit_rpm:
+                  description: "Pass null to clear the override (key inherits the global default). 0 = unlimited."
+                  oneOf:
+                    - type: integer
+                      minimum: 0
+                    - type: "null"
+      responses:
+        "200":
+          description: Override updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [id, rate_limit_rpm]
+                        properties:
+                          id:             { type: integer }
+                          rate_limit_rpm: { type: [integer, "null"] }
+        "400":
+          description: rate_limit_rpm must be null or a non-negative integer
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid admin credentials
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Key not found, revoked, or RPM unchanged
           content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
   /admin/keys/{id}:
     delete:

--- a/Subnet-Calculator/api/schemas/vlsm-session.schema.json
+++ b/Subnet-Calculator/api/schemas/vlsm-session.schema.json
@@ -1,55 +1,143 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://subnetcalculator.app/api/schemas/vlsm-session.schema.json",
-  "title": "VLSM Session Payload",
-  "description": "Persisted shape of a saved VLSM planner session as accepted by POST /api/v1/sessions and returned by GET /api/v1/sessions/{id}. Currently IPv4 only; IPv6 VLSM sessions are not persisted in this version.",
+  "$id": "https://subnetcalculator.app/api/schemas/vlsm-session.v2.schema.json",
+  "title": "VLSM / Tree Session Payload (v2)",
+  "description": "Persisted shape of a saved planner session as accepted by POST /api/v1/sessions and returned by GET /api/v1/sessions/{id}. v2 (v3.0.0, #315) introduces a `type` discriminator so IPv4 VLSM, IPv6 VLSM, and (v3.0.0, #302) tree-editor sessions share one endpoint. Payloads written before v3.0.0 omit `type`; the server treats a missing `type` as `'ipv4'` so existing sessions continue to load. The schema permits all three discriminator values from v3.0.0 PR1; server validation for `type='tree'` activates in PR3 (#302).",
   "type": "object",
-  "required": ["network", "cidr", "requirements"],
-  "additionalProperties": false,
-  "properties": {
-    "network": {
-      "type": "string",
-      "description": "Parent IPv4 network address (with or without an attached prefix).",
-      "minLength": 1,
-      "maxLength": 64,
-      "examples": ["10.0.0.0", "192.168.1.0/24"]
-    },
-    "cidr": {
-      "type": "string",
-      "description": "Parent prefix length as a bare number (no leading slash). Server-side handlers also accept this with a leading slash but it is normalised on save.",
-      "pattern": "^(3[0-2]|[12]?[0-9])$",
-      "examples": ["24", "16"]
-    },
-    "requirements": {
-      "type": "array",
-      "description": "Subnet requirements, sorted largest-first by the allocator at calculation time. Order is preserved as provided.",
-      "minItems": 1,
-      "maxItems": 256,
-      "items": {
-        "type": "object",
-        "required": ["name", "hosts"],
-        "additionalProperties": false,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Human-readable label for the subnet.",
-            "minLength": 1,
-            "maxLength": 128,
-            "examples": ["LAN", "DMZ", "Mgmt"]
-          },
-          "hosts": {
-            "type": "integer",
-            "description": "Required number of usable host addresses.",
-            "minimum": 1,
-            "maximum": 1073741822,
-            "examples": [50, 14, 2]
+  "oneOf": [
+    {
+      "title": "IPv4 VLSM",
+      "type": "object",
+      "required": ["network", "cidr", "requirements"],
+      "properties": {
+        "type": { "const": "ipv4" },
+        "network": {
+          "type": "string",
+          "description": "Parent IPv4 network address (with or without an attached prefix).",
+          "minLength": 1,
+          "maxLength": 64,
+          "examples": ["10.0.0.0", "192.168.1.0/24"]
+        },
+        "cidr": {
+          "type": "string",
+          "description": "Parent prefix length as a bare number.",
+          "pattern": "^(3[0-2]|[12]?[0-9])$",
+          "examples": ["24", "16"]
+        },
+        "requirements": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "items": {
+            "type": "object",
+            "required": ["name", "hosts"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "hosts": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1073741822
+              }
+            }
           }
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    {
+      "title": "IPv6 VLSM",
+      "type": "object",
+      "required": ["type", "network", "cidr", "requirements"],
+      "properties": {
+        "type": { "const": "ipv6" },
+        "network": {
+          "type": "string",
+          "description": "Parent IPv6 network address (with or without an attached prefix).",
+          "minLength": 1,
+          "maxLength": 64,
+          "examples": ["2001:db8::", "fd00:1234::/48"]
+        },
+        "cidr": {
+          "type": "string",
+          "description": "Parent prefix length as a bare number (0–128).",
+          "pattern": "^(12[0-8]|1[01][0-9]|[1-9]?[0-9])$",
+          "examples": ["48", "64", "126"]
+        },
+        "requirements": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "items": {
+            "type": "object",
+            "required": ["name", "hosts"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "hosts": {
+                "description": "Required addresses. Integer for sizings within PHP's signed 64-bit range; the string form `\"2^N\"` (N is 0–128) is required for larger sizings since `2^63` overflows a PHP int.",
+                "oneOf": [
+                  { "type": "integer", "minimum": 1 },
+                  { "type": "string", "pattern": "^2\\^([0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$" }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "title": "Subnet tree editor (v3.0.0 #302)",
+      "type": "object",
+      "required": ["type", "root"],
+      "properties": {
+        "type": { "const": "tree" },
+        "root": { "$ref": "#/$defs/treeNode" }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "$defs": {
+    "treeNode": {
+      "type": "object",
+      "required": ["cidr"],
+      "properties": {
+        "cidr": {
+          "type": "string",
+          "description": "IPv4 or IPv6 CIDR with prefix.",
+          "minLength": 3,
+          "maxLength": 64
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "notes": {
+          "type": "string",
+          "maxLength": 1024
+        },
+        "children": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/treeNode" }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "examples": [
     {
+      "type": "ipv4",
       "network": "10.0.0.0",
       "cidr": "24",
       "requirements": [
@@ -57,6 +145,26 @@
         {"name": "DMZ", "hosts": 14},
         {"name": "Mgmt", "hosts": 2}
       ]
+    },
+    {
+      "type": "ipv6",
+      "network": "2001:db8::",
+      "cidr": "48",
+      "requirements": [
+        {"name": "Site-A", "hosts": "2^16"},
+        {"name": "Site-B", "hosts": 100}
+      ]
+    },
+    {
+      "type": "tree",
+      "root": {
+        "cidr": "10.0.0.0/16",
+        "name": "Corp HQ",
+        "children": [
+          {"cidr": "10.0.0.0/17", "name": "Production"},
+          {"cidr": "10.0.128.0/17", "name": "Lab"}
+        ]
+      }
     }
   ]
 }

--- a/Subnet-Calculator/api/v1/handlers/admin_keys.php
+++ b/Subnet-Calculator/api/v1/handlers/admin_keys.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 // down the JSON endpoints separately.
 
 require_once dirname(__DIR__, 3) . '/includes/functions-admin-auth.php';
+require_once dirname(__DIR__, 3) . '/includes/functions-audit.php';
 
 // Override the api-level Bearer auth challenge with a JSON envelope.
 admin_authenticate(static function (string $reason, int $status): void {
@@ -20,9 +21,17 @@ admin_authenticate(static function (string $reason, int $status): void {
 });
 
 // Route parsing happens against $uri, which the router already normalised.
-// Trailing /{id} extraction:
-$id = null;
-if (preg_match('#^/admin/keys/(\d+)$#', $uri, $m)) {
+// Supported routes:
+//   GET    /admin/keys
+//   POST   /admin/keys
+//   DELETE /admin/keys/{id}
+//   PATCH  /admin/keys/{id}/rate-limit  -- v3.0.0 (#312)
+$id            = null;
+$is_rate_route = false;
+if (preg_match('#^/admin/keys/(\d+)/rate-limit$#', $uri, $m)) {
+    $id            = (int)$m[1];
+    $is_rate_route = true;
+} elseif (preg_match('#^/admin/keys/(\d+)$#', $uri, $m)) {
     $id = (int)$m[1];
 }
 
@@ -43,19 +52,72 @@ try {
         if (!is_string($rawName)) {
             json_err('Field "name" must be a string.', 400);
         }
+        $rawRpm = $body['rate_limit_rpm'] ?? null;
+        $rpm    = null;
+        if ($rawRpm !== null) {
+            if (!is_int($rawRpm) || $rawRpm < 0) {
+                json_err('Field "rate_limit_rpm" must be null or a non-negative integer.', 400);
+            }
+            $rpm = $rawRpm;
+        }
         try {
-            $created = apikey_create($db, $rawName);
+            $created = apikey_create($db, $rawName, $rpm);
         } catch (\InvalidArgumentException $e) {
             json_err($e->getMessage(), 400);
         }
+        audit_log(
+            $db,
+            'key.mint',
+            audit_actor_from_request(),
+            audit_ip_from_request(),
+            (int)$created['id'],
+            ['name' => $created['name'], 'prefix' => $created['prefix'], 'rate_limit_rpm' => $rpm]
+        );
         json_ok($created, 201);
     }
 
-    if ($id !== null && $method === 'DELETE') {
+    if ($id !== null && $is_rate_route && $method === 'PATCH') {
+        $body   = api_body();
+        $rawRpm = $body['rate_limit_rpm'] ?? null;
+        $rpm    = null;
+        if ($rawRpm !== null) {
+            if (!is_int($rawRpm) || $rawRpm < 0) {
+                json_err('Field "rate_limit_rpm" must be null or a non-negative integer.', 400);
+            }
+            $rpm = $rawRpm;
+        }
+        try {
+            $changed = apikey_set_rate_limit($db, $id, $rpm);
+        } catch (\InvalidArgumentException $e) {
+            json_err($e->getMessage(), 400);
+        }
+        if (!$changed) {
+            json_err('Key not found, already revoked, or RPM unchanged.', 404);
+        }
+        audit_log(
+            $db,
+            'key.rate_limit',
+            audit_actor_from_request(),
+            audit_ip_from_request(),
+            $id,
+            ['rate_limit_rpm' => $rpm]
+        );
+        json_ok(['id' => $id, 'rate_limit_rpm' => $rpm]);
+    }
+
+    if ($id !== null && !$is_rate_route && $method === 'DELETE') {
         $ok = apikey_revoke($db, $id);
         if (!$ok) {
             json_err('Key not found or already revoked.', 404);
         }
+        audit_log(
+            $db,
+            'key.revoke',
+            audit_actor_from_request(),
+            audit_ip_from_request(),
+            $id,
+            null
+        );
         json_ok(['id' => $id, 'revoked' => true]);
     }
 } catch (\Throwable $e) {

--- a/Subnet-Calculator/api/v1/handlers/sessions.php
+++ b/Subnet-Calculator/api/v1/handlers/sessions.php
@@ -44,6 +44,53 @@ if (!is_array($payload) || $payload === []) {
     json_err('Field "payload" must be a non-empty object.');
 }
 
+// v3.0.0 (#315) — validate the type discriminator. Missing `type` defaults
+// to 'ipv4' for back-compat with v2 callers. Unknown types are rejected.
+$type = $payload['type'] ?? 'ipv4';
+if (!is_string($type) || !in_array($type, ['ipv4', 'ipv6', 'tree'], true)) {
+    json_err('Field "type" must be one of: ipv4, ipv6, tree.');
+}
+$payload['type'] = $type; // normalise so the loaded session always has it
+
+if ($type === 'ipv4' || $type === 'ipv6') {
+    foreach (['network', 'cidr', 'requirements'] as $required) {
+        if (!array_key_exists($required, $payload)) {
+            json_err('Missing required field: ' . $required);
+        }
+    }
+    if (!is_array($payload['requirements']) || $payload['requirements'] === []) {
+        json_err('Field "requirements" must be a non-empty array.');
+    }
+    foreach ($payload['requirements'] as $i => $req) {
+        if (!is_array($req) || !isset($req['name'], $req['hosts'])) {
+            json_err("requirements[$i] must have name and hosts.");
+        }
+        // IPv6 'hosts' may be the "2^N" string form; ipv4 must be int.
+        if ($type === 'ipv4' && !is_int($req['hosts'])) {
+            json_err("requirements[$i].hosts must be an integer for ipv4.");
+        }
+        if (
+            $type === 'ipv6'
+            && !is_int($req['hosts'])
+            && !(
+                is_string($req['hosts'])
+                && preg_match('/^2\^([0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$/', $req['hosts'])
+            )
+        ) {
+            json_err("requirements[$i].hosts must be a positive integer or the string \"2^N\" with N in 0–128.");
+        }
+    }
+} elseif ($type === 'tree') {
+    // Schema-level validation only at this stage (PR1). Full tree_validate()
+    // ships in PR3 (#302) when the tree editor lands.
+    if (!isset($payload['root']) || !is_array($payload['root'])) {
+        json_err('Field "root" must be an object for tree sessions.');
+    }
+    if (!isset($payload['root']['cidr']) || !is_string($payload['root']['cidr'])) {
+        json_err('root.cidr is required for tree sessions.');
+    }
+}
+
 $db_dir = dirname($db_path);
 if (!is_dir($db_dir)) {
     mkdir($db_dir, 0755, true);

--- a/Subnet-Calculator/api/v1/helpers.php
+++ b/Subnet-Calculator/api/v1/helpers.php
@@ -34,7 +34,7 @@ function api_cors(): void
     global $api_cors_origins;
     $origin = (string)($api_cors_origins ?? '*');
     header('Access-Control-Allow-Origin: ' . $origin);
-    header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+    header('Access-Control-Allow-Methods: GET, POST, PATCH, DELETE, OPTIONS');
     header('Access-Control-Allow-Headers: Authorization, Content-Type');
     header('Access-Control-Max-Age: 86400');
     if (($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') {
@@ -120,6 +120,23 @@ function api_sqlite_keys_present(): bool
     return $cached;
 }
 
+/**
+ * Stash the SQLite-verified key row so api_rate_limit() can read it
+ * without re-running bcrypt. Returns the previously-stashed value when
+ * called with no argument.
+ *
+ * @param  array<string, mixed>|null $row
+ * @return array<string, mixed>|null
+ */
+function api_verified_sqlite_key(?array $row = null): ?array
+{
+    static $stash = null;
+    if (func_num_args() > 0) {
+        $stash = $row;
+    }
+    return $stash;
+}
+
 function api_authenticate(): void
 {
     global $api_tokens;
@@ -151,6 +168,12 @@ function api_authenticate(): void
             $db = apikey_db_open($db_path);
             $row = apikey_verify($db, $token);
             if ($row !== null) {
+                // Stash the verified row for api_rate_limit() so it can
+                // honour the per-key rate_limit_rpm override (#312) without
+                // re-running bcrypt. Cleared at the end of the request by
+                // PHP's normal teardown — statics live for one request only.
+                api_verified_sqlite_key($row);
+
                 // Stat update is best-effort: a transient lock or perms blip
                 // here must NOT reject a token that just verified. Log and
                 // proceed so the caller sees a 200 with a stale last_used_at.
@@ -178,30 +201,58 @@ function api_rate_limit(string $key): void
 {
     global $api_rate_limit_rpm, $api_rate_limit_tokens, $api_tokens, $session_db_path;
 
-    // Determine effective RPM: per-token override takes precedence when a valid
-    // Bearer token is present and has an entry in $api_rate_limit_tokens.
-    $rpm = (int)($api_rate_limit_rpm ?? 0);
+    // Effective RPM lookup order (first match wins):
+    //   1. Static $api_rate_limit_tokens[token] override (operator-edited config)
+    //   2. SQLite api_keys.rate_limit_rpm override (#312, set via /admin/keys.php)
+    //   3. Global $api_rate_limit_rpm fallback
+    // An RPM of 0 at any tier means "unlimited" for that match.
+    $rpm    = (int)($api_rate_limit_rpm ?? 0);
     $rl_key = $key; // default: key by IP
+
+    $authRaw = $_SERVER['HTTP_AUTHORIZATION'] ?? null;
+    $auth    = is_string($authRaw) ? $authRaw : '';
+    $token   = str_starts_with($auth, 'Bearer ') ? substr($auth, 7) : '';
+
+    // Tier 1 — static map from $api_tokens
+    $matched = false;
     if (
-        is_array($api_tokens) && $api_tokens !== []
+        $token !== ''
+        && is_array($api_tokens) && $api_tokens !== []
         && is_array($api_rate_limit_tokens) && $api_rate_limit_tokens !== []
+        && in_array($token, $api_tokens, true)
+        && array_key_exists($token, $api_rate_limit_tokens)
     ) {
-        $authRaw = $_SERVER['HTTP_AUTHORIZATION'] ?? null;
-        $auth    = is_string($authRaw) ? $authRaw : '';
-        if (str_starts_with($auth, 'Bearer ')) {
-            $token = substr($auth, 7);
-            if (in_array($token, $api_tokens, true) && array_key_exists($token, $api_rate_limit_tokens)) {
-                $raw_rpm = $api_rate_limit_tokens[$token];
-                if (is_numeric($raw_rpm)) {
-                    $token_rpm = (int)$raw_rpm;
-                    if ($token_rpm === 0) {
-                        return; // explicit 0 = unlimited for this token
-                    }
-                    $rpm    = $token_rpm;
-                    $rl_key = 'tok:' . hash('sha256', $token); // key by token hash, not IP
-                }
-                // non-numeric entry: ignore override, fall through to global $rpm
+        $raw_rpm = $api_rate_limit_tokens[$token];
+        if (is_numeric($raw_rpm)) {
+            $token_rpm = (int)$raw_rpm;
+            $matched   = true;
+            if ($token_rpm === 0) {
+                return; // explicit 0 = unlimited for this token
             }
+            $rpm    = $token_rpm;
+            $rl_key = 'tok:' . hash('sha256', $token);
+        }
+        // non-numeric entry: ignore, fall through to next tier
+    }
+
+    // Tier 2 — SQLite per-key override (#312). Only applies when api_authenticate()
+    // already verified the bearer token via apikey_verify() and stashed the row.
+    if (!$matched && $token !== '' && function_exists('api_verified_sqlite_key')) {
+        $verified = api_verified_sqlite_key();
+        if (
+            is_array($verified)
+            && isset($verified['rate_limit_rpm']) && is_int($verified['rate_limit_rpm'])
+            && isset($verified['id'])             && is_int($verified['id'])
+        ) {
+            $sqlite_rpm = $verified['rate_limit_rpm'];
+            $matched    = true;
+            if ($sqlite_rpm === 0) {
+                return; // 0 = unlimited for this key
+            }
+            $rpm    = $sqlite_rpm;
+            // Bucket by key id, not token plaintext — stable across tokens
+            // sharing a prefix and avoids hashing the token here.
+            $rl_key = 'key:' . $verified['id'];
         }
     }
 

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -116,6 +116,7 @@ if ($uri === '/' && $method === 'GET') {
             'GET    /api/v1/admin/keys',
             'POST   /api/v1/admin/keys',
             'DELETE /api/v1/admin/keys/{id}',
+            'PATCH  /api/v1/admin/keys/{id}/rate-limit',
         ] : [],
     ]);
 }
@@ -151,12 +152,14 @@ if ($method === 'GET' && preg_match('#^/schemas/[a-z0-9\-]+$#', $uri)) {
     require __DIR__ . '/handlers/schemas.php';
 }
 
-// Admin: /admin/keys (POST, GET) and /admin/keys/{id} (DELETE).
+// Admin: /admin/keys (POST, GET), /admin/keys/{id} (DELETE),
+// /admin/keys/{id}/rate-limit (PATCH).
 // Auth happens inside the handler so that every failure path emits JSON
 // with a proper WWW-Authenticate challenge on 401.
 if (
     ($uri === '/admin/keys' && in_array($method, ['POST', 'GET'], true))
     || (preg_match('#^/admin/keys/\d+$#', $uri) && $method === 'DELETE')
+    || (preg_match('#^/admin/keys/\d+/rate-limit$#', $uri) && $method === 'PATCH')
 ) {
     require __DIR__ . '/handlers/admin_keys.php';
 }

--- a/Subnet-Calculator/includes/config.php
+++ b/Subnet-Calculator/includes/config.php
@@ -51,8 +51,16 @@ $admin_user        = '';     // Admin username for HTTP Basic Auth on /admin/
 $admin_pass_hash   = '';     // PASSWORD_BCRYPT hash of the admin password
 $apikey_db_path    = '';     // SQLite file for api_keys (auto: data/sessions.sqlite or data/admin.sqlite)
 
+// Admin audit log (v3.0.0, #306)
+$admin_audit_retention_days = 90;  // 0 = never purge; rows older than this are removed on each audit write
+
 if (file_exists(__DIR__ . '/../config.php')) {
     require __DIR__ . '/../config.php';
+}
+// Optional second-tier config written by the first-run admin wizard (v3.0.0, #311).
+// Hand-edited config.php takes precedence; config-admin.php only fills gaps.
+if (file_exists(__DIR__ . '/../config-admin.php')) {
+    require __DIR__ . '/../config-admin.php';
 }
 
 // Sanitise config values
@@ -121,3 +129,4 @@ $admin_ui_enabled = (bool)$admin_ui_enabled;
 $admin_user       = is_string($admin_user)      ? $admin_user      : '';
 $admin_pass_hash  = is_string($admin_pass_hash) ? $admin_pass_hash : '';
 $apikey_db_path   = is_string($apikey_db_path)  ? $apikey_db_path  : '';
+$admin_audit_retention_days = max(0, (int)$admin_audit_retention_days);

--- a/Subnet-Calculator/includes/functions-admin-auth.php
+++ b/Subnet-Calculator/includes/functions-admin-auth.php
@@ -60,8 +60,49 @@ function admin_authenticate(?callable $onFail = null): void
     // Constant-time username compare; bcrypt verify is itself constant-time
     // for matching-cost hashes.
     if (!hash_equals($admin_user, $u) || !password_verify($p, $admin_pass_hash)) {
+        admin_audit_login_outcome(false, $u);
         $onFail('Invalid credentials.', 401);
         return;
+    }
+
+    admin_audit_login_outcome(true, $u);
+}
+
+/**
+ * Best-effort audit log entry for an admin auth attempt. Lazily loads
+ * functions-audit.php so the audit module remains optional at install time
+ * (some self-hosters may strip the admin DB writeability for read-only
+ * inspection). Any error is swallowed — auth must remain authoritative.
+ */
+function admin_audit_login_outcome(bool $ok, string $attemptedUser): void
+{
+    static $loaded = false;
+    if (!$loaded) {
+        $audit_path = __DIR__ . '/functions-audit.php';
+        if (!is_file($audit_path)) {
+            return;
+        }
+        require_once $audit_path;
+        $loaded = true;
+    }
+    if (!function_exists('audit_log') || !function_exists('audit_ip_from_request')) {
+        return;
+    }
+    try {
+        $db = new \SQLite3(admin_apikey_db_path());
+        $db->enableExceptions(true);
+        $db->busyTimeout(1500);
+        audit_log(
+            $db,
+            $ok ? 'login.ok' : 'login.fail',
+            $attemptedUser !== '' ? $attemptedUser : null,
+            audit_ip_from_request(),
+            null,
+            null
+        );
+        $db->close();
+    } catch (\Throwable $e) {
+        error_log('sc admin_audit_login_outcome error: ' . $e->getMessage());
     }
 }
 

--- a/Subnet-Calculator/includes/functions-apikeys.php
+++ b/Subnet-Calculator/includes/functions-apikeys.php
@@ -42,7 +42,34 @@ function apikey_db_open(string $path): \SQLite3
         CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(prefix);'
     );
 
+    // v3.0.0 (#312) — per-key rate-limit override. Backfilled NULL on
+    // existing rows so they continue to inherit the global setting.
+    apikey_migrate_add_rate_limit($db);
+
     return $db;
+}
+
+/**
+ * Idempotent migration: add the `rate_limit_rpm` column if it is missing.
+ * Safe to call on every open — costs a single PRAGMA query when present.
+ */
+function apikey_migrate_add_rate_limit(\SQLite3 $db): void
+{
+    $res = $db->query("PRAGMA table_info('api_keys')");
+    if ($res === false) {
+        return;
+    }
+    $hasColumn = false;
+    while (($row = $res->fetchArray(SQLITE3_ASSOC)) !== false) {
+        if ((string)($row['name'] ?? '') === 'rate_limit_rpm') {
+            $hasColumn = true;
+            break;
+        }
+    }
+    if (!$hasColumn) {
+        // ALTER TABLE ... ADD COLUMN is fully supported on SQLite >= 3.2.
+        $db->exec('ALTER TABLE api_keys ADD COLUMN rate_limit_rpm INTEGER');
+    }
 }
 
 /**
@@ -60,7 +87,7 @@ function apikey_db_open(string $path): \SQLite3
  * (the historical `false` return was removed); we therefore do not guard
  * against a hash failure on the happy path.
  */
-function apikey_create(\SQLite3 $db, string $name): array
+function apikey_create(\SQLite3 $db, string $name, ?int $rateLimitRpm = null): array
 {
     $name = trim($name);
     if ($name === '') {
@@ -69,6 +96,9 @@ function apikey_create(\SQLite3 $db, string $name): array
     if (strlen($name) > APIKEY_NAME_MAX) {
         throw new InvalidArgumentException('API key name exceeds ' . APIKEY_NAME_MAX . ' characters.');
     }
+    if ($rateLimitRpm !== null && $rateLimitRpm < 0) {
+        throw new InvalidArgumentException('Rate limit (RPM) must be 0 (unlimited) or a positive integer.');
+    }
 
     $hex    = bin2hex(random_bytes(APIKEY_RAND_HEX_LEN / 2));
     $token  = APIKEY_TOKEN_PREFIX . $hex;
@@ -76,8 +106,8 @@ function apikey_create(\SQLite3 $db, string $name): array
     $hash = password_hash($token, PASSWORD_BCRYPT);
     $now  = time();
     $stmt = $db->prepare(
-        'INSERT INTO api_keys (name, prefix, token_hash, created_at)
-         VALUES (:name, :prefix, :hash, :ts)'
+        'INSERT INTO api_keys (name, prefix, token_hash, created_at, rate_limit_rpm)
+         VALUES (:name, :prefix, :hash, :ts, :rpm)'
     );
     if ($stmt === false) {
         throw new \RuntimeException('Failed to prepare insert.');
@@ -86,14 +116,20 @@ function apikey_create(\SQLite3 $db, string $name): array
     $stmt->bindValue(':prefix', $prefix, SQLITE3_TEXT);
     $stmt->bindValue(':hash', $hash, SQLITE3_TEXT);
     $stmt->bindValue(':ts', $now, SQLITE3_INTEGER);
+    $stmt->bindValue(
+        ':rpm',
+        $rateLimitRpm,
+        $rateLimitRpm === null ? SQLITE3_NULL : SQLITE3_INTEGER
+    );
     $stmt->execute();
 
     return [
-        'id'         => (int)$db->lastInsertRowID(),
-        'token'      => $token,
-        'prefix'     => $prefix,
-        'name'       => $name,
-        'created_at' => $now,
+        'id'             => (int)$db->lastInsertRowID(),
+        'token'          => $token,
+        'prefix'         => $prefix,
+        'name'           => $name,
+        'created_at'     => $now,
+        'rate_limit_rpm' => $rateLimitRpm,
     ];
 }
 
@@ -119,7 +155,7 @@ function apikey_verify(\SQLite3 $db, string $token): ?array
     $prefix = substr($hex, 0, APIKEY_PUBLIC_PREFIX);
 
     $stmt = $db->prepare(
-        'SELECT id, name, prefix, token_hash, created_at, last_used_at
+        'SELECT id, name, prefix, token_hash, created_at, last_used_at, rate_limit_rpm
          FROM api_keys
          WHERE prefix = :p AND revoked_at IS NULL'
     );
@@ -134,11 +170,12 @@ function apikey_verify(\SQLite3 $db, string $token): ?array
     while (($row = $res->fetchArray(SQLITE3_ASSOC)) !== false) {
         if (password_verify($token, (string)$row['token_hash'])) {
             return [
-                'id'           => (int)$row['id'],
-                'name'         => (string)$row['name'],
-                'prefix'       => (string)$row['prefix'],
-                'created_at'   => (int)$row['created_at'],
-                'last_used_at' => $row['last_used_at'] !== null ? (int)$row['last_used_at'] : null,
+                'id'             => (int)$row['id'],
+                'name'           => (string)$row['name'],
+                'prefix'         => (string)$row['prefix'],
+                'created_at'     => (int)$row['created_at'],
+                'last_used_at'   => $row['last_used_at'] !== null ? (int)$row['last_used_at'] : null,
+                'rate_limit_rpm' => $row['rate_limit_rpm'] !== null ? (int)$row['rate_limit_rpm'] : null,
             ];
         }
     }
@@ -156,7 +193,7 @@ function apikey_list(\SQLite3 $db): array
     // enableExceptions(true) set in apikey_db_open). Callers must
     // surface errors — silently returning [] would mask DB failures.
     $res = $db->query(
-        'SELECT id, name, prefix, created_at, last_used_at, revoked_at
+        'SELECT id, name, prefix, created_at, last_used_at, revoked_at, rate_limit_rpm
          FROM api_keys
          ORDER BY id DESC'
     );
@@ -166,15 +203,43 @@ function apikey_list(\SQLite3 $db): array
     $rows = [];
     while (($r = $res->fetchArray(SQLITE3_ASSOC)) !== false) {
         $rows[] = [
-            'id'           => (int)$r['id'],
-            'name'         => (string)$r['name'],
-            'prefix'       => (string)$r['prefix'],
-            'created_at'   => (int)$r['created_at'],
-            'last_used_at' => $r['last_used_at'] !== null ? (int)$r['last_used_at'] : null,
-            'revoked_at'   => $r['revoked_at']   !== null ? (int)$r['revoked_at']   : null,
+            'id'             => (int)$r['id'],
+            'name'           => (string)$r['name'],
+            'prefix'         => (string)$r['prefix'],
+            'created_at'     => (int)$r['created_at'],
+            'last_used_at'   => $r['last_used_at']   !== null ? (int)$r['last_used_at']   : null,
+            'revoked_at'     => $r['revoked_at']     !== null ? (int)$r['revoked_at']     : null,
+            'rate_limit_rpm' => $r['rate_limit_rpm'] !== null ? (int)$r['rate_limit_rpm'] : null,
         ];
     }
     return $rows;
+}
+
+/**
+ * Set or clear the per-key RPM override. Pass null to revert to the
+ * global default. Returns true if the row existed and was active, false
+ * otherwise — matches apikey_revoke()'s convention so the admin UI can
+ * distinguish "no such key" from "DB error" (the latter throws).
+ *
+ * @throws InvalidArgumentException for negative RPM
+ * @throws \RuntimeException        on prepare failure
+ */
+function apikey_set_rate_limit(\SQLite3 $db, int $id, ?int $rpm): bool
+{
+    if ($rpm !== null && $rpm < 0) {
+        throw new InvalidArgumentException('Rate limit (RPM) must be 0 (unlimited) or a positive integer.');
+    }
+    $stmt = $db->prepare(
+        'UPDATE api_keys SET rate_limit_rpm = :rpm
+         WHERE id = :id AND revoked_at IS NULL'
+    );
+    if ($stmt === false) {
+        throw new \RuntimeException('Failed to prepare rate-limit update.');
+    }
+    $stmt->bindValue(':rpm', $rpm, $rpm === null ? SQLITE3_NULL : SQLITE3_INTEGER);
+    $stmt->bindValue(':id', $id, SQLITE3_INTEGER);
+    $stmt->execute();
+    return $db->changes() > 0;
 }
 
 /**

--- a/Subnet-Calculator/includes/functions-audit.php
+++ b/Subnet-Calculator/includes/functions-audit.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+// Admin audit log (v3.0.0, #306).
+//
+// Persists a structured trail of security-relevant admin actions so an
+// operator can answer "who did what, when, from where". All admin entry
+// points (HTTP Basic auth result, key mint, key revoke, and PR2's wizard
+// + TOTP events) call audit_log() through a single SQLite-backed table
+// that lives in the same database as api_keys.
+//
+// Retention is bounded by $admin_audit_retention_days (default 90); rows
+// older than the window are purged whenever audit_log() runs (lazy purge,
+// matching session_create()'s pattern — no separate cron required).
+
+const AUDIT_RETENTION_DEFAULT_DAYS = 90;
+const AUDIT_ACTION_MAX             = 64;
+const AUDIT_ACTOR_MAX              = 128;
+const AUDIT_IP_MAX                 = 64;
+const AUDIT_META_MAX               = 4096;
+
+/**
+ * Open (and migrate) the admin_audit table on the supplied database
+ * handle. The handle is reused across calls — callers typically pass the
+ * same SQLite3 instance returned from apikey_db_open() so all admin data
+ * lives in one file.
+ *
+ * @throws \RuntimeException on schema failure
+ */
+function audit_db_init(\SQLite3 $db): void
+{
+    $db->exec(
+        'CREATE TABLE IF NOT EXISTS admin_audit (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts        INTEGER NOT NULL,
+            actor     TEXT,
+            ip        TEXT,
+            action    TEXT NOT NULL,
+            target_id INTEGER,
+            meta      TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_admin_audit_ts ON admin_audit(ts);
+        CREATE INDEX IF NOT EXISTS idx_admin_audit_action ON admin_audit(action);'
+    );
+}
+
+/**
+ * Record an admin action.
+ *
+ * Best-effort: a write failure logs to error_log but does not throw — we
+ * never want an audit failure to mask the underlying admin action (e.g.
+ * a successful key revocation must complete even if the audit table is
+ * locked by a concurrent writer).
+ *
+ * @param array<string, mixed>|null $meta  Action-specific JSON-serialisable detail.
+ */
+function audit_log(
+    \SQLite3 $db,
+    string $action,
+    ?string $actor = null,
+    ?string $ip = null,
+    ?int $targetId = null,
+    ?array $meta = null
+): void {
+    if ($action === '' || strlen($action) > AUDIT_ACTION_MAX) {
+        error_log('sc audit_log: invalid action: ' . $action);
+        return;
+    }
+
+    if ($actor !== null) {
+        $actor = mb_substr($actor, 0, AUDIT_ACTOR_MAX);
+    }
+    if ($ip !== null) {
+        $ip = substr($ip, 0, AUDIT_IP_MAX);
+    }
+
+    $metaJson = null;
+    if ($meta !== null) {
+        try {
+            $metaJson = json_encode($meta, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+            if (strlen((string)$metaJson) > AUDIT_META_MAX) {
+                $metaJson = json_encode(['truncated' => true], JSON_THROW_ON_ERROR);
+            }
+        } catch (\Throwable $e) {
+            error_log('sc audit_log meta encode error: ' . $e->getMessage());
+            $metaJson = null;
+        }
+    }
+
+    try {
+        audit_db_init($db);
+        audit_purge($db);
+
+        $stmt = $db->prepare(
+            'INSERT INTO admin_audit (ts, actor, ip, action, target_id, meta)
+             VALUES (:ts, :actor, :ip, :action, :tid, :meta)'
+        );
+        if ($stmt === false) {
+            throw new \RuntimeException('Failed to prepare admin_audit insert.');
+        }
+        $stmt->bindValue(':ts', time(), SQLITE3_INTEGER);
+        $stmt->bindValue(':actor', $actor, $actor === null ? SQLITE3_NULL : SQLITE3_TEXT);
+        $stmt->bindValue(':ip', $ip, $ip === null ? SQLITE3_NULL : SQLITE3_TEXT);
+        $stmt->bindValue(':action', $action, SQLITE3_TEXT);
+        $stmt->bindValue(':tid', $targetId, $targetId === null ? SQLITE3_NULL : SQLITE3_INTEGER);
+        $stmt->bindValue(':meta', $metaJson, $metaJson === null ? SQLITE3_NULL : SQLITE3_TEXT);
+        $stmt->execute();
+    } catch (\Throwable $e) {
+        error_log('sc audit_log write error: ' . $e->getMessage());
+    }
+}
+
+/**
+ * List audit rows newest-first, with optional offset for pagination and
+ * an optional action prefix filter (e.g. 'login.' surfaces only auth events).
+ *
+ * @return array<int, array{id:int, ts:int, actor:?string, ip:?string, action:string, target_id:?int, meta:?string}>
+ * @throws \RuntimeException on read failure (callers should surface, not hide)
+ */
+function audit_list(\SQLite3 $db, int $limit = 50, int $offset = 0, ?string $actionPrefix = null): array
+{
+    audit_db_init($db);
+
+    $limit  = max(1, min(500, $limit));
+    $offset = max(0, $offset);
+
+    if ($actionPrefix !== null && $actionPrefix !== '') {
+        $stmt = $db->prepare(
+            'SELECT id, ts, actor, ip, action, target_id, meta
+             FROM admin_audit
+             WHERE action LIKE :pfx
+             ORDER BY id DESC
+             LIMIT :lim OFFSET :off'
+        );
+        if ($stmt === false) {
+            throw new \RuntimeException('Failed to prepare admin_audit select.');
+        }
+        $stmt->bindValue(':pfx', $actionPrefix . '%', SQLITE3_TEXT);
+    } else {
+        $stmt = $db->prepare(
+            'SELECT id, ts, actor, ip, action, target_id, meta
+             FROM admin_audit
+             ORDER BY id DESC
+             LIMIT :lim OFFSET :off'
+        );
+        if ($stmt === false) {
+            throw new \RuntimeException('Failed to prepare admin_audit select.');
+        }
+    }
+    $stmt->bindValue(':lim', $limit, SQLITE3_INTEGER);
+    $stmt->bindValue(':off', $offset, SQLITE3_INTEGER);
+
+    $res = $stmt->execute();
+    if ($res === false) {
+        throw new \RuntimeException('Failed to read admin_audit.');
+    }
+
+    $rows = [];
+    while (($r = $res->fetchArray(SQLITE3_ASSOC)) !== false) {
+        $rows[] = [
+            'id'        => (int)$r['id'],
+            'ts'        => (int)$r['ts'],
+            'actor'     => $r['actor']  !== null ? (string)$r['actor']  : null,
+            'ip'        => $r['ip']     !== null ? (string)$r['ip']     : null,
+            'action'    => (string)$r['action'],
+            'target_id' => $r['target_id'] !== null ? (int)$r['target_id'] : null,
+            'meta'      => $r['meta']   !== null ? (string)$r['meta']   : null,
+        ];
+    }
+    return $rows;
+}
+
+/**
+ * Total row count for pagination footer.
+ *
+ * @throws \RuntimeException on read failure
+ */
+function audit_count(\SQLite3 $db, ?string $actionPrefix = null): int
+{
+    audit_db_init($db);
+
+    if ($actionPrefix !== null && $actionPrefix !== '') {
+        $stmt = $db->prepare('SELECT COUNT(*) FROM admin_audit WHERE action LIKE :pfx');
+        if ($stmt === false) {
+            throw new \RuntimeException('Failed to prepare admin_audit count.');
+        }
+        $stmt->bindValue(':pfx', $actionPrefix . '%', SQLITE3_TEXT);
+    } else {
+        $stmt = $db->prepare('SELECT COUNT(*) FROM admin_audit');
+        if ($stmt === false) {
+            throw new \RuntimeException('Failed to prepare admin_audit count.');
+        }
+    }
+    $res = $stmt->execute();
+    if ($res === false) {
+        throw new \RuntimeException('Failed to count admin_audit.');
+    }
+    $row = $res->fetchArray(SQLITE3_NUM);
+    return is_array($row) ? (int)$row[0] : 0;
+}
+
+/**
+ * Drop rows older than the configured retention window. Resolves the
+ * retention from the global $admin_audit_retention_days, falling back to
+ * AUDIT_RETENTION_DEFAULT_DAYS. A retention of 0 disables purging
+ * (operators who want to keep everything until they manually rotate).
+ */
+function audit_purge(\SQLite3 $db): void
+{
+    global $admin_audit_retention_days;
+
+    $days = is_int($admin_audit_retention_days ?? null)
+        ? $admin_audit_retention_days
+        : AUDIT_RETENTION_DEFAULT_DAYS;
+    if ($days <= 0) {
+        return;
+    }
+    $cutoff = time() - ($days * 86400);
+    $stmt = $db->prepare('DELETE FROM admin_audit WHERE ts < :c');
+    if ($stmt === false) {
+        return;
+    }
+    $stmt->bindValue(':c', $cutoff, SQLITE3_INTEGER);
+    $stmt->execute();
+}
+
+/**
+ * Convenience: derive the actor + IP that surrounding code will pass to
+ * audit_log(). Centralised so a future header change (e.g. trusting an
+ * X-Real-IP from a known-good reverse proxy) only happens here.
+ */
+function audit_actor_from_request(): ?string
+{
+    $u = $_SERVER['PHP_AUTH_USER'] ?? null;
+    return is_string($u) && $u !== '' ? $u : null;
+}
+
+function audit_ip_from_request(): ?string
+{
+    $ipRaw = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? null;
+    if (!is_string($ipRaw) || $ipRaw === '') {
+        return null;
+    }
+    return trim(explode(',', $ipRaw)[0]);
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -643,52 +643,125 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     if ($is_session_save && !$form_blocked && $session_enabled) {
-        $vlsm_network    = trim((string)($_POST['vlsm_network'] ?? ''));
-        $vlsm_cidr_input = trim((string)($_POST['vlsm_cidr']   ?? ''));
-        $rv = resolve_ipv4_input($vlsm_network, $vlsm_cidr_input);
-        if (!$rv['result']) {
-            $session_error = 'Parent network: ' . ($rv['error'] ?? 'Invalid input.');
-        } else {
-            $names = $_POST['vlsm_name']  ?? [];
-            $hosts = $_POST['vlsm_hosts'] ?? [];
-            $reqs  = [];
-            if (is_array($names) && is_array($hosts)) {
-                foreach ($names as $i => $name) {
-                    $name = mb_substr(trim((string)$name), 0, 100);
-                    $hval = trim((string)($hosts[$i] ?? ''));
-                    if ($name !== '' && ctype_digit($hval) && (int)$hval >= 1) {
-                        $reqs[] = ['name' => $name, 'hosts' => (int)$hval];
+        // v3.0.0 (#315) — POST distinguishes ipv4 vs ipv6 sessions via the
+        // session_type hidden input on the IPv6 VLSM tab. Default 'ipv4' keeps
+        // back-compat with the original single-tab Save Session button.
+        $session_type_in = (string)($_POST['session_type'] ?? 'ipv4');
+        if (!in_array($session_type_in, ['ipv4', 'ipv6'], true)) {
+            $session_type_in = 'ipv4';
+        }
+
+        if ($session_type_in === 'ipv6') {
+            $vlsm6_network    = trim((string)($_POST['vlsm6_network'] ?? ''));
+            $vlsm6_cidr_input = trim((string)($_POST['vlsm6_cidr']   ?? ''));
+            $rv6 = resolve_ipv6_input($vlsm6_network, $vlsm6_cidr_input);
+            if (!$rv6['result6']) {
+                $session_error = 'Parent network: ' . ($rv6['error6'] ?? 'Invalid input.');
+            } else {
+                $names6 = $_POST['vlsm6_name']  ?? [];
+                $hosts6 = $_POST['vlsm6_hosts'] ?? [];
+                $reqs6  = [];
+                if (is_array($names6) && is_array($hosts6)) {
+                    foreach ($names6 as $i => $name) {
+                        $name = mb_substr(trim((string)$name), 0, 100);
+                        $hval = trim((string)($hosts6[$i] ?? ''));
+                        if ($name === '' || $hval === '') {
+                            continue;
+                        }
+                        if (ctype_digit($hval) && (int)$hval >= 1) {
+                            $reqs6[] = ['name' => $name, 'hosts' => (int)$hval];
+                        } elseif (preg_match('/^2\^([0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$/', $hval)) {
+                            // Preserve the "2^N" string form for sizings that overflow int64.
+                            $reqs6[] = ['name' => $name, 'hosts' => $hval];
+                        }
+                    }
+                }
+                if ($reqs6 === []) {
+                    $session_error = 'No valid IPv6 VLSM requirements to save.';
+                } else {
+                    $vlsm6_cidr_int   = (int)ltrim($rv6['result6']['prefix'], '/');
+                    $vlsm6_network_ip = explode('/', $rv6['result6']['network_cidr'])[0];
+                    $vlsm6_requirements = $reqs6;
+                    $vr6 = vlsm6_allocate($vlsm6_network_ip, $vlsm6_cidr_int, $reqs6);
+                    if (isset($vr6['error'])) {
+                        $session_error = $vr6['error'];
+                    } else {
+                        $vlsm6_result = $vr6['allocations'] ?? [];
+                        try {
+                            $db_path = $session_db_path !== '' ? $session_db_path
+                                : dirname(__DIR__) . '/data/sessions.sqlite';
+                            $db_dir  = dirname($db_path);
+                            if (!is_dir($db_dir)) {
+                                mkdir($db_dir, 0755, true);
+                            }
+                            $sdb  = session_db_open($db_path);
+                            $session_save_id = session_create($sdb, [
+                                'type'         => 'ipv6',
+                                'network'      => $vlsm6_network,
+                                'cidr'         => ltrim($vlsm6_cidr_input, '/'),
+                                'requirements' => $reqs6,
+                            ], $session_ttl_days);
+                            $sdb->close();
+                        } catch (\Exception $e) {
+                            error_log('sc session save (ipv6) error: ' . $e->getMessage());
+                            $session_error = 'Failed to save session. Please try again.';
+                        }
                     }
                 }
             }
-            if ($reqs === []) {
-                $session_error = 'No valid VLSM requirements to save.';
+        } else {
+            // IPv4 path — unchanged behaviour. The 'type' field is added
+            // explicitly so newly-saved IPv4 sessions are tagged for the v2
+            // schema; older payloads remain readable thanks to the default
+            // in the load path.
+            $vlsm_network    = trim((string)($_POST['vlsm_network'] ?? ''));
+            $vlsm_cidr_input = trim((string)($_POST['vlsm_cidr']   ?? ''));
+            $rv = resolve_ipv4_input($vlsm_network, $vlsm_cidr_input);
+            if (!$rv['result']) {
+                $session_error = 'Parent network: ' . ($rv['error'] ?? 'Invalid input.');
             } else {
-                $vlsm_cidr_int   = (int)ltrim($rv['result']['netmask_cidr'], '/');
-                $vlsm_network_ip = explode('/', $rv['result']['network_cidr'])[0];
-                $vlsm_requirements = $reqs;
-                $vr = vlsm_allocate($vlsm_network_ip, $vlsm_cidr_int, $reqs);
-                if (isset($vr['error'])) {
-                    $session_error = $vr['error'];
-                } else {
-                    $vlsm_result = $vr['allocations'] ?? [];
-                    try {
-                        $db_path = $session_db_path !== '' ? $session_db_path
-                            : dirname(__DIR__) . '/data/sessions.sqlite';
-                        $db_dir  = dirname($db_path);
-                        if (!is_dir($db_dir)) {
-                            mkdir($db_dir, 0755, true);
+                $names = $_POST['vlsm_name']  ?? [];
+                $hosts = $_POST['vlsm_hosts'] ?? [];
+                $reqs  = [];
+                if (is_array($names) && is_array($hosts)) {
+                    foreach ($names as $i => $name) {
+                        $name = mb_substr(trim((string)$name), 0, 100);
+                        $hval = trim((string)($hosts[$i] ?? ''));
+                        if ($name !== '' && ctype_digit($hval) && (int)$hval >= 1) {
+                            $reqs[] = ['name' => $name, 'hosts' => (int)$hval];
                         }
-                        $sdb  = session_db_open($db_path);
-                        $session_save_id = session_create($sdb, [
-                            'network'      => $vlsm_network,
-                            'cidr'         => ltrim($vlsm_cidr_input, '/'),
-                            'requirements' => $reqs,
-                        ], $session_ttl_days);
-                        $sdb->close();
-                    } catch (\Exception $e) {
-                        error_log('sc session save error: ' . $e->getMessage());
-                        $session_error = 'Failed to save session. Please try again.';
+                    }
+                }
+                if ($reqs === []) {
+                    $session_error = 'No valid VLSM requirements to save.';
+                } else {
+                    $vlsm_cidr_int   = (int)ltrim($rv['result']['netmask_cidr'], '/');
+                    $vlsm_network_ip = explode('/', $rv['result']['network_cidr'])[0];
+                    $vlsm_requirements = $reqs;
+                    $vr = vlsm_allocate($vlsm_network_ip, $vlsm_cidr_int, $reqs);
+                    if (isset($vr['error'])) {
+                        $session_error = $vr['error'];
+                    } else {
+                        $vlsm_result = $vr['allocations'] ?? [];
+                        try {
+                            $db_path = $session_db_path !== '' ? $session_db_path
+                                : dirname(__DIR__) . '/data/sessions.sqlite';
+                            $db_dir  = dirname($db_path);
+                            if (!is_dir($db_dir)) {
+                                mkdir($db_dir, 0755, true);
+                            }
+                            $sdb  = session_db_open($db_path);
+                            $session_save_id = session_create($sdb, [
+                                'type'         => 'ipv4',
+                                'network'      => $vlsm_network,
+                                'cidr'         => ltrim($vlsm_cidr_input, '/'),
+                                'requirements' => $reqs,
+                            ], $session_ttl_days);
+                            $sdb->close();
+                        } catch (\Exception $e) {
+                            error_log('sc session save error: ' . $e->getMessage());
+                            $session_error = 'Failed to save session. Please try again.';
+                        }
                     }
                 }
             }
@@ -774,8 +847,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') {
-    // Session load: ?tab=vlsm&s=<id>
-    if ($session_enabled && $active_tab === 'vlsm' && isset($_GET['s'])) {
+    // Session load: ?tab=vlsm&s=<id>  or  ?tab=vlsm6&s=<id>
+    // v3.0.0 (#315) — load path now dispatches on the payload's `type` field
+    // (default 'ipv4' for back-compat). The active tab determines which
+    // template variables get populated, so an IPv6 session loaded on the
+    // ipv4 tab is reported as a tab mismatch rather than silently mis-rendered.
+    if ($session_enabled && in_array($active_tab, ['vlsm', 'vlsm6'], true) && isset($_GET['s'])) {
         $session_load_id = trim((string)$_GET['s']);
         if (preg_match('/^[0-9a-f]{8}$/', $session_load_id)) {
             try {
@@ -788,29 +865,71 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if ($payload === null) {
                         $session_error = 'Session not found or expired.';
                     } else {
-                        $vlsm_network    = (string)($payload['network'] ?? '');
-                        $vlsm_cidr_input = (string)($payload['cidr']    ?? '');
-                        $raw_reqs        = $payload['requirements'] ?? [];
-                        if (is_array($raw_reqs)) {
-                            foreach ($raw_reqs as $req) {
-                                if (is_array($req) && isset($req['name'], $req['hosts'])) {
-                                    $vlsm_requirements[] = [
-                                        'name'  => (string)$req['name'],
-                                        'hosts' => (int)$req['hosts'],
-                                    ];
+                        $payload_type = (string)($payload['type'] ?? 'ipv4');
+                        $expected_type = $active_tab === 'vlsm6' ? 'ipv6' : 'ipv4';
+                        if ($payload_type !== $expected_type) {
+                            $session_error = 'Session is for the '
+                                . ($payload_type === 'ipv6' ? 'IPv6' : 'IPv4')
+                                . ' VLSM planner — switch tabs to load it.';
+                        } elseif ($payload_type === 'ipv6') {
+                            $vlsm6_network    = (string)($payload['network'] ?? '');
+                            $vlsm6_cidr_input = (string)($payload['cidr']    ?? '');
+                            $raw_reqs6        = $payload['requirements'] ?? [];
+                            if (is_array($raw_reqs6)) {
+                                foreach ($raw_reqs6 as $req) {
+                                    if (!is_array($req) || !isset($req['name'], $req['hosts'])) {
+                                        continue;
+                                    }
+                                    $hosts_in = $req['hosts'];
+                                    if (is_int($hosts_in) && $hosts_in >= 1) {
+                                        $vlsm6_requirements[] = ['name' => (string)$req['name'], 'hosts' => $hosts_in];
+                                    } elseif (
+                                        is_string($hosts_in)
+                                        && preg_match('/^2\^([0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$/', $hosts_in)
+                                    ) {
+                                        $vlsm6_requirements[] = ['name' => (string)$req['name'], 'hosts' => $hosts_in];
+                                    }
                                 }
                             }
-                        }
-                        if ($vlsm_requirements !== [] && $vlsm_network !== '') {
-                            $rv = resolve_ipv4_input($vlsm_network, $vlsm_cidr_input);
-                            if ($rv['result']) {
-                                $vlsm_cidr_int   = (int)ltrim($rv['result']['netmask_cidr'], '/');
-                                $vlsm_network_ip = explode('/', $rv['result']['network_cidr'])[0];
-                                $vr = vlsm_allocate($vlsm_network_ip, $vlsm_cidr_int, $vlsm_requirements);
-                                if (isset($vr['error'])) {
-                                    $vlsm_error = $vr['error'];
-                                } else {
-                                    $vlsm_result = $vr['allocations'] ?? [];
+                            if ($vlsm6_requirements !== [] && $vlsm6_network !== '') {
+                                $rv6 = resolve_ipv6_input($vlsm6_network, $vlsm6_cidr_input);
+                                if ($rv6['result6']) {
+                                    $vlsm6_cidr_int   = (int)ltrim($rv6['result6']['prefix'], '/');
+                                    $vlsm6_network_ip = explode('/', $rv6['result6']['network_cidr'])[0];
+                                    $vr6 = vlsm6_allocate($vlsm6_network_ip, $vlsm6_cidr_int, $vlsm6_requirements);
+                                    if (isset($vr6['error'])) {
+                                        $vlsm6_error = $vr6['error'];
+                                    } else {
+                                        $vlsm6_result = $vr6['allocations'] ?? [];
+                                    }
+                                }
+                            }
+                        } else {
+                            // ipv4 (or pre-v3 untyped payload)
+                            $vlsm_network    = (string)($payload['network'] ?? '');
+                            $vlsm_cidr_input = (string)($payload['cidr']    ?? '');
+                            $raw_reqs        = $payload['requirements'] ?? [];
+                            if (is_array($raw_reqs)) {
+                                foreach ($raw_reqs as $req) {
+                                    if (is_array($req) && isset($req['name'], $req['hosts'])) {
+                                        $vlsm_requirements[] = [
+                                            'name'  => (string)$req['name'],
+                                            'hosts' => (int)$req['hosts'],
+                                        ];
+                                    }
+                                }
+                            }
+                            if ($vlsm_requirements !== [] && $vlsm_network !== '') {
+                                $rv = resolve_ipv4_input($vlsm_network, $vlsm_cidr_input);
+                                if ($rv['result']) {
+                                    $vlsm_cidr_int   = (int)ltrim($rv['result']['netmask_cidr'], '/');
+                                    $vlsm_network_ip = explode('/', $rv['result']['network_cidr'])[0];
+                                    $vr = vlsm_allocate($vlsm_network_ip, $vlsm_cidr_int, $vlsm_requirements);
+                                    if (isset($vr['error'])) {
+                                        $vlsm_error = $vr['error'];
+                                    } else {
+                                        $vlsm_result = $vr['allocations'] ?? [];
+                                    }
                                 }
                             }
                         }
@@ -1053,4 +1172,10 @@ $share_base_server = $share_proto . '://' . ($_SERVER['HTTP_HOST'] ?? 'localhost
 $share_url_abs = $share_url !== '' ? $share_base_server . $share_url : '';
 
 // Session save URL (shown after a successful session save)
-$session_save_url = $session_save_id !== '' ? '?tab=vlsm&s=' . urlencode($session_save_id) : '';
+// v3.0.0 (#315) — anchor the share-link tab to the saved session's planner.
+// IPv6 saves go to ?tab=vlsm6, IPv4 stays on ?tab=vlsm. The active tab at
+// save time is the source of truth (IPv6 saves only happen on vlsm6).
+$session_save_tab = ($active_tab === 'vlsm6') ? 'vlsm6' : 'vlsm';
+$session_save_url = $session_save_id !== ''
+    ? '?tab=' . $session_save_tab . '&s=' . urlencode($session_save_id)
+    : '';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -1345,6 +1345,51 @@ if ($i < 3) {
             </div>
             <?php endif; ?>
         <?php endif; ?>
+
+        <?php if ($session_enabled && $active_tab === 'vlsm6') : ?>
+        <!-- v3.0.0 (#315) IPv6 VLSM session save / load -->
+        <div class="vlsm6-session-controls" id="vlsm6-session-controls">
+            <div class="overlap-title">Save &amp; Restore IPv6 Session<?= help_bubble('vlsm6-session', 'Saves your IPv6 VLSM inputs to the server so you can restore them later via a short link. Sessions expire after the configured TTL.') ?></div>
+            <p class="session-ttl-notice">Saved sessions expire after <?= (int)$session_ttl_days ?> day<?= (int)$session_ttl_days === 1 ? '' : 's' ?>.</p>
+            <?php if ($session_save_id !== '' && $active_tab === 'vlsm6') : ?>
+                <div class="overlap-result overlap-contains share-bar session-saved-bar">
+                    <span class="share-label">Session saved. Share this link:</span>
+                    <code class="share-url"><?= htmlspecialchars($share_base_server . $session_save_url) ?></code>
+                    <button type="button" class="share-copy"
+                            data-copy="<?= htmlspecialchars($session_save_url) ?>">Copy</button>
+                </div>
+            <?php endif; ?>
+            <?php if ($session_error && $active_tab === 'vlsm6') : ?>
+                <div class="error"><?= htmlspecialchars($session_error) ?></div>
+            <?php endif; ?>
+            <div class="session-forms">
+                <?php if ($vlsm6_requirements !== []) : ?>
+                <form method="post" novalidate>
+                    <input type="hidden" name="tab" value="vlsm6">
+                    <input type="hidden" name="session_type" value="ipv6">
+                    <input type="hidden" name="vlsm6_network" value="<?= htmlspecialchars($vlsm6_network) ?>">
+                    <input type="hidden" name="vlsm6_cidr" value="<?= htmlspecialchars($vlsm6_cidr_input) ?>">
+                    <?php foreach ($vlsm6_requirements as $req6s) : ?>
+                        <input type="hidden" name="vlsm6_name[]"  value="<?= htmlspecialchars($req6s['name']) ?>">
+                        <input type="hidden" name="vlsm6_hosts[]" value="<?= htmlspecialchars((string)$req6s['hosts']) ?>">
+                    <?php endforeach; ?>
+                    <button type="submit" name="session_action" value="save" class="splitter-btn">Save Session</button>
+                </form>
+                <?php endif; ?>
+                <form method="get" novalidate>
+                    <div class="overlap-inputs">
+                        <input type="hidden" name="tab" value="vlsm6">
+                        <input type="text" name="s"
+                               value="<?= htmlspecialchars($session_load_id) ?>"
+                               placeholder="8-char session ID"
+                               autocomplete="off" spellcheck="false" maxlength="8"
+                               aria-label="Session ID">
+                        <button type="submit" class="splitter-btn">Load</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <?php endif; ?>
     </div>
 
     <footer>

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -130,13 +130,75 @@ an attacker would need to crack the bcrypt hash to recover the token.
 - **Audit trail.** `last_used_at` updates on every successful API call,
   so you can spot keys that haven't been used in a while and revoke them.
 
+## Per-key rate limits (v3.0.0+, #312)
+
+Each SQLite-stored API key may carry an `rate_limit_rpm` override that takes
+precedence over the global `$api_rate_limit_rpm` ceiling. Set it in the
+**RPM** column on `/admin/keys.php`:
+
+- **blank** → key inherits the global default.
+- **`0`** → unlimited for this key.
+- any positive integer → that RPM ceiling for this key.
+
+The lookup order in `api_rate_limit()` is: static `$api_rate_limit_tokens`
+override → SQLite per-key override → global `$api_rate_limit_rpm`. Keys
+bucket by row id (`key:N`) so two tokens that share a prefix (a 1-in-4-billion
+collision) cannot interfere with each other's rate-limit window.
+
+There is no upper bound on the SQLite override — operators who configure
+themselves into a denial-of-service can revoke and re-mint at any time.
+
+JSON API:
+
+```bash
+# Mint a key with a 600 RPM ceiling
+curl -u admin:pass -X POST -H 'Content-Type: application/json' \
+  -d '{"name":"hot-svc","rate_limit_rpm":600}' \
+  https://host/api/v1/admin/keys
+
+# Update an existing key's override; null clears it back to the global default
+curl -u admin:pass -X PATCH -H 'Content-Type: application/json' \
+  -d '{"rate_limit_rpm":0}' \
+  https://host/api/v1/admin/keys/42/rate-limit
+```
+
+## Audit log (v3.0.0+, #306)
+
+Every admin auth attempt and every key.mint / key.revoke / key.rate_limit
+action writes a structured row to the `admin_audit` table. The log is
+viewable at `/admin/audit.php` with a paginated newest-first table and a
+prefix filter (`login.`, `key.`, `wizard.` reserved for v3 PR2, `totp.`
+reserved for v3 PR2).
+
+Schema:
+
+```sql
+CREATE TABLE admin_audit (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts        INTEGER NOT NULL,
+  actor     TEXT,           -- admin username or NULL on failed auth
+  ip        TEXT,           -- client IP from REMOTE_ADDR / X-Forwarded-For
+  action    TEXT NOT NULL,  -- 'login.ok', 'login.fail', 'key.mint', 'key.revoke', 'key.rate_limit'
+  target_id INTEGER,        -- e.g. api_keys.id for mint/revoke/rate_limit
+  meta      TEXT            -- JSON blob with action-specific detail
+);
+```
+
+Retention is bounded by `$admin_audit_retention_days` (default `90`; set to
+`0` to keep everything until manually rotated). Old rows are purged lazily
+on every audit write — there is no separate cron required.
+
+The audit module fails open: a write failure logs to `error_log` but never
+masks the underlying admin action.
+
 ## Out of scope
 
-The following are intentionally not in v2.12.0 and will land in v3.0.0:
+The following are intentionally not in v3.0.0 and are deferred to v3.1.0:
 
-- A first-run setup wizard for the admin password (currently it is a
-  manual `php -r` step so the hash never touches the wire).
-- Per-key rate-limit overrides via the UI (still possible via
-  `$api_rate_limit_tokens` for static tokens).
-- Audit log of admin actions (mint/revoke history beyond `revoked_at`).
-- TOTP / 2FA on admin login.
+- TOTP recovery codes beyond the 10 generated at TOTP enable (e.g. download
+  as printable PDF, automatic regeneration warnings).
+- Per-actor TOTP secrets (the v3 implementation is single-secret because
+  there is currently a single `$admin_user`).
+- Webhook / syslog integration for the audit log.
+- Multi-admin user support (separate row per admin in a future
+  `admin_users` table).

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -17,12 +17,20 @@ dialect.
 
 ## VLSM session payload
 
-The `vlsm-session` schema describes the JSON shape a VLSM planner session is
-persisted in. Today the calculator only persists IPv4 VLSM state; the schema
-will be expanded if/when IPv6 VLSM session save lands.
+The `vlsm-session` schema (**v2** as of v3.0.0, #315) is a `oneOf` over three
+discriminated branches via a `type` field: `'ipv4'`, `'ipv6'`, or `'tree'`.
+The `type` field is optional on the IPv4 branch — when omitted, it defaults
+to `'ipv4'` so payloads written by v2.x callers continue to validate.
+
+The published `$id` is now
+`https://subnetcalculator.app/api/schemas/vlsm-session.v2.schema.json`. v1
+consumers that pinned the prior `$id` are unaffected; the v1 document remains
+the historical record of what shipped before v3.0.0.
 
 ```json
+// IPv4 (legacy & v3.0.0)
 {
+  "type": "ipv4",
   "network": "10.0.0.0",
   "cidr": "24",
   "requirements": [
@@ -30,6 +38,31 @@ will be expanded if/when IPv6 VLSM session save lands.
     {"name": "DMZ",  "hosts": 14},
     {"name": "Mgmt", "hosts": 2}
   ]
+}
+
+// IPv6 — `hosts` can be an integer OR the "2^N" string form for sizings
+// that overflow a signed 64-bit integer (N = 0–128).
+{
+  "type": "ipv6",
+  "network": "2001:db8::",
+  "cidr": "48",
+  "requirements": [
+    {"name": "Site-A", "hosts": "2^16"},
+    {"name": "Site-B", "hosts": 100}
+  ]
+}
+
+// Tree (v3.0.0 #302 — interactive subnet tree editor; lands in PR3)
+{
+  "type": "tree",
+  "root": {
+    "cidr":     "10.0.0.0/16",
+    "name":     "Corp HQ",
+    "children": [
+      {"cidr": "10.0.0.0/17",   "name": "Production"},
+      {"cidr": "10.0.128.0/17", "name": "Lab"}
+    ]
+  }
 }
 ```
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,13 +1,13 @@
 # VLSM Sessions
 
-Session controls are in the **Tool Drawer** — click the toolbar button on the VLSM tab. They let you save your planner inputs and share them via a link.
+Session controls are available on **both the IPv4 VLSM tab** (in the Tool Drawer) **and the IPv6 VLSM tab** (in the Save & Restore IPv6 Session card under the results, v3.0.0+). They let you save your planner inputs and share them via a link.
 
 ## Saving
 
 1. Click **Save Session**.
 2. A shareable link is displayed. Copy it and bookmark it or share it with colleagues.
 
-The session stores: parent network, prefix length, and all subnet rows (name + host count).
+The session stores: planner type (`ipv4` or `ipv6`), parent network, prefix length, and all subnet rows (name + host count). For IPv6, host counts may be either an integer or the `"2^N"` string form (used when the value would overflow a signed 64-bit integer).
 
 ## Restoring
 
@@ -33,5 +33,23 @@ Sessions can also be created and retrieved programmatically:
 
 - `POST /api/v1/sessions` — save a payload, receive an 8-hex-char ID
 - `GET /api/v1/sessions/:id` — retrieve a session by its 8-hex-char ID
+
+The payload accepts a `type` discriminator (v3.0.0+):
+
+```json
+{
+  "payload": {
+    "type": "ipv6",
+    "network": "2001:db8::",
+    "cidr": "48",
+    "requirements": [
+      {"name": "Site-A", "hosts": "2^16"},
+      {"name": "Site-B", "hosts": 100}
+    ]
+  }
+}
+```
+
+`type` defaults to `'ipv4'` when omitted, so v2.x callers keep working unchanged. Allowed values: `'ipv4'`, `'ipv6'`, `'tree'` (the tree form is reserved for the v3.0.0 #302 interactive editor and lands in PR3).
 
 See [REST API](api.md#post-apiv1sessions) for curl examples.

--- a/docs/superpowers/plans/v3.0.0-living-doc.md
+++ b/docs/superpowers/plans/v3.0.0-living-doc.md
@@ -33,7 +33,7 @@ across 4 sessions, each owning one PR. Every session must:
 | Session | PR | Issues | Status | Notes |
 |---|---|---|---|---|
 | **0** (scaffold) | — | Setup | ✅ Done 2026-05-03 | Branch + plan + design lock + tracking PR |
-| **A** | PR1 — Foundations | #315, #312, #306, #307 | ⬜ Not started | Largely backend; low UI risk |
+| **A** | PR1 — Foundations | #315, #312, #306, #307 | 🟡 In review (PR pending) | Largely backend; low UI risk |
 | **B** | PR2 — Admin hardening | #311, #313 | ⬜ Not started | Auth-touching; needs careful review |
 | **C** | PR3 — Power-user UX | #300, #301, #302 | ⬜ Not started | Tree editor (#302) is the headline; may split into PR3a + PR3b |
 | **D** | PR4 — Release cut | — | ⬜ Not started | Version bump, CHANGELOG, README, mkdocs, tarball, dev→main PR |
@@ -140,14 +140,55 @@ All must be green before opening / pushing to a PR.
 - Updated GH issues #302, #311, #312, #313, #315, #306 with cross-references to design lock and PR.
 - **Scope change:** TOTP recovery codes (originally deferred) folded back into PR2 / #313 — TOTP without recovery is a foot-gun for self-hosters.
 
-### Session A — _date_ — PR1 Foundations
-_To be filled by the agent that runs Session A._
+### Session A — 2026-05-03 — PR1 Foundations
+**PR:** _populated by `gh pr create`_
 
-Required updates at end of session:
-- Mark Session A row in "Session map" as ✅ with merge SHA + date.
-- Note any deviations from this doc.
-- Update issue table with actual PR # next to #315/#312/#306/#307.
-- Flag any new gaps surfaced during implementation.
+Delivered:
+- **#306 admin_audit table + /admin/audit.php UI** — new `functions-audit.php` (audit_db_init / audit_log / audit_list / audit_count / audit_purge / audit_actor_from_request / audit_ip_from_request); paginated `/admin/audit.php` with prefix filter (login./key./wizard./totp.); lazy purge on every write; `$admin_audit_retention_days` config (default 90); login.ok / login.fail hooks in `admin_authenticate()`; key.mint / key.revoke / key.rate_limit hooks in both `admin/keys.php` and `api/v1/handlers/admin_keys.php`. PHPUnit: 12 new cases.
+- **#312 per-key rate-limit overrides** — `ALTER TABLE api_keys ADD COLUMN rate_limit_rpm` (idempotent migration via PRAGMA check); `apikey_create($db, $name, ?int $rpm)`, `apikey_set_rate_limit()`, `apikey_verify` returns RPM; `api_rate_limit()` 3-tier lookup (static $api_rate_limit_tokens → SQLite per-key → global); admin/keys.php mint form + per-row inline RPM editor; new `PATCH /api/v1/admin/keys/{id}/rate-limit`; OpenAPI updated. PHPUnit: 10 new cases.
+- **#315 IPv6 VLSM session persistence + schema v2** — `vlsm-session.schema.json` rewritten as `oneOf` over `type: ipv4|ipv6|tree` discriminator (tree branch already valid in schema, server validation lands in PR3); IPv6 `hosts` accepts `int | "2^N"` string form; new `$id` ends in `.v2.schema.json`; back-compat: missing `type` defaults to `ipv4`; `request.php` IPv4 save block extended with IPv6 path (gated by `session_type` hidden input); GET load dispatches on payload type; share-URL bound to source tab (`?tab=vlsm` vs `?tab=vlsm6`); IPv6 panel gets a "Save & Restore IPv6 Session" card; `api/v1/handlers/sessions.php` validates the discriminator on POST. PHPUnit: 5 new SessionTest cases + 9 SchemaTest cases rewritten for v2.
+- **#307 Playwright coverage** — partial. Added test fixture: Dockerfile generates `config.php` at build time with `$session_enabled = true`, `$admin_ui_enabled = true`, hashed `testadmin` / `test-admin-password`. New tests: `test_vlsm6_session_save_load`, `test_admin_keys_unauth_challenge`, `test_admin_keys_authed_renders`, `test_admin_audit_renders`, `test_admin_audit_records_login_failure`. **Deferred to PR2** (where they ride alongside wizard/TOTP UI work that needs admin context anyway): full mint validation matrix, CSRF rejection, revoke confirm flow, per-row RPM edit Playwright path, audit pagination.
+
+QA gates (all green):
+- PHPUnit: 278 tests / 567 assertions / 14 skipped (was 226 / 379 — +52 tests)
+- PHPStan L9: clean
+- PHPCS PSR-12: clean
+- Spectral OpenAPI lint: clean
+- Semgrep (php + owasp + sql-injection): 0 findings on 53 files
+
+Files added:
+- `Subnet-Calculator/includes/functions-audit.php`
+- `Subnet-Calculator/admin/audit.php`
+- `testing/unit/AuditTest.php`
+
+Files modified:
+- `Subnet-Calculator/api/schemas/vlsm-session.schema.json` (rewritten as v2)
+- `Subnet-Calculator/includes/config.php` (audit retention + config-admin.php hook)
+- `Subnet-Calculator/includes/functions-admin-auth.php` (login audit hook)
+- `Subnet-Calculator/includes/functions-apikeys.php` (rate_limit_rpm column + functions)
+- `Subnet-Calculator/includes/request.php` (IPv6 session save/load + share-tab fix)
+- `Subnet-Calculator/admin/keys.php` (RPM mint field + per-row editor + audit nav link)
+- `Subnet-Calculator/api/v1/helpers.php` (3-tier rate-limit + verified-key stash + PATCH CORS)
+- `Subnet-Calculator/api/v1/index.php` (PATCH route + meta listing)
+- `Subnet-Calculator/api/v1/handlers/admin_keys.php` (audit hooks + PATCH rate-limit endpoint)
+- `Subnet-Calculator/api/v1/handlers/sessions.php` (type discriminator validation)
+- `Subnet-Calculator/api/openapi.yaml` (rate_limit_rpm + new PATCH endpoint)
+- `Subnet-Calculator/templates/layout.php` (IPv6 VLSM session card)
+- `testing/unit/ApiKeysTest.php` (+10 RPM/migration cases)
+- `testing/unit/SessionTest.php` (+5 type-discriminator cases)
+- `testing/unit/SchemaTest.php` (rewritten for v2 oneOf)
+- `testing/scripts/playwright_test.py` (5 new tests + base64 import)
+- `Dockerfile` (test-rig config.php with admin enabled)
+- `docs/sessions.md`, `docs/schemas.md`, `docs/admin.md` (v3.0.0 sections)
+
+Deviations from the original PR1 plan:
+- **#307 split** — only the smoke set (5 tests) ships here; the comprehensive admin Playwright matrix lands in PR2 to ride alongside the wizard + TOTP UI changes. Rationale: those UI features will need their own admin Playwright groups anyway, and writing the full matrix once against the final UI shape is cheaper than writing-then-rewriting.
+
+New gaps surfaced:
+- **bcrypt hashes are semgrep-blocked** in committed source (CWE-798). The Docker test rig generates the hash at build time inside a `RUN` step instead. Worth documenting somewhere if other contributors want a local test config — they need to run `php -r "echo password_hash(...)"` themselves.
+- **The lazy `audit_purge()` runs inside every `audit_log()` call.** Fine at low volume, but a busy admin (e.g. mass key rotation) could pay an extra DELETE per write. If audit volume becomes substantive in v3.x, consider a cron-style sampled purge. Not actioned now.
+- **`api_verified_sqlite_key()` uses a function-local static.** Works for one-request-per-process; for long-running PHP-FPM workers across requests, PHP's natural request teardown clears it correctly. Documented in the inline comment.
+- **`session_save_tab` is derived from `$active_tab`, not from the saved payload.** Correct because save always happens on the same tab the form is on, but a future refactor that allows cross-tab save would need to revisit.
 
 ### Session B — _date_ — PR2 Admin hardening
 _(template — same shape as Session A)_

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -9,6 +9,7 @@ Usage:
 """
 
 import asyncio
+import base64
 import json
 import os
 import re
@@ -2699,6 +2700,157 @@ async def test_session_forms_spacing(page: Page) -> None:
 
 
 # ---------------------------------------------------------------------------
+# v3.0.0 — IPv6 VLSM session save/load round trip (#315)
+# ---------------------------------------------------------------------------
+
+async def test_vlsm6_session_save_load(page: Page) -> None:
+    section("v3.0.0 #315 IPv6 VLSM session save/load")
+    # Calculate first so the Save Session form is populated.
+    url = (APP_URL + "?tab=vlsm6&vlsm6_network=2001:db8::&vlsm6_cidr=32"
+           + "&vlsm6_name%5B%5D=Site-A&vlsm6_hosts%5B%5D=256")
+    await navigate(page, url)
+    panel = await page.query_selector("#vlsm6-session-controls")
+    if panel is None:
+        ok("vlsm6 session save/load: sessions not enabled on this server (skipped)")
+        return
+
+    # Click "Save Session" inside the IPv6 VLSM panel.
+    save_btn = page.locator(
+        '#vlsm6-session-controls button[name="session_action"][value="save"]'
+    )
+    if await save_btn.count() == 0:
+        ok("vlsm6 session save/load: save button not present (skipped)")
+        return
+    await save_btn.first.click()
+    await page.wait_for_load_state("networkidle")
+
+    # Saved session URL appears in the saved-bar; capture the 8-char id.
+    saved_bar = page.locator("#vlsm6-session-controls .session-saved-bar code.share-url")
+    assert_true(
+        "vlsm6 save: saved-bar appears after save",
+        await saved_bar.count() > 0,
+    )
+    href_text_raw = await saved_bar.first.text_content()
+    href_text = href_text_raw or ""
+    m = re.search(r"\?tab=vlsm6&s=([0-9a-f]{8})", href_text)
+    assert_true(
+        "vlsm6 save: URL contains tab=vlsm6 and 8-char id",
+        m is not None,
+        f"got: {href_text!r}",
+    )
+    if m is None:
+        return
+    sid = m.group(1)
+
+    # Reload via the session URL — fields must be restored.
+    await navigate(page, APP_URL + f"?tab=vlsm6&s={sid}")
+    network_val = await page.input_value("#vlsm6_network")
+    cidr_val    = await page.input_value("#vlsm6_cidr")
+    assert_eq("vlsm6 load: network restored", network_val, "2001:db8::")
+    assert_true(
+        "vlsm6 load: cidr restored to 32",
+        cidr_val.lstrip("/") == "32",
+        f"got: {cidr_val!r}",
+    )
+    # Result table from auto-calc on load.
+    result_count = await page.locator(".vlsm6-table tbody tr").count()
+    assert_true("vlsm6 load: results auto-render", result_count >= 1, f"rows={result_count}")
+
+
+# ---------------------------------------------------------------------------
+# v3.0.0 — Admin /admin/keys.php smoke (#307)
+# ---------------------------------------------------------------------------
+
+ADMIN_USER = "testadmin"
+ADMIN_PASS = "test-admin-password"
+
+
+async def test_admin_keys_unauth_challenge(page: Page) -> None:
+    section("v3.0.0 #307 admin/keys.php — unauth 401 + WWW-Authenticate")
+    # The page sends a Basic challenge; we use page.request to inspect the
+    # raw response without the browser intercepting the auth dialog.
+    resp = await page.context.request.get(APP_URL + "admin/keys.php")
+    assert_eq("admin/keys unauth: status 401", resp.status, 401)
+    www_auth = resp.headers.get("www-authenticate", "")
+    assert_true(
+        "admin/keys unauth: WWW-Authenticate Basic realm present",
+        www_auth.lower().startswith("basic "),
+        f"got: {www_auth!r}",
+    )
+
+
+async def test_admin_keys_authed_renders(page: Page) -> None:
+    section("v3.0.0 #307 admin/keys.php — authed renders")
+    auth = (ADMIN_USER, ADMIN_PASS)
+    resp = await page.context.request.get(
+        APP_URL + "admin/keys.php",
+        headers={"Authorization": "Basic " + base64.b64encode(
+            f"{auth[0]}:{auth[1]}".encode()
+        ).decode()},
+    )
+    assert_eq("admin/keys authed: status 200", resp.status, 200)
+    body = await resp.text()
+    assert_true(
+        "admin/keys authed: page contains 'API Keys' heading",
+        "API Keys" in body,
+    )
+    assert_true(
+        "admin/keys authed: mint form RPM input present (#312)",
+        'name="rate_limit_rpm"' in body,
+    )
+
+
+async def test_admin_audit_renders(page: Page) -> None:
+    section("v3.0.0 #307 admin/audit.php — authed renders + filters present")
+    auth_header = "Basic " + base64.b64encode(
+        f"{ADMIN_USER}:{ADMIN_PASS}".encode()
+    ).decode()
+    resp = await page.context.request.get(
+        APP_URL + "admin/audit.php",
+        headers={"Authorization": auth_header},
+    )
+    assert_eq("admin/audit authed: status 200", resp.status, 200)
+    body = await resp.text()
+    assert_true(
+        "admin/audit: page title present",
+        "Admin Audit Log" in body,
+    )
+    for label in ["all", "login", "key"]:
+        assert_true(
+            f"admin/audit: '{label}' filter link present",
+            f">{label}</a>" in body,
+            f"missing filter '{label}'",
+        )
+
+
+async def test_admin_audit_records_login_failure(page: Page) -> None:
+    section("v3.0.0 #306 audit log records failed admin login")
+    # Trigger a failed login (bad password) — should write a login.fail row.
+    bad_auth = "Basic " + base64.b64encode(
+        f"{ADMIN_USER}:wrong-password".encode()
+    ).decode()
+    bad_resp = await page.context.request.get(
+        APP_URL + "admin/keys.php",
+        headers={"Authorization": bad_auth},
+    )
+    assert_eq("audit login.fail: bad creds → 401", bad_resp.status, 401)
+
+    # Now read audit page with the login.fail filter.
+    good_auth = "Basic " + base64.b64encode(
+        f"{ADMIN_USER}:{ADMIN_PASS}".encode()
+    ).decode()
+    audit_resp = await page.context.request.get(
+        APP_URL + "admin/audit.php?filter=login.",
+        headers={"Authorization": good_auth},
+    )
+    body = await audit_resp.text()
+    assert_true(
+        "audit log: login.fail badge appears in body",
+        "login.fail" in body,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Permissions-Policy header directives (coverage gap)
 # ---------------------------------------------------------------------------
 
@@ -4169,6 +4321,11 @@ async def main() -> None:
             await test_api_bulk(page)
             await test_vlsm_session_ttl_notice(page)
             await test_session_forms_spacing(page)
+            await test_vlsm6_session_save_load(page)
+            await test_admin_keys_unauth_challenge(page)
+            await test_admin_keys_authed_renders(page)
+            await test_admin_audit_renders(page)
+            await test_admin_audit_records_login_failure(page)
             await test_permissions_policy_directives(page)
             await test_vlsm_utilisation_accuracy(page)
             await test_ipv4_binary_hex_decimal(page)

--- a/testing/unit/ApiKeysTest.php
+++ b/testing/unit/ApiKeysTest.php
@@ -112,6 +112,106 @@ class ApiKeysTest extends TestCase
         $this->assertStringStartsWith('$2y$', (string)$row['token_hash'], 'must be bcrypt');
     }
 
+    // ── v3.0.0 (#312) per-key rate-limit overrides ─────────────────────────────
+
+    public function testCreateAcceptsNullRateLimit(): void
+    {
+        $created = apikey_create($this->db, 'no-override');
+        $this->assertNull($created['rate_limit_rpm']);
+        $row = apikey_list($this->db)[0];
+        $this->assertNull($row['rate_limit_rpm']);
+    }
+
+    public function testCreateAcceptsExplicitRateLimit(): void
+    {
+        $created = apikey_create($this->db, 'fast', 600);
+        $this->assertSame(600, $created['rate_limit_rpm']);
+        $this->assertSame(600, apikey_list($this->db)[0]['rate_limit_rpm']);
+    }
+
+    public function testCreateAcceptsZeroAsUnlimited(): void
+    {
+        $created = apikey_create($this->db, 'no-limit', 0);
+        $this->assertSame(0, $created['rate_limit_rpm']);
+    }
+
+    public function testCreateRejectsNegativeRateLimit(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        apikey_create($this->db, 'bad', -1);
+    }
+
+    public function testVerifyExposesRateLimit(): void
+    {
+        $created  = apikey_create($this->db, 'svc', 120);
+        $verified = apikey_verify($this->db, $created['token']);
+        $this->assertSame(120, $verified['rate_limit_rpm']);
+    }
+
+    public function testSetRateLimitUpdatesAndClears(): void
+    {
+        $created = apikey_create($this->db, 'k');
+        $this->assertTrue(apikey_set_rate_limit($this->db, (int)$created['id'], 300));
+        $this->assertSame(300, apikey_list($this->db)[0]['rate_limit_rpm']);
+        $this->assertTrue(apikey_set_rate_limit($this->db, (int)$created['id'], null));
+        $this->assertNull(apikey_list($this->db)[0]['rate_limit_rpm']);
+    }
+
+    public function testSetRateLimitOnUnknownIdReturnsFalse(): void
+    {
+        $this->assertFalse(apikey_set_rate_limit($this->db, 99999, 100));
+    }
+
+    public function testSetRateLimitOnRevokedKeyReturnsFalse(): void
+    {
+        $created = apikey_create($this->db, 'revoked-soon');
+        apikey_revoke($this->db, (int)$created['id']);
+        $this->assertFalse(apikey_set_rate_limit($this->db, (int)$created['id'], 100));
+    }
+
+    public function testSetRateLimitRejectsNegative(): void
+    {
+        $created = apikey_create($this->db, 'k');
+        $this->expectException(InvalidArgumentException::class);
+        apikey_set_rate_limit($this->db, (int)$created['id'], -5);
+    }
+
+    public function testMigrationIdempotent(): void
+    {
+        // Calling migrate again on an already-migrated DB must be a no-op.
+        apikey_migrate_add_rate_limit($this->db);
+        apikey_migrate_add_rate_limit($this->db);
+        // If the column was added twice, ALTER TABLE would have thrown.
+        $this->assertTrue(true);
+    }
+
+    public function testMigrationBackfillsOnLegacySchema(): void
+    {
+        // Simulate a pre-v3.0.0 install: drop the column and re-run migrate.
+        $legacy = new \SQLite3(':memory:');
+        $legacy->enableExceptions(true);
+        $legacy->exec(
+            'CREATE TABLE api_keys (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                name         TEXT    NOT NULL,
+                prefix       TEXT    NOT NULL,
+                token_hash   TEXT    NOT NULL,
+                created_at   INTEGER NOT NULL,
+                last_used_at INTEGER,
+                revoked_at   INTEGER
+            );'
+        );
+        $legacy->exec(
+            "INSERT INTO api_keys (name, prefix, token_hash, created_at)
+             VALUES ('legacy', 'aaaa1111', '\$2y\$10\$xxxxxxxxxxxxxxxxxxxxxx', " . time() . ")"
+        );
+        apikey_migrate_add_rate_limit($legacy);
+        $row = $legacy->query('SELECT rate_limit_rpm FROM api_keys WHERE name = "legacy"')
+            ->fetchArray(SQLITE3_ASSOC);
+        $this->assertNull($row['rate_limit_rpm'], 'pre-existing rows must backfill NULL');
+        $legacy->close();
+    }
+
     public function testTwoTokensWithIdenticalPrefixStillVerifyDistinctly(): void
     {
         // Real-world collision is ~1-in-4-billion per pair. Force one by

--- a/testing/unit/AuditTest.php
+++ b/testing/unit/AuditTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../Subnet-Calculator/includes/functions-audit.php';
+
+/**
+ * Unit tests for the admin audit log (#306).
+ *
+ * Each test gets an isolated in-memory SQLite database so tests cannot
+ * interfere with each other and the project data dir is never written to.
+ */
+class AuditTest extends TestCase
+{
+    private \SQLite3 $db;
+
+    protected function setUp(): void
+    {
+        $this->db = new \SQLite3(':memory:');
+        $this->db->enableExceptions(true);
+        audit_db_init($this->db);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->db->close();
+        // Reset the global so retention tests do not bleed across cases.
+        $GLOBALS['admin_audit_retention_days'] = AUDIT_RETENTION_DEFAULT_DAYS;
+    }
+
+    public function testInitCreatesTableAndIndexes(): void
+    {
+        $res = $this->db->query("SELECT name FROM sqlite_master WHERE type='table' AND name='admin_audit'");
+        $row = $res->fetchArray(SQLITE3_ASSOC);
+        $this->assertSame('admin_audit', $row['name']);
+    }
+
+    public function testLogStoresMinimalRow(): void
+    {
+        audit_log($this->db, 'login.ok', 'admin', '10.0.0.1');
+        $rows = audit_list($this->db);
+        $this->assertCount(1, $rows);
+        $this->assertSame('login.ok', $rows[0]['action']);
+        $this->assertSame('admin',    $rows[0]['actor']);
+        $this->assertSame('10.0.0.1', $rows[0]['ip']);
+        $this->assertNull($rows[0]['target_id']);
+        $this->assertNull($rows[0]['meta']);
+    }
+
+    public function testLogPersistsTargetIdAndMetaJson(): void
+    {
+        audit_log($this->db, 'key.mint', 'admin', '127.0.0.1', 42, ['name' => 'svc-A', 'prefix' => 'abcd1234']);
+        $rows = audit_list($this->db);
+        $this->assertSame(42, $rows[0]['target_id']);
+        $decoded = json_decode((string)$rows[0]['meta'], true);
+        $this->assertSame('svc-A', $decoded['name']);
+        $this->assertSame('abcd1234', $decoded['prefix']);
+    }
+
+    public function testLogIgnoresOversizedAction(): void
+    {
+        audit_log($this->db, str_repeat('x', AUDIT_ACTION_MAX + 1));
+        $this->assertSame(0, audit_count($this->db));
+    }
+
+    public function testLogIgnoresEmptyAction(): void
+    {
+        audit_log($this->db, '');
+        $this->assertSame(0, audit_count($this->db));
+    }
+
+    public function testListNewestFirst(): void
+    {
+        audit_log($this->db, 'login.ok', 'a');
+        audit_log($this->db, 'login.fail', 'b');
+        $rows = audit_list($this->db);
+        $this->assertSame('login.fail', $rows[0]['action']);
+        $this->assertSame('login.ok',   $rows[1]['action']);
+    }
+
+    public function testListPrefixFilter(): void
+    {
+        audit_log($this->db, 'login.ok', 'a');
+        audit_log($this->db, 'key.mint', 'a');
+        audit_log($this->db, 'key.revoke', 'a');
+        $loginOnly = audit_list($this->db, 50, 0, 'login.');
+        $keyOnly   = audit_list($this->db, 50, 0, 'key.');
+        $this->assertCount(1, $loginOnly);
+        $this->assertCount(2, $keyOnly);
+    }
+
+    public function testListPagination(): void
+    {
+        for ($i = 0; $i < 7; $i++) {
+            audit_log($this->db, 'login.ok', 'u' . $i);
+        }
+        $page1 = audit_list($this->db, 3, 0);
+        $page2 = audit_list($this->db, 3, 3);
+        $this->assertCount(3, $page1);
+        $this->assertCount(3, $page2);
+        $this->assertNotSame($page1[0]['id'], $page2[0]['id']);
+    }
+
+    public function testCountRespectsFilter(): void
+    {
+        audit_log($this->db, 'login.ok');
+        audit_log($this->db, 'key.mint');
+        $this->assertSame(2, audit_count($this->db));
+        $this->assertSame(1, audit_count($this->db, 'login.'));
+    }
+
+    public function testRetentionPurgesOldRows(): void
+    {
+        // Force a row 100 days old via direct insert (bypasses time())
+        $past = time() - (100 * 86400);
+        $stmt = $this->db->prepare(
+            'INSERT INTO admin_audit (ts, action) VALUES (:ts, :a)'
+        );
+        $stmt->bindValue(':ts', $past, SQLITE3_INTEGER);
+        $stmt->bindValue(':a', 'login.ok', SQLITE3_TEXT);
+        $stmt->execute();
+
+        $GLOBALS['admin_audit_retention_days'] = 90;
+        // audit_log() invokes purge before insert
+        audit_log($this->db, 'login.ok', 'fresh');
+        $rows = audit_list($this->db);
+        $this->assertCount(1, $rows, 'old row should have been purged');
+        $this->assertSame('fresh', $rows[0]['actor']);
+    }
+
+    public function testRetentionZeroDisablesPurge(): void
+    {
+        $past = time() - (100 * 86400);
+        $stmt = $this->db->prepare('INSERT INTO admin_audit (ts, action) VALUES (:ts, :a)');
+        $stmt->bindValue(':ts', $past, SQLITE3_INTEGER);
+        $stmt->bindValue(':a', 'login.ok', SQLITE3_TEXT);
+        $stmt->execute();
+
+        $GLOBALS['admin_audit_retention_days'] = 0;
+        audit_log($this->db, 'login.ok', 'fresh');
+        $this->assertSame(2, audit_count($this->db), 'purge must be disabled when retention=0');
+    }
+
+    public function testMetaTruncatedWhenOversized(): void
+    {
+        $huge = ['blob' => str_repeat('x', AUDIT_META_MAX + 100)];
+        audit_log($this->db, 'login.ok', 'a', null, null, $huge);
+        $rows = audit_list($this->db);
+        $decoded = json_decode((string)$rows[0]['meta'], true);
+        $this->assertSame(['truncated' => true], $decoded);
+    }
+}

--- a/testing/unit/SchemaTest.php
+++ b/testing/unit/SchemaTest.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * Validates published JSON-Schema documents structurally.
+ * Validates the published vlsm-session JSON schema structurally.
  *
- * Confirms the file parses as JSON, declares the Draft 2020-12 dialect,
- * has a stable $id, and that every advertised example matches the schema's
- * own `required` / `properties` declarations.
+ * v2 (v3.0.0, #315) introduced a `type` discriminator with three branches
+ * (ipv4 / ipv6 / tree) under a top-level `oneOf`. The schema also gained
+ * the `"2^N"` host-string form for IPv6 VLSM (parity with vlsm6_allocate's
+ * accepted input).
  *
  * We intentionally do not pull in a full JSON-Schema validator dependency —
  * these checks catch the common breakage modes (missing $schema, broken
- * pattern, missing required field on an example) without the ~2 MB transitive
- * dependency surface that ships with justinrainbow/json-schema or opis/json-schema.
+ * pattern, missing required field on an example) without the ~2 MB
+ * transitive dependency surface that ships with opis/json-schema.
  */
 class SchemaTest extends TestCase
 {
@@ -37,70 +38,126 @@ class SchemaTest extends TestCase
     {
         $this->assertSame(
             'https://json-schema.org/draft/2020-12/schema',
-            $this->schema['$schema'] ?? null,
-            'Must declare Draft 2020-12'
+            $this->schema['$schema'] ?? null
         );
     }
 
-    public function testHasStableId(): void
+    public function testV2IdReflectsVersion(): void
     {
         $this->assertArrayHasKey('$id', $this->schema);
         $this->assertIsString($this->schema['$id']);
-        $this->assertStringStartsWith('https://', $this->schema['$id']);
+        $this->assertStringContainsString('v2', $this->schema['$id'], 'v2 schema must publish a v2 $id so pinned consumers do not break');
     }
 
-    public function testTopLevelStructure(): void
+    public function testTopLevelIsOneOfThreeBranches(): void
     {
-        $this->assertSame('object', $this->schema['type'] ?? null);
-        $this->assertContains('network', $this->schema['required'] ?? []);
-        $this->assertContains('cidr', $this->schema['required'] ?? []);
-        $this->assertContains('requirements', $this->schema['required'] ?? []);
-        $this->assertSame(false, $this->schema['additionalProperties'] ?? null);
+        $this->assertArrayHasKey('oneOf', $this->schema);
+        $branches = $this->schema['oneOf'];
+        $this->assertCount(3, $branches, 'expect ipv4 / ipv6 / tree branches');
+        $titles = array_column($branches, 'title');
+        $this->assertContains('IPv4 VLSM', $titles);
+        $this->assertContains('IPv6 VLSM', $titles);
+        $this->assertContains('Subnet tree editor (v3.0.0 #302)', $titles);
     }
 
-    public function testRequirementsItemSchema(): void
+    public function testIpv4BranchKeepsLegacyShape(): void
     {
-        $items = $this->schema['properties']['requirements']['items'] ?? null;
-        $this->assertIsArray($items);
-        $this->assertSame('object', $items['type'] ?? null);
-        $this->assertContains('name', $items['required'] ?? []);
-        $this->assertContains('hosts', $items['required'] ?? []);
-        $this->assertSame('integer', $items['properties']['hosts']['type'] ?? null);
-        $this->assertSame(1, $items['properties']['hosts']['minimum'] ?? null);
+        $branch = $this->branchByTitle('IPv4 VLSM');
+        $this->assertContains('network', $branch['required']);
+        $this->assertContains('cidr', $branch['required']);
+        $this->assertContains('requirements', $branch['required']);
+        $this->assertSame(false, $branch['additionalProperties'] ?? null);
+        // type is OPTIONAL for ipv4 (back-compat) — pre-v3 payloads omit it
+        $this->assertNotContains('type', $branch['required']);
     }
 
-    public function testCidrPatternMatchesValidPrefixes(): void
+    public function testIpv6BranchRequiresType(): void
     {
-        $pattern = $this->schema['properties']['cidr']['pattern'] ?? '';
-        $this->assertNotSame('', $pattern, 'cidr must declare a pattern');
+        $branch = $this->branchByTitle('IPv6 VLSM');
+        $this->assertContains('type', $branch['required'], 'ipv6 branch must REQUIRE type discriminator');
+        $this->assertSame('ipv6', $branch['properties']['type']['const']);
+    }
+
+    public function testTreeBranchRequiresTypeAndRoot(): void
+    {
+        $branch = $this->branchByTitle('Subnet tree editor (v3.0.0 #302)');
+        $this->assertContains('type', $branch['required']);
+        $this->assertContains('root', $branch['required']);
+        $this->assertSame('tree', $branch['properties']['type']['const']);
+    }
+
+    public function testIpv6HostsAcceptsIntOrPowerOfTwoString(): void
+    {
+        $branch = $this->branchByTitle('IPv6 VLSM');
+        $hosts  = $branch['properties']['requirements']['items']['properties']['hosts'];
+        $this->assertArrayHasKey('oneOf', $hosts);
+        $forms = array_column($hosts['oneOf'], 'type');
+        $this->assertContains('integer', $forms);
+        $this->assertContains('string', $forms);
+
+        // Verify the 2^N regex
+        $pattern = null;
+        foreach ($hosts['oneOf'] as $f) {
+            if (($f['type'] ?? null) === 'string') {
+                $pattern = $f['pattern'];
+                break;
+            }
+        }
+        $this->assertNotNull($pattern);
         $regex = '/' . str_replace('/', '\\/', $pattern) . '/';
-        foreach (['0', '8', '16', '24', '32'] as $valid) {
-            $this->assertSame(1, preg_match($regex, $valid), "valid cidr '$valid' should match");
+        foreach (['2^0', '2^1', '2^16', '2^63', '2^128'] as $valid) {
+            $this->assertSame(1, preg_match($regex, $valid), "valid 2^N '$valid' should match");
         }
-        foreach (['33', '-1', 'abc', '/24', ' 24', '99'] as $invalid) {
-            $this->assertSame(0, preg_match($regex, $invalid), "invalid cidr '$invalid' should not match");
+        foreach (['2^129', '2^999', '3^4', '2^', '16'] as $invalid) {
+            $this->assertSame(0, preg_match($regex, $invalid), "invalid '$invalid' should not match");
         }
     }
 
-    public function testExamplesMatchOwnSchema(): void
+    public function testIpv4CidrPattern(): void
+    {
+        $branch  = $this->branchByTitle('IPv4 VLSM');
+        $pattern = $branch['properties']['cidr']['pattern'];
+        $regex   = '/' . str_replace('/', '\\/', $pattern) . '/';
+        foreach (['0', '8', '16', '24', '32'] as $valid) {
+            $this->assertSame(1, preg_match($regex, $valid));
+        }
+        foreach (['33', '-1', 'abc', '/24', ' 24'] as $invalid) {
+            $this->assertSame(0, preg_match($regex, $invalid));
+        }
+    }
+
+    public function testIpv6CidrPattern(): void
+    {
+        $branch  = $this->branchByTitle('IPv6 VLSM');
+        $pattern = $branch['properties']['cidr']['pattern'];
+        $regex   = '/' . str_replace('/', '\\/', $pattern) . '/';
+        foreach (['0', '48', '64', '127', '128'] as $valid) {
+            $this->assertSame(1, preg_match($regex, $valid), "ipv6 cidr '$valid' should match");
+        }
+        foreach (['129', '-1', '/64', 'abc'] as $invalid) {
+            $this->assertSame(0, preg_match($regex, $invalid));
+        }
+    }
+
+    public function testTreeRootIsRecursiveDef(): void
+    {
+        $branch = $this->branchByTitle('Subnet tree editor (v3.0.0 #302)');
+        $this->assertSame('#/$defs/treeNode', $branch['properties']['root']['$ref']);
+        $this->assertArrayHasKey('treeNode', $this->schema['$defs']);
+        $node = $this->schema['$defs']['treeNode'];
+        $this->assertContains('cidr', $node['required']);
+        // children is recursive
+        $this->assertSame('#/$defs/treeNode', $node['properties']['children']['items']['$ref']);
+    }
+
+    public function testExamplesExistForEveryBranch(): void
     {
         $examples = $this->schema['examples'] ?? [];
-        $this->assertNotEmpty($examples, 'schema must ship at least one example');
-        foreach ($examples as $idx => $ex) {
-            $this->assertIsArray($ex, "example $idx must be an object");
-            foreach (['network', 'cidr', 'requirements'] as $key) {
-                $this->assertArrayHasKey($key, $ex, "example $idx missing $key");
-            }
-            $this->assertIsString($ex['network']);
-            $this->assertIsString($ex['cidr']);
-            $this->assertIsArray($ex['requirements']);
-            $this->assertNotEmpty($ex['requirements']);
-            foreach ($ex['requirements'] as $r) {
-                $this->assertIsString($r['name']);
-                $this->assertIsInt($r['hosts']);
-                $this->assertGreaterThanOrEqual(1, $r['hosts']);
-            }
-        }
+        $this->assertNotEmpty($examples);
+        $types = array_map(static fn ($e) => $e['type'] ?? 'ipv4', $examples);
+        $this->assertContains('ipv4', $types);
+        $this->assertContains('ipv6', $types);
+        $this->assertContains('tree', $types);
     }
 
     public function testHandlerServesSchema(): void
@@ -109,7 +166,18 @@ class SchemaTest extends TestCase
         $this->assertFileExists($handler);
         $code = file_get_contents($handler);
         $this->assertNotFalse($code);
-        $this->assertStringContainsString('vlsm-session', (string)$code, 'handler must allowlist vlsm-session');
-        $this->assertStringContainsString('application/schema+json', (string)$code, 'handler must set schema MIME type');
+        $this->assertStringContainsString('vlsm-session', (string)$code);
+        $this->assertStringContainsString('application/schema+json', (string)$code);
+    }
+
+    /** @return array<string, mixed> */
+    private function branchByTitle(string $title): array
+    {
+        foreach ($this->schema['oneOf'] as $branch) {
+            if (($branch['title'] ?? '') === $title) {
+                return $branch;
+            }
+        }
+        $this->fail("No branch with title '$title'");
     }
 }

--- a/testing/unit/SessionTest.php
+++ b/testing/unit/SessionTest.php
@@ -121,4 +121,82 @@ class SessionTest extends TestCase
         session_purge($this->db);
         $this->assertNotNull(session_load($this->db, $id));
     }
+
+    // ── v3.0.0 (#315) — schema v2 discriminator round-trips ────────────────────
+
+    public function testCreate_Ipv4PayloadWithExplicitTypeRoundTrips(): void
+    {
+        $payload = [
+            'type'         => 'ipv4',
+            'network'      => '10.0.0.0',
+            'cidr'         => '24',
+            'requirements' => [['name' => 'LAN', 'hosts' => 50]],
+        ];
+        $id = session_create($this->db, $payload, 30);
+        $this->assertSame($payload, session_load($this->db, $id));
+    }
+
+    public function testCreate_Ipv6PayloadWithIntHostsRoundTrips(): void
+    {
+        $payload = [
+            'type'         => 'ipv6',
+            'network'      => '2001:db8::',
+            'cidr'         => '48',
+            'requirements' => [['name' => 'Site-A', 'hosts' => 256]],
+        ];
+        $id = session_create($this->db, $payload, 30);
+        $this->assertSame($payload, session_load($this->db, $id));
+    }
+
+    public function testCreate_Ipv6PayloadWithPowerOfTwoStringHostsRoundTrips(): void
+    {
+        // The "2^N" string form is required for sizings that overflow int64.
+        // session_create stores arbitrary JSON-serialisable arrays, so this
+        // should round-trip byte-identical.
+        $payload = [
+            'type'         => 'ipv6',
+            'network'      => 'fd00:1234::',
+            'cidr'         => '16',
+            'requirements' => [
+                ['name' => 'Site-Huge',  'hosts' => '2^96'],
+                ['name' => 'Site-Small', 'hosts' => 50],
+            ],
+        ];
+        $id = session_create($this->db, $payload, 30);
+        $this->assertSame($payload, session_load($this->db, $id));
+    }
+
+    public function testLoad_LegacyUntypedPayloadRetainsAbsentType(): void
+    {
+        // Pre-v3.0.0 payloads omit `type`. The session store must return them
+        // unchanged so callers can apply their own back-compat default.
+        $payload = [
+            'network'      => '192.168.0.0',
+            'cidr'         => '24',
+            'requirements' => [['name' => 'LAN', 'hosts' => 100]],
+        ];
+        $id = session_create($this->db, $payload, 30);
+        $loaded = session_load($this->db, $id);
+        $this->assertArrayNotHasKey('type', $loaded, 'absent type must remain absent on load');
+        $this->assertSame($payload, $loaded);
+    }
+
+    public function testCreate_TreePayloadRoundTrips(): void
+    {
+        // Schema-supported in PR1; full editor lands in PR3 (#302). Storage
+        // must already accept tree payloads so PR3 has nothing to migrate.
+        $payload = [
+            'type' => 'tree',
+            'root' => [
+                'cidr'     => '10.0.0.0/16',
+                'name'     => 'Corp HQ',
+                'children' => [
+                    ['cidr' => '10.0.0.0/17',   'name' => 'Production'],
+                    ['cidr' => '10.0.128.0/17', 'name' => 'Lab'],
+                ],
+            ],
+        ];
+        $id = session_create($this->db, $payload, 30);
+        $this->assertSame($payload, session_load($this->db, $id));
+    }
 }


### PR DESCRIPTION
## v3.0.0 PR1 — Foundations

First of four sub-PRs that compose the v3.0.0 release. Targets \`release/v3.0.0\`,
not \`main\`. Tracked in #316.

Bundles four milestone items because they share infrastructure (the admin SQLite file, the audit hooks called from key.mint/revoke, the schema-v2 discriminator that PR3's tree editor will piggy-back on).

## Issues closed

- Closes #306 — admin audit log
- Closes #312 — per-key rate-limit overrides
- Closes #315 — IPv6 VLSM session persistence + schema v2

## Issue partially closed

- #307 — Playwright coverage: smoke set ships here (5 tests). Full matrix deferred to PR2 where it rides alongside the wizard/TOTP UI changes that need admin context anyway. **Not closing #307 in this PR**; the remaining work is captured in the PR2 plan (see living doc).

## Highlights

### Audit log (#306)
- New \`functions-audit.php\` (init/log/list/count/purge/actor+ip helpers)
- Paginated \`/admin/audit.php\` with prefix filter (\`login.\`, \`key.\`, \`wizard.\`, \`totp.\`)
- Hooks: \`login.ok\`, \`login.fail\`, \`key.mint\`, \`key.revoke\`, \`key.rate_limit\`
- Lazy retention purge on every write; \`\$admin_audit_retention_days\` default 90; \`0\` disables purge
- Fails open — a write error never blocks the underlying admin action

### Per-key rate-limit (#312)
- Idempotent \`ALTER TABLE api_keys ADD COLUMN rate_limit_rpm\` migration
- 3-tier \`api_rate_limit()\` lookup: static map → SQLite per-key → global fallback
- Mint form RPM input + per-row inline editor on \`/admin/keys.php\`
- New \`PATCH /api/v1/admin/keys/{id}/rate-limit\` JSON endpoint (OpenAPI updated)
- CORS \`Allow-Methods\` now includes \`PATCH\`/\`DELETE\`

### IPv6 VLSM sessions + schema v2 (#315)
- \`vlsm-session.schema.json\` rewritten as \`oneOf\` over \`type: ipv4 | ipv6 | tree\` discriminator (tree branch already valid in schema; server validation in PR3)
- IPv6 \`hosts\` accepts \`int | \"2^N\"\` string (parity with \`vlsm6_allocate()\`)
- New \`\$id\` ends in \`v2.schema.json\` — pinned v1 consumers unaffected
- Back-compat: missing \`type\` defaults to \`ipv4\` throughout
- Save & Restore IPv6 Session card on the IPv6 VLSM panel
- Share-URL anchored to source tab (\`?tab=vlsm\` vs \`?tab=vlsm6\`)
- API session handler validates the discriminator on POST

### Test fixture
- \`Dockerfile\` generates \`config.php\` at build time (\`testadmin\` / \`test-admin-password\`, hashed fresh each build — no bcrypt hash committed; semgrep enforces this)
- 5 new Playwright tests + 27 new PHPUnit cases

## QA gates (all green)

| Gate | Before | After |
|---|---|---|
| PHPUnit | 226 / 379 | **278 / 567** (+52 tests) |
| PHPStan L9 | clean | clean |
| PHPCS PSR-12 | clean | clean |
| Spectral OpenAPI | clean | clean |
| Semgrep | clean | **clean** (53 files, 83 rules) |

## Cross-cutting touch

- \`includes/config.php\` now requires \`config-admin.php\` if present — paves the way for PR2's first-run wizard target (no behaviour change in PR1; the file simply doesn't exist yet).

## Known surfaced gaps (in living doc)

- \`audit_purge()\` runs inside every \`audit_log()\` write. Acceptable at low volume; revisit if v3.x sees high audit traffic.
- \`api_verified_sqlite_key()\` uses a function-local static — correct for one-request-per-process, documented inline.
- bcrypt hashes are semgrep-blocked in committed source. The Docker rig hashes at build time. Worth surfacing for contributors who want a local test config.

## Test plan

- [ ] \`vendor/bin/phpunit\` — 278 / 14 skipped expected
- [ ] \`phpstan analyse --memory-limit=512M\` — no errors
- [ ] \`vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/\` — clean
- [ ] \`npx @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml\` — no errors
- [ ] \`semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten --config p/sql-injection --error\` over \`includes/ api/ templates/ admin/\` — 0 findings
- [ ] \`make test-docker\` — full Playwright suite (existing + 5 new)
- [ ] Manual UI smoke: enable admin in test deploy, mint a key with RPM, edit RPM inline, verify audit page shows the actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)