### PR TITLE
feat(v3.0.0): PR3a power-user UX — keyboard overlay (#300) + recent history (#301)

### DIFF
--- a/Subnet-Calculator/assets/app.css
+++ b/Subnet-Calculator/assets/app.css
@@ -390,6 +390,25 @@
         html[data-theme="light"] .icon-moon { display: block; }
         html[data-theme="light"] .icon-sun  { display: none; }
 
+        /* Header icon buttons (#300 keyboard help, #301 history) — share theme-toggle styling */
+        .header-icon-btn {
+            background: none;
+            border: 1px solid var(--color-border);
+            border-radius: 6px;
+            color: var(--color-text-subtle);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.3rem 0.4rem;
+            transition: background 0.15s, color 0.15s;
+        }
+        .header-icon-btn:hover { background: var(--color-border); color: var(--color-text); }
+        /* Hide on coarse-pointer devices: ? key and history are desktop affordances. */
+        @media (hover: none) {
+            #kbd-help-toggle { display: none; }
+        }
+
         /* Honeypot — always hidden regardless of CSS cascade */
         .sc-honeypot { display: none !important; }
 
@@ -1402,4 +1421,172 @@
     .diff-summary { gap: 4px; }
     .diff-summary-pill { font-size: 11px; padding: 2px 8px; }
     .diff-item { font-size: 12px; }
+}
+
+/* v3.0.0 (#300, #301) — modal overlays for keyboard help and history */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgb(0 0 0 / 55%);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 4rem 1rem 2rem;
+    z-index: 100;
+}
+.modal-overlay[hidden] { display: none; }
+.modal {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    box-shadow: 0 12px 48px rgb(0 0 0 / 40%);
+    color: var(--color-text);
+    max-width: 520px;
+    width: 100%;
+    max-height: calc(100vh - 6rem);
+    display: flex;
+    flex-direction: column;
+}
+.modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--color-border);
+}
+.modal-header h2 {
+    font-size: 1rem;
+    margin: 0;
+    color: var(--color-text);
+}
+.modal-close {
+    background: none;
+    border: none;
+    color: var(--color-text-subtle);
+    cursor: pointer;
+    font-size: 1.4rem;
+    line-height: 1;
+    padding: 0 0.3rem;
+}
+.modal-close:hover { color: var(--color-text); }
+.modal-body {
+    padding: 1rem;
+    overflow-y: auto;
+}
+.modal-note {
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    margin: 0.75rem 0 0;
+}
+
+/* Keyboard shortcut list */
+.kbd-list {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.5rem 1.25rem;
+    margin: 0;
+}
+.kbd-list dt {
+    margin: 0;
+    white-space: nowrap;
+}
+.kbd-list dd {
+    margin: 0;
+    color: var(--color-text);
+}
+.kbd-list kbd {
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text);
+    font-family: 'Fira Code', monospace;
+    font-size: 0.8rem;
+    padding: 1px 6px;
+}
+
+/* History list */
+.history-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 0.75rem;
+}
+.history-toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+.btn-small {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text-subtle);
+    cursor: pointer;
+    font-size: 0.8rem;
+    padding: 0.25rem 0.6rem;
+}
+.btn-small:hover { background: var(--color-border); color: var(--color-text); }
+.history-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.history-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0.6rem;
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+}
+.history-item button.history-link {
+    background: none;
+    border: none;
+    color: var(--color-text);
+    cursor: pointer;
+    flex: 1;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.8rem;
+    padding: 0;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.history-item button.history-link:hover { color: var(--color-accent); }
+.history-item .history-tab-badge {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+    padding: 1px 6px;
+    text-transform: uppercase;
+}
+.history-item button.history-remove {
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 0.3rem;
+}
+.history-item button.history-remove:hover { color: var(--color-text); }
+
+@media (prefers-reduced-motion: reduce) {
+    .modal { transition: none; }
+}
+
+@media (width <= 480px) {
+    .modal-overlay { padding: 2rem 0.5rem; }
 }

--- a/Subnet-Calculator/assets/app.js
+++ b/Subnet-Calculator/assets/app.js
@@ -993,3 +993,222 @@ document.addEventListener('click', function (e) {
 if (window.self === window.top && 'serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js').catch(() => {});
 }
+
+// ── v3.0.0 (#300) keyboard shortcut overlay + (#301) history pane ─────────
+(function () {
+    const TAB_KEY_MAP = { '1': 'tab-ipv4', '2': 'tab-ipv6', '3': 'tab-vlsm', '4': 'tab-vlsm6' };
+    const HISTORY_ENABLED_KEY = 'sc.history.enabled';
+    const HISTORY_ENTRIES_KEY = 'sc.history.entries';
+    const HISTORY_CAP = 50;
+
+    const kbdOverlay = document.getElementById('kbd-overlay');
+    const historyOverlay = document.getElementById('history-overlay');
+    const kbdToggle = document.getElementById('kbd-help-toggle');
+    const historyToggle = document.getElementById('history-toggle');
+    const historyEnabledToggle = document.getElementById('history-enabled-toggle');
+    const historyClearBtn = document.getElementById('history-clear');
+    const historyList = document.getElementById('history-list');
+    const historyEmptyMsg = document.getElementById('history-empty-msg');
+    const historyDisabledMsg = document.getElementById('history-disabled-msg');
+
+    if (!kbdOverlay || !historyOverlay) return;
+
+    function isEditableTarget(el) {
+        if (!el) return false;
+        const tag = el.tagName;
+        return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+    }
+
+    function activeTabId() {
+        const active = document.querySelector('.tab-btn.active');
+        return active ? active.id : null;
+    }
+
+    function openOverlay(overlay) {
+        // Close the other overlay first so only one is visible at a time.
+        [kbdOverlay, historyOverlay].forEach(o => { if (o !== overlay) o.hidden = true; });
+        overlay.hidden = false;
+        const closeBtn = overlay.querySelector('.modal-close');
+        if (closeBtn) closeBtn.focus();
+    }
+
+    function closeOverlays() {
+        kbdOverlay.hidden = true;
+        historyOverlay.hidden = true;
+    }
+
+    function isAnyOverlayOpen() {
+        return !kbdOverlay.hidden || !historyOverlay.hidden;
+    }
+
+    [kbdOverlay, historyOverlay].forEach(overlay => {
+        overlay.addEventListener('click', e => { if (e.target === overlay) closeOverlays(); });
+        const btn = overlay.querySelector('.modal-close');
+        if (btn) btn.addEventListener('click', closeOverlays);
+    });
+
+    if (kbdToggle) kbdToggle.addEventListener('click', () => openOverlay(kbdOverlay));
+    if (historyToggle) historyToggle.addEventListener('click', () => { renderHistory(); openOverlay(historyOverlay); });
+
+    // ── History storage ──────────────────────────────────────────────────
+    function historyEnabled() {
+        try { return localStorage.getItem(HISTORY_ENABLED_KEY) === '1'; } catch { return false; }
+    }
+
+    function setHistoryEnabled(on) {
+        try { localStorage.setItem(HISTORY_ENABLED_KEY, on ? '1' : '0'); } catch (e) { void e; }
+    }
+
+    function loadHistory() {
+        try {
+            const raw = localStorage.getItem(HISTORY_ENTRIES_KEY);
+            if (!raw) return [];
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch { return []; }
+    }
+
+    function saveHistory(entries) {
+        try { localStorage.setItem(HISTORY_ENTRIES_KEY, JSON.stringify(entries)); } catch (e) { void e; }
+    }
+
+    function pushHistory(entry) {
+        if (!historyEnabled()) return;
+        const entries = loadHistory();
+        // De-dupe consecutive identical URLs.
+        if (entries.length > 0 && entries[entries.length - 1].url === entry.url) return;
+        entries.push(entry);
+        while (entries.length > HISTORY_CAP) entries.shift();
+        saveHistory(entries);
+    }
+
+    function clearChildren(node) {
+        while (node.firstChild) node.removeChild(node.firstChild);
+    }
+
+    function renderHistory() {
+        const enabled = historyEnabled();
+        if (historyEnabledToggle) historyEnabledToggle.checked = enabled;
+        const entries = loadHistory();
+        clearChildren(historyList);
+        historyDisabledMsg.hidden = enabled;
+        historyEmptyMsg.hidden = !enabled || entries.length > 0;
+        historyClearBtn.hidden = entries.length === 0;
+        for (let i = entries.length - 1; i >= 0; i--) {
+            const entry = entries[i];
+            const li = document.createElement('li');
+            li.className = 'history-item';
+            const badge = document.createElement('span');
+            badge.className = 'history-tab-badge';
+            badge.textContent = entry.tab || '?';
+            const link = document.createElement('button');
+            link.type = 'button';
+            link.className = 'history-link';
+            link.textContent = entry.label || entry.url;
+            link.title = entry.url;
+            link.addEventListener('click', () => { window.location.assign(entry.url); });
+            const remove = document.createElement('button');
+            remove.type = 'button';
+            remove.className = 'history-remove';
+            remove.setAttribute('aria-label', 'Remove from history');
+            remove.textContent = '×';
+            remove.addEventListener('click', () => {
+                const all = loadHistory();
+                all.splice(i, 1);
+                saveHistory(all);
+                renderHistory();
+            });
+            li.append(badge, link, remove);
+            historyList.appendChild(li);
+        }
+    }
+
+    if (historyEnabledToggle) {
+        historyEnabledToggle.addEventListener('change', () => {
+            setHistoryEnabled(historyEnabledToggle.checked);
+            renderHistory();
+        });
+    }
+
+    if (historyClearBtn) {
+        historyClearBtn.addEventListener('click', () => {
+            saveHistory([]);
+            renderHistory();
+        });
+    }
+
+    function captureCurrentPage() {
+        if (!historyEnabled()) return;
+        const hasResult = document.querySelector('.results, .vlsm-results, .overlap-result, .split-list');
+        if (!hasResult) return;
+        const url = window.location.pathname + window.location.search;
+        const tabId = activeTabId();
+        const tab = tabId ? tabId.replace(/^tab-/, '') : '';
+        const labelInput = document.querySelector('.panel.active input[type="text"], .panel.active textarea');
+        const label = (labelInput && labelInput.value.trim()) || url;
+        pushHistory({ url, tab, label, ts: Date.now() });
+    }
+    captureCurrentPage();
+
+    // ── Keyboard handler ─────────────────────────────────────────────────
+    document.addEventListener('keydown', e => {
+        const inEditable = isEditableTarget(e.target);
+
+        if (e.key === 'Escape' && isAnyOverlayOpen()) {
+            closeOverlays();
+            e.preventDefault();
+            return;
+        }
+
+        if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'r') {
+            const tabId = activeTabId();
+            const tabSlug = tabId ? tabId.replace(/^tab-/, '') : '';
+            const target = window.location.pathname + (tabSlug ? '?tab=' + encodeURIComponent(tabSlug) : '');
+            window.location.assign(target);
+            e.preventDefault();
+            return;
+        }
+
+        if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.key.toLowerCase() === 'c') {
+            const firstVal = document.querySelector('.panel.active .result-value');
+            if (firstVal) {
+                copyText(firstVal.textContent.trim());
+                e.preventDefault();
+            }
+            return;
+        }
+
+        if (inEditable) return;
+
+        if (e.key === '?' || (e.shiftKey && e.key === '/')) {
+            openOverlay(kbdOverlay);
+            e.preventDefault();
+            return;
+        }
+
+        if (e.key === '/' && !e.shiftKey) {
+            const firstInput = document.querySelector('.panel.active input[type="text"], .panel.active input:not([type]), .panel.active textarea');
+            if (firstInput) {
+                firstInput.focus();
+                e.preventDefault();
+            }
+            return;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(TAB_KEY_MAP, e.key)) {
+            const btn = document.getElementById(TAB_KEY_MAP[e.key]);
+            if (btn) {
+                btn.click();
+                btn.focus();
+                e.preventDefault();
+            }
+            return;
+        }
+
+        if (e.key === 'h' || e.key === 'H') {
+            renderHistory();
+            openOverlay(historyOverlay);
+            e.preventDefault();
+        }
+    });
+})();

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -79,6 +79,14 @@
             <svg class="icon-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
             <svg class="icon-moon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
         </button>
+        <button id="history-toggle" class="header-icon-btn" type="button"
+                title="Recent calculations (H)" aria-label="Recent calculations" aria-haspopup="dialog">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/><path d="M12 7v5l3 2"/></svg>
+        </button>
+        <button id="kbd-help-toggle" class="header-icon-btn" type="button"
+                title="Keyboard shortcuts (?)" aria-label="Keyboard shortcuts" aria-haspopup="dialog">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 10h.01M10 10h.01M14 10h.01M18 10h.01M6 14h.01M18 14h.01M10 14h4"/></svg>
+        </button>
     </div>
 
     <div class="tabs" role="tablist" aria-label="IP version">
@@ -1400,6 +1408,52 @@ if ($i < 3) {
 </main>
 
 <div id="toast" class="toast" role="status" aria-live="polite" aria-atomic="true">Copied!</div>
+
+<!-- v3.0.0 (#300) keyboard shortcut overlay -->
+<div id="kbd-overlay" class="modal-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="kbd-overlay-title">
+    <div class="modal">
+        <div class="modal-header">
+            <h2 id="kbd-overlay-title">Keyboard shortcuts</h2>
+            <button type="button" class="modal-close" aria-label="Close">&times;</button>
+        </div>
+        <div class="modal-body">
+            <dl class="kbd-list">
+                <dt><kbd>?</kbd></dt><dd>Show this help</dd>
+                <dt><kbd>Esc</kbd></dt><dd>Close any open overlay or tool drawer</dd>
+                <dt><kbd>1</kbd> &hellip; <kbd>4</kbd></dt><dd>Switch to tab (IPv4, IPv6, VLSM, VLSM IPv6)</dd>
+                <dt><kbd>/</kbd></dt><dd>Focus the first input on the active tab</dd>
+                <dt><kbd>Enter</kbd></dt><dd>Submit the current form (native; from any input)</dd>
+                <dt><kbd>Ctrl</kbd>+<kbd>R</kbd> / <kbd>Cmd</kbd>+<kbd>R</kbd></dt><dd>Reset the active tab (intercepts browser reload)</dd>
+                <dt><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd></dt><dd>Copy the first result on the active tab</dd>
+                <dt><kbd>H</kbd></dt><dd>Open recent calculations history</dd>
+            </dl>
+            <p class="modal-note">Shortcuts are ignored while typing in inputs (other than <kbd>Enter</kbd>, <kbd>Esc</kbd>, and <kbd>Ctrl</kbd>+<kbd>R</kbd>).</p>
+        </div>
+    </div>
+</div>
+
+<!-- v3.0.0 (#301) recent calculations history overlay -->
+<div id="history-overlay" class="modal-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="history-overlay-title">
+    <div class="modal">
+        <div class="modal-header">
+            <h2 id="history-overlay-title">Recent calculations</h2>
+            <button type="button" class="modal-close" aria-label="Close">&times;</button>
+        </div>
+        <div class="modal-body">
+            <div class="history-controls">
+                <label class="history-toggle-label">
+                    <input type="checkbox" id="history-enabled-toggle">
+                    <span>Remember calculations on this device</span>
+                </label>
+                <button type="button" id="history-clear" class="btn btn-small" hidden>Clear all</button>
+            </div>
+            <p class="modal-note" id="history-empty-msg" hidden>No history yet. Run a calculation with history enabled and it will appear here.</p>
+            <p class="modal-note" id="history-disabled-msg" hidden>History is off. Enable it above to start recording calculations on this device.</p>
+            <ul class="history-list" id="history-list"></ul>
+            <p class="modal-note">Stored in this browser only. Up to 50 most-recent entries (FIFO).</p>
+        </div>
+    </div>
+</div>
 
 <script defer src="assets/vendor/xlsx/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
 <script src="assets/app.js?v=<?= $app_version ?>"></script>

--- a/docs/superpowers/plans/v3.0.0-living-doc.md
+++ b/docs/superpowers/plans/v3.0.0-living-doc.md
@@ -35,7 +35,8 @@ across 4 sessions, each owning one PR. Every session must:
 | **0** (scaffold) | — | Setup | ✅ Done 2026-05-03 | Branch + plan + design lock + tracking PR |
 | **A** | PR1 — Foundations | #315, #312, #306, #307 | ✅ Merged (PR #317) | Largely backend; low UI risk |
 | **B** | PR2 — Admin hardening | #311, #313, #307 (matrix) | 🟡 In review (PR pending) | Auth-touching; needs careful review |
-| **C** | PR3 — Power-user UX | #300, #301, #302 | ⬜ Not started | Tree editor (#302) is the headline; may split into PR3a + PR3b |
+| **C** | PR3a — Keyboard + history | #300, #301 | 🟡 In review (PR pending) | Split agreed: tree editor (#302) is its own PR3b |
+| **C₂** | PR3b — Tree editor | #302 | ⬜ Not started | Headline feature; depends on PR1 schema bump (already merged); follows design lock |
 | **D** | PR4 — Release cut | — | ⬜ Not started | Version bump, CHANGELOG, README, mkdocs, tarball, dev→main PR |
 
 After Session A, PR1 must be merged into `release/v3.0.0` before Session B starts
@@ -235,8 +236,81 @@ New gaps surfaced:
 
 
 
-### Session C — _date_ — PR3 Power-user UX
-_(template — same shape as Session A; tree editor may split into 3a/3b)_
+### Session C — 2026-05-03 — PR3a Keyboard + history
+**PR:** _(open — see PR link stamped after merge)_ (open against `release/v3.0.0`)
+
+**Scope split decision:** PR3 was split into PR3a (this session, #300 + #301) and
+PR3b (next session, #302). Reasoning: #302 alone is ~600 LOC of new JS plus a
+new partial, new PHP helpers, and ~10 Playwright groups per the design lock —
+too large to bundle with the small power-user features without quality loss.
+The living-doc explicitly allowed this split.
+
+Delivered:
+- **#300 keyboard shortcut overlay** — global modal triggered by `?` (Shift+/)
+  or the new header icon button. Esc closes any open overlay; backdrop click
+  closes too. Implemented shortcuts: `1`/`2`/`3`/`4` switch tabs (only 4 tabs
+  exist; spec said 1–9 but extras would dead-key); `/` focuses the first text
+  input on the active tab; `Ctrl/Cmd+R` intercepted to reset the active tab via
+  `?tab=<slug>`; `Ctrl+Shift+C` copies the first `.result-value` on the active
+  tab; `H` opens the history overlay. `?` and `/` are ignored while typing in
+  inputs. The header help button is hidden via `@media (hover: none)` on
+  touch devices (touch users can't trigger `?` anyway).
+- **#301 recent calculations history** — global modal with opt-in toggle inside
+  the pane itself (no new "settings drawer" needed; the toggle is the entire
+  surface area for the setting). Backed by `localStorage`: `sc.history.enabled`
+  ('0'/'1') and `sc.history.entries` (JSON array, capped at 50 FIFO).
+  Captures the current page URL on load whenever any result block is present
+  (`.results, .vlsm-results, .overlap-result, .split-list`). Consecutive duplicate
+  URLs de-duped. Each entry shows tab badge + truncated label (input value or URL).
+  Clicking an entry re-runs via `location.assign`. Per-row remove + Clear All.
+  Open via the header icon button or `H` key.
+- **9 Playwright groups** covering: `?` opens overlay, header button opens
+  overlay + backdrop closes, `1`/`3` digits switch tabs, `/` focuses input,
+  `@media (hover: none)` rule shipped, history off-by-default state, opt-in
+  records the current page on next load, Clear All empties the list (+ verifies
+  localStorage), `H` key opens history.
+
+QA gates (all green):
+- Playwright (docker): 814/814 (was 795 — +19 assertions across 9 new tests)
+- PHPUnit: 306 / 636 / 14 skipped (unchanged — no PHP code touched)
+- PHPStan L9: clean
+- PHPCS PSR-12: clean
+- Spectral OpenAPI lint: clean
+- Semgrep (php + owasp + sql-injection): 0 findings on 51 files
+- ESLint + Stylelint: clean
+
+Files modified:
+- `Subnet-Calculator/templates/layout.php` (header icon buttons + two modal containers)
+- `Subnet-Calculator/assets/app.js` (keyboard handler + history storage/render — pure plain JS)
+- `Subnet-Calculator/assets/app.css` (header-icon-btn, modal/overlay, kbd-list, history-list)
+- `testing/scripts/playwright_test.py` (9 new test groups)
+
+Deviations from the PR3 plan:
+- The overlay surface for both features is a **single global modal**, not per-tab tool-drawer panes.
+  Rationale: keyboard help is inherently global (shortcuts span tabs); history is also global
+  (entries from any tab live in the same store). Adding either to all four tool drawers would
+  quadruple the markup with no benefit.
+- The history toggle lives **inside the history pane itself**, not in a separate "Settings drawer".
+  Rationale: there is no Settings drawer in the existing UI, and the toggle is the only setting
+  this feature would need; building a new drawer for one checkbox is overkill. The opt-in story
+  is preserved (off by default; user must explicitly enable).
+- Tab shortcuts are `1`–`4`, not `1`–`9`. There are only 4 tabs; the unused digits would silently no-op.
+
+New gaps surfaced:
+- **History does not capture cross-tool actions** (e.g. running a Subnet Diff).
+  The "successful calculation" detection scans for any of the four common result containers
+  on page load, but tool-drawer-only outcomes that don't render a top-level result block won't
+  enter history. Acceptable for v3.0.0; a `data-history-source` attribute could be added
+  per-tool in a future pass.
+- **Tab focus after `1`-`4` switching** moves the focus ring to the tab button. If a user
+  expects to immediately type into the first input, they need a follow-up `/`. Documented
+  in the overlay (`/` is right next to the tab list).
+- **`H` key fires even if focus is on a `<button>`**. By design — buttons aren't editable
+  targets — but it could theoretically conflict with a future button that wants to consume
+  raw `H` keys. Not a concern in current UI.
+
+### Session C₂ — _date_ — PR3b Tree editor
+_(template — implements #302 against the locked design doc)_
 
 ### Session D — _date_ — PR4 Release cut
 _(template — same shape as Session A; ends with merged dev→main PR + release tag)_

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -4306,6 +4306,173 @@ async def test_a11y_reduced_motion_css(page: Page) -> None:
     assert_true("prefers-reduced-motion media query present", has_rule)
 
 
+# ---------------------------------------------------------------------------
+# v3.0.0 — keyboard shortcut overlay (#300) and recent calculations (#301)
+# ---------------------------------------------------------------------------
+
+async def test_kbd_overlay_question_mark_opens(page: Page) -> None:
+    section("v3.0.0 #300 keyboard overlay — '?' opens, Esc closes")
+    await navigate(page, APP_URL)
+    overlay = page.locator("#kbd-overlay")
+    assert_true("kbd overlay: hidden by default", await overlay.is_hidden())
+    # Press ? on the body (not in any input).
+    await page.locator("body").click()
+    await page.keyboard.press("Shift+/")
+    assert_true(
+        "kbd overlay: visible after '?'",
+        await overlay.is_visible(),
+    )
+    assert_true(
+        "kbd overlay: shows shortcut entries",
+        await overlay.locator(".kbd-list dt").count() >= 5,
+    )
+    await page.keyboard.press("Escape")
+    assert_true(
+        "kbd overlay: hidden after Esc",
+        await overlay.is_hidden(),
+    )
+
+
+async def test_kbd_overlay_header_button_opens(page: Page) -> None:
+    section("v3.0.0 #300 keyboard overlay — header button opens it")
+    await navigate(page, APP_URL)
+    await page.click("#kbd-help-toggle")
+    assert_true(
+        "kbd overlay: visible after header click",
+        await page.locator("#kbd-overlay").is_visible(),
+    )
+    # Backdrop click closes.
+    await page.locator("#kbd-overlay").click(position={"x": 5, "y": 5})
+    assert_true(
+        "kbd overlay: hidden after backdrop click",
+        await page.locator("#kbd-overlay").is_hidden(),
+    )
+
+
+async def test_kbd_tab_switching_digits(page: Page) -> None:
+    section("v3.0.0 #300 keyboard — digits 1-4 switch tabs")
+    await navigate(page, APP_URL)
+    await page.locator("body").click()
+    await page.keyboard.press("3")
+    assert_eq(
+        "kbd: '3' selects vlsm tab",
+        await page.get_attribute("#tab-vlsm", "aria-selected"),
+        "true",
+    )
+    await page.keyboard.press("1")
+    assert_eq(
+        "kbd: '1' selects ipv4 tab",
+        await page.get_attribute("#tab-ipv4", "aria-selected"),
+        "true",
+    )
+
+
+async def test_kbd_slash_focuses_input(page: Page) -> None:
+    section("v3.0.0 #300 keyboard — '/' focuses first input on active tab")
+    await navigate(page, APP_URL)
+    await page.locator("body").click()
+    await page.keyboard.press("/")
+    focused_id = await page.evaluate("() => document.activeElement?.id")
+    assert_eq("kbd: '/' focuses #ip on IPv4 tab", focused_id, "ip")
+
+
+async def test_kbd_help_button_hidden_on_touch(page: Page) -> None:
+    section("v3.0.0 #300 keyboard — help button hidden on coarse pointers (CSS @media)")
+    await navigate(page, APP_URL)
+    has_rule = await page.evaluate("""() => {
+        for (const sheet of document.styleSheets) {
+            try {
+                for (const rule of sheet.cssRules) {
+                    if (rule.conditionText?.includes('hover: none')) {
+                        const css = rule.cssText || '';
+                        if (css.includes('kbd-help-toggle')) return true;
+                    }
+                }
+            } catch (e) {}
+        }
+        return false;
+    }""")
+    assert_true("kbd help: @media (hover: none) hides #kbd-help-toggle", has_rule)
+
+
+async def test_history_disabled_by_default(page: Page) -> None:
+    section("v3.0.0 #301 history — disabled by default; opening overlay shows opt-in")
+    await navigate(page, APP_URL)
+    # Clear any localStorage from previous tests in this context.
+    await page.evaluate("() => localStorage.clear()")
+    await page.click("#history-toggle")
+    overlay = page.locator("#history-overlay")
+    assert_true("history: overlay visible", await overlay.is_visible())
+    cb = page.locator("#history-enabled-toggle")
+    assert_eq("history: toggle starts unchecked", await cb.is_checked(), False)
+    assert_true(
+        "history: disabled-msg is shown when off",
+        await page.locator("#history-disabled-msg").is_visible(),
+    )
+
+
+async def test_history_opt_in_records_calculation(page: Page) -> None:
+    section("v3.0.0 #301 history — enabling, calculating, then re-opening shows entry")
+    await navigate(page, APP_URL)
+    await page.evaluate("() => localStorage.clear()")
+    await page.click("#history-toggle")
+    await page.locator("#history-enabled-toggle").check()
+    await page.locator("#history-overlay .modal-close").click()
+
+    # Run a successful calculation; module captures URL on next page load.
+    await navigate(page, APP_URL + "?ip=192.168.50.0&mask=24&tab=ipv4")
+    # Open history again and assert the entry appears.
+    await page.click("#history-toggle")
+    items = page.locator("#history-list .history-item")
+    assert_true(
+        "history: at least one entry recorded",
+        await items.count() >= 1,
+    )
+    first_link = items.first.locator(".history-link")
+    label = await first_link.text_content()
+    assert_true(
+        "history: entry label contains the input",
+        bool(label) and "192.168.50.0" in (label or ""),
+    )
+
+
+async def test_history_clear_removes_entries(page: Page) -> None:
+    section("v3.0.0 #301 history — Clear all empties the list")
+    await navigate(page, APP_URL)
+    # Seed an entry directly so this test does not depend on order.
+    await page.evaluate(
+        """() => {
+            localStorage.setItem('sc.history.enabled', '1');
+            localStorage.setItem('sc.history.entries',
+                JSON.stringify([{url: '?ip=10.0.0.0&mask=8', tab: 'ipv4', label: '10.0.0.0', ts: 1}]));
+        }"""
+    )
+    await page.click("#history-toggle")
+    assert_true(
+        "history: seeded entry visible",
+        await page.locator("#history-list .history-item").count() == 1,
+    )
+    await page.click("#history-clear")
+    assert_eq(
+        "history: cleared list is empty",
+        await page.locator("#history-list .history-item").count(),
+        0,
+    )
+    stored = await page.evaluate("() => localStorage.getItem('sc.history.entries')")
+    assert_eq("history: localStorage cleared", stored, "[]")
+
+
+async def test_history_h_key_opens(page: Page) -> None:
+    section("v3.0.0 #301 history — 'h' key opens overlay")
+    await navigate(page, APP_URL)
+    await page.locator("body").click()
+    await page.keyboard.press("h")
+    assert_true(
+        "history: 'h' opens overlay",
+        await page.locator("#history-overlay").is_visible(),
+    )
+
+
 async def test_vlsm_keyboard_delete(page: Page) -> None:
     section("VLSM — keyboard Delete on remove button")
     await navigate(page, APP_URL)
@@ -4587,6 +4754,16 @@ async def main() -> None:
             await test_a11y_help_bubble_keyboard(page)
             await test_a11y_reduced_motion_css(page)
             await test_vlsm_keyboard_delete(page)
+            # v3.0.0 PR3a — keyboard shortcut overlay (#300) + history (#301)
+            await test_kbd_overlay_question_mark_opens(page)
+            await test_kbd_overlay_header_button_opens(page)
+            await test_kbd_tab_switching_digits(page)
+            await test_kbd_slash_focuses_input(page)
+            await test_kbd_help_button_hidden_on_touch(page)
+            await test_history_disabled_by_default(page)
+            await test_history_opt_in_records_calculation(page)
+            await test_history_clear_removes_entries(page)
+            await test_history_h_key_opens(page)
             await test_v290_typography(page)
         finally:
             await context.close()


### PR DESCRIPTION
## Summary

Session C of the v3.0.0 release. PR3 was split into PR3a (this) and PR3b (the tree editor #302, in its own session) — see the [living doc](../blob/release/v3.0.0/docs/superpowers/plans/v3.0.0-living-doc.md) for the rationale.

### #300 Keyboard shortcut overlay
- Global modal triggered by \`?\` or new header icon button; \`Esc\` / backdrop click closes.
- Shortcuts: \`1\`-\`4\` switch tabs · \`/\` focuses first input · \`Ctrl/Cmd+R\` intercepted (reset active tab) · \`Ctrl+Shift+C\` copies first result · \`H\` opens history.
- \`?\` / \`/\` ignored while typing in inputs. Header help button hidden on touch via \`@media (hover: none)\`.

### #301 Recent calculations history
- Global modal with opt-in toggle inside the pane (no separate Settings drawer needed).
- \`localStorage\`-backed: \`sc.history.enabled\` + \`sc.history.entries\` (JSON, FIFO 50).
- Captures the current page URL on load when any result block is present. Consecutive dupes de-duped.
- Click an entry to re-run via \`location.assign\`. Per-row remove + Clear All.

### Deviations from PR3 plan
- One **global modal per feature** instead of per-tab tool-drawer panes (both features are inherently global).
- History toggle lives **inside the history pane**, not in a new Settings drawer (overkill for one checkbox).
- Tab shortcuts are \`1\`-\`4\` (only 4 tabs exist; \`5\`-\`9\` would silently no-op).

## QA gates (all green)

- Playwright (docker): **814/814** (+19 from 9 new tests)
- PHPUnit: 306 / 636 / 14 skipped (no PHP touched)
- PHPStan L9: clean · PHPCS PSR-12: clean · Spectral: clean · Semgrep: 0 findings · ESLint + Stylelint: clean

## Test plan

- [x] \`?\` opens overlay; Esc + backdrop close
- [x] Header icon button opens overlay
- [x] \`1\`/\`3\` switch tabs; \`/\` focuses first input
- [x] \`@media (hover: none)\` hides \`#kbd-help-toggle\` (touch)
- [x] History off by default; opt-in checkbox visible
- [x] Enabling history then loading a results page records the entry
- [x] Clear All empties list and clears localStorage
- [x] \`H\` opens history overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)