### PR TITLE
feat(v3.0.0): PR3b interactive subnet tree editor (#302)

### DIFF
--- a/Subnet-Calculator/api/v1/handlers/sessions.php
+++ b/Subnet-Calculator/api/v1/handlers/sessions.php
@@ -81,13 +81,13 @@ if ($type === 'ipv4' || $type === 'ipv6') {
         }
     }
 } elseif ($type === 'tree') {
-    // Schema-level validation only at this stage (PR1). Full tree_validate()
-    // ships in PR3 (#302) when the tree editor lands.
-    if (!isset($payload['root']) || !is_array($payload['root'])) {
-        json_err('Field "root" must be an object for tree sessions.');
-    }
-    if (!isset($payload['root']['cidr']) || !is_string($payload['root']['cidr'])) {
-        json_err('root.cidr is required for tree sessions.');
+    // v3.0.0 PR3 (#302): full structural + semantic validation via
+    // tree_validate(). Throws \InvalidArgumentException on the first rule
+    // violation — message is safe to surface to the API caller.
+    try {
+        tree_validate($payload);
+    } catch (\InvalidArgumentException $e) {
+        json_err($e->getMessage());
     }
 }
 

--- a/Subnet-Calculator/assets/app.css
+++ b/Subnet-Calculator/assets/app.css
@@ -1590,3 +1590,266 @@
 @media (width <= 480px) {
     .modal-overlay { padding: 2rem 0.5rem; }
 }
+
+/* ─── Subnet Tree Editor (#302, v3.0.0) ───────────────────────────────────── */
+
+.tree-editor-panel { display: flex; flex-direction: column; gap: 0.75rem; }
+
+.tree-editor-init {
+    display: flex;
+    gap: 0.5rem;
+    align-items: end;
+    flex-wrap: wrap;
+}
+.tree-editor-init input[type="text"] {
+    flex: 1 1 14ch;
+    min-width: 12ch;
+}
+
+.tree-editor[hidden] { display: none; }
+
+.tree-editor-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.tree-editor-spacer { flex: 1 1 auto; }
+
+.tree-editor-btn {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    padding: 0.35rem 0.7rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 120ms, border-color 120ms;
+}
+.tree-editor-btn:hover { border-color: var(--color-accent); }
+.tree-editor-btn:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+.tree-editor-btn:disabled { opacity: 40%; cursor: not-allowed; }
+.tree-editor-btn-danger { color: #c0392b; }
+
+.tree-editor-status {
+    font-size: 0.8rem;
+    color: var(--color-text);
+    opacity: 75%;
+    min-height: 1.2em;
+}
+
+.tree-editor-canvas {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.5rem 0;
+    max-height: 60vh;
+    overflow: auto;
+}
+
+.tree-editor-node { display: flex; flex-direction: column; }
+
+.tree-editor-card {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-surface);
+    cursor: pointer;
+    user-select: none;
+    margin-left: calc(var(--depth, 0) * 1.4rem);
+    max-width: 100%;
+}
+.tree-editor-card:hover { border-color: var(--color-accent); }
+.tree-editor-card:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+.tree-editor-node-root > .tree-editor-card {
+    border-color: var(--color-accent);
+    font-weight: 600;
+}
+
+.tree-editor-cidr {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.9rem;
+}
+.tree-editor-name {
+    color: var(--color-accent);
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+.tree-editor-notes {
+    opacity: 70%;
+    font-size: 0.8rem;
+    font-style: italic;
+}
+
+.tree-editor-pencil {
+    margin-left: auto;
+    background: transparent;
+    border: 0;
+    color: var(--color-text);
+    cursor: pointer;
+    font-size: 0.95rem;
+    padding: 0 0.25rem;
+    opacity: 60%;
+}
+.tree-editor-pencil:hover { opacity: 100%; }
+.tree-editor-pencil:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+}
+
+.tree-editor-children {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+}
+
+.tree-editor-share {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--color-border);
+    flex-wrap: wrap;
+}
+.tree-editor-share-label { font-size: 0.85rem; opacity: 75%; }
+.tree-editor-share-url {
+    flex: 1 1 12rem;
+    overflow-x: auto;
+    white-space: nowrap;
+    background: var(--color-bg);
+    padding: 0.25rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+}
+.tree-editor-share-copy {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    padding: 0.25rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+.tree-editor-share-copy:hover { border-color: var(--color-accent); }
+
+/* ── Modals ─────────────────────────────────────────────────────────────── */
+
+.tree-modal[hidden],
+.tree-action-sheet[hidden] { display: none; }
+
+.tree-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.tree-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgb(0 0 0 / 50%);
+}
+.tree-modal-card {
+    position: relative;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 1.25rem;
+    min-width: 18rem;
+    max-width: 92vw;
+    box-shadow: 0 10px 30px rgb(0 0 0 / 40%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.tree-modal-card h3 { margin: 0; font-size: 1rem; }
+.tree-modal-help { margin: 0; font-size: 0.85rem; opacity: 75%; }
+.tree-modal-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.tree-modal-cancel {
+    align-self: flex-end;
+    background: transparent;
+    border: 0;
+    color: var(--color-text);
+    cursor: pointer;
+    font-size: 0.85rem;
+    opacity: 70%;
+}
+.tree-modal-cancel:hover { opacity: 100%; }
+.tree-modal-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+}
+.tree-modal-label input,
+.tree-modal-label textarea {
+    width: 100%;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+    box-sizing: border-box;
+}
+
+/* ── Mobile action sheet ───────────────────────────────────────────────── */
+
+.tree-action-sheet {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+}
+.tree-action-sheet-card {
+    position: relative;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-top: 1px solid var(--color-border);
+    border-radius: 12px 12px 0 0;
+    padding: 1rem;
+    width: 100%;
+    max-width: 32rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    box-shadow: 0 -8px 24px rgb(0 0 0 / 40%);
+}
+.tree-action-sheet-card h3 { margin: 0 0 0.4rem; font-size: 1rem; }
+.tree-action-sheet-btn {
+    background: var(--color-bg);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    padding: 0.7rem 0.9rem;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    text-align: left;
+    cursor: pointer;
+}
+.tree-action-sheet-btn:hover { border-color: var(--color-accent); }
+.tree-action-sheet-btn-cancel {
+    text-align: center;
+    margin-top: 0.4rem;
+    opacity: 70%;
+}
+
+@media (hover: none) {
+    .tree-editor-card { cursor: pointer; }
+}

--- a/Subnet-Calculator/assets/app.js
+++ b/Subnet-Calculator/assets/app.js
@@ -1212,3 +1212,679 @@ if (window.self === window.top && 'serviceWorker' in navigator) {
         }
     });
 })();
+
+// ─── Subnet Tree Editor (#302, v3.0.0) ──────────────────────────────────────
+//
+// Client-only reducer-style editor.  All state lives in JS; localStorage
+// autosave covers reload-recovery; explicit "Save Session" persists via
+// POST /api/v1/sessions (type: 'tree') for cross-device share.  See
+// docs/superpowers/plans/2026-05-03-v3.0.0-tree-editor-design.md for the
+// design lock.  No new runtime deps — plain JS + BigInt for v6 math.
+
+(function () {
+    'use strict';
+
+    const root = document.querySelector('.tool-panel[data-tool="tree-editor"]');
+    if (!root) { return; }
+
+    const initForm = root.querySelector('#tree-editor-init');
+    const initInput = root.querySelector('#tree_editor_cidr');
+    const editorEl = root.querySelector('.tree-editor');
+    const canvas = root.querySelector('[data-role="canvas"]');
+    const statusEl = root.querySelector('[data-role="status"]');
+    const splitModal = root.querySelector('[data-role="split-modal"]');
+    const renameModal = root.querySelector('[data-role="rename-modal"]');
+    const sheet = root.querySelector('[data-role="action-sheet"]');
+    const undoBtn = root.querySelector('[data-action="undo"]');
+    const redoBtn = root.querySelector('[data-action="redo"]');
+    const shareBox = root.querySelector('[data-role="share"]');
+
+    const MAX_UNDO = 50;
+    const SHARE_NODE_CAP = 50;
+    const AUTOSAVE_DELAY = 300;
+
+    let state = null;       // { root: TreeNode, family: 'ipv4'|'ipv6' }
+    let undoStack = [];     // serialized prior states
+    let redoStack = [];
+    let autosaveTimer = null;
+    let pickerTarget = null;   // CIDR string the picker is acting on
+    let renameTarget = null;
+    let sheetTarget = null;
+    let dragSource = null;
+
+    // ── CIDR math (BigInt for unified v4 + v6) ──────────────────────────────
+
+    function cidrFamily(cidr) {
+        return cidr.indexOf(':') !== -1 ? 'ipv6' : 'ipv4';
+    }
+
+    function cidrParts(cidr) {
+        const [ip, pxStr] = cidr.split('/');
+        return { ip: ip, prefix: parseInt(pxStr, 10) };
+    }
+
+    function ipv4ToBig(ip) {
+        const o = ip.split('.').map(function (s) { return parseInt(s, 10); });
+        return (BigInt(o[0]) << 24n) | (BigInt(o[1]) << 16n) | (BigInt(o[2]) << 8n) | BigInt(o[3]);
+    }
+
+    function bigToIpv4(n) {
+        return [
+            Number((n >> 24n) & 0xffn),
+            Number((n >> 16n) & 0xffn),
+            Number((n >> 8n) & 0xffn),
+            Number(n & 0xffn)
+        ].join('.');
+    }
+
+    function ipv6ToBig(ip) {
+        // Expand :: and parse 8 hextets.
+        const halves = ip.split('::');
+        const left = halves[0] ? halves[0].split(':') : [];
+        const right = halves.length > 1 && halves[1] ? halves[1].split(':') : [];
+        const missing = 8 - left.length - right.length;
+        const parts = left.concat(Array(missing).fill('0'), right);
+        let n = 0n;
+        for (let i = 0; i < 8; i++) {
+            n = (n << 16n) | BigInt(parseInt(parts[i] || '0', 16));
+        }
+        return n;
+    }
+
+    function bigToIpv6(n) {
+        const parts = [];
+        for (let i = 7; i >= 0; i--) {
+            parts.push(Number((n >> BigInt(i * 16)) & 0xffffn).toString(16));
+        }
+        // Compress longest run of zeros.
+        let bestStart = -1, bestLen = 0, curStart = -1, curLen = 0;
+        for (let i = 0; i < parts.length; i++) {
+            if (parts[i] === '0') {
+                if (curStart === -1) { curStart = i; }
+                curLen++;
+                if (curLen > bestLen) { bestStart = curStart; bestLen = curLen; }
+            } else { curStart = -1; curLen = 0; }
+        }
+        if (bestLen >= 2) {
+            return parts.slice(0, bestStart).join(':') + '::' + parts.slice(bestStart + bestLen).join(':');
+        }
+        return parts.join(':');
+    }
+
+    function ipToBig(ip, family) { return family === 'ipv6' ? ipv6ToBig(ip) : ipv4ToBig(ip); }
+    function bigToIp(n, family) { return family === 'ipv6' ? bigToIpv6(n) : bigToIpv4(n); }
+    function familyMaxBits(family) { return family === 'ipv6' ? 128 : 32; }
+
+    function canonicalCidr(cidr, family) {
+        const { ip, prefix } = cidrParts(cidr);
+        const bits = familyMaxBits(family);
+        const n = ipToBig(ip, family);
+        const shift = BigInt(bits - prefix);
+        const mask = prefix === 0 ? 0n : (((1n << BigInt(prefix)) - 1n) << shift);
+        return bigToIp(n & mask, family) + '/' + prefix;
+    }
+
+    function splitInto(cidr, count, family) {
+        // count must be a power of 2, 2..16.
+        const { ip, prefix } = cidrParts(cidr);
+        const bits = Math.log2(count);
+        if (!Number.isInteger(bits) || bits < 1) { return []; }
+        const newPx = prefix + bits;
+        if (newPx > familyMaxBits(family)) { return []; }
+        const start = ipToBig(ip, family);
+        const stride = 1n << BigInt(familyMaxBits(family) - newPx);
+        const out = [];
+        for (let i = 0; i < count; i++) {
+            out.push(bigToIp(start + BigInt(i) * stride, family) + '/' + newPx);
+        }
+        return out;
+    }
+
+    // ── Tree state helpers ──────────────────────────────────────────────────
+
+    function deepClone(o) { return JSON.parse(JSON.stringify(o)); }
+
+    function findNode(node, cidr) {
+        if (node.cidr === cidr) { return node; }
+        if (node.children) {
+            for (let i = 0; i < node.children.length; i++) {
+                const r = findNode(node.children[i], cidr);
+                if (r) { return r; }
+            }
+        }
+        return null;
+    }
+
+    function findParent(node, cidr, parent) {
+        if (node.cidr === cidr) { return parent; }
+        if (node.children) {
+            for (let i = 0; i < node.children.length; i++) {
+                const r = findParent(node.children[i], cidr, node);
+                if (r !== undefined) { return r; }
+            }
+        }
+        return undefined;
+    }
+
+    function countNodes(node) {
+        let n = 1;
+        if (node.children) {
+            node.children.forEach(function (c) { n += countNodes(c); });
+        }
+        return n;
+    }
+
+    // ── Reducer ─────────────────────────────────────────────────────────────
+
+    function pushHistory() {
+        undoStack.push(JSON.stringify(state.root));
+        if (undoStack.length > MAX_UNDO) { undoStack.shift(); }
+        redoStack = [];
+        updateUndoButtons();
+    }
+
+    function updateUndoButtons() {
+        if (undoBtn) { undoBtn.disabled = undoStack.length === 0; }
+        if (redoBtn) { redoBtn.disabled = redoStack.length === 0; }
+    }
+
+    function dispatch(action) {
+        if (!state) { return; }
+        const before = JSON.stringify(state.root);
+        switch (action.type) {
+            case 'SPLIT': {
+                const node = findNode(state.root, action.cidr);
+                if (!node || (node.children && node.children.length)) { return; }
+                const kids = splitInto(node.cidr, action.count, state.family);
+                if (!kids.length) { return; }
+                pushHistory();
+                node.children = kids.map(function (c) { return { cidr: c }; });
+                break;
+            }
+            case 'MERGE': {
+                const parent = findParent(state.root, action.cidr, null);
+                if (!parent) { return; }
+                pushHistory();
+                delete parent.children;
+                break;
+            }
+            case 'RENAME': {
+                const node = findNode(state.root, action.cidr);
+                if (!node) { return; }
+                pushHistory();
+                if (action.name) { node.name = action.name; } else { delete node.name; }
+                if (action.notes) { node.notes = action.notes; } else { delete node.notes; }
+                break;
+            }
+            case 'UNDO': {
+                if (!undoStack.length) { return; }
+                redoStack.push(JSON.stringify(state.root));
+                state.root = JSON.parse(undoStack.pop());
+                break;
+            }
+            case 'REDO': {
+                if (!redoStack.length) { return; }
+                undoStack.push(JSON.stringify(state.root));
+                state.root = JSON.parse(redoStack.pop());
+                break;
+            }
+            case 'LOAD': {
+                state.root = action.root;
+                undoStack = [];
+                redoStack = [];
+                break;
+            }
+            case 'RESET': {
+                pushHistory();
+                state.root = { cidr: state.root.cidr };
+                break;
+            }
+        }
+        if (JSON.stringify(state.root) !== before) {
+            updateUndoButtons();
+            render();
+            scheduleAutosave();
+        }
+    }
+
+    // ── Autosave (localStorage) ─────────────────────────────────────────────
+
+    function autosaveKey() { return 'sc.tree.draft.' + state.root.cidr; }
+
+    function scheduleAutosave() {
+        if (autosaveTimer) { clearTimeout(autosaveTimer); }
+        autosaveTimer = setTimeout(function () {
+            try {
+                localStorage.setItem(autosaveKey(), JSON.stringify(state.root));
+                setStatus('Autosaved.');
+            } catch (e) { /* quota exceeded — surface silently */ }
+        }, AUTOSAVE_DELAY);
+    }
+
+    function loadAutosave(rootCidr) {
+        try {
+            const raw = localStorage.getItem('sc.tree.draft.' + rootCidr);
+            return raw ? JSON.parse(raw) : null;
+        } catch (e) { return null; }
+    }
+
+    // ── Rendering ───────────────────────────────────────────────────────────
+
+    function setStatus(msg) {
+        if (statusEl) { statusEl.textContent = msg || ''; }
+    }
+
+    function render() {
+        if (!state) { return; }
+        canvas.innerHTML = '';
+        canvas.appendChild(renderNode(state.root, 0, true));
+    }
+
+    function renderNode(node, depth, isRoot) {
+        const wrap = document.createElement('div');
+        wrap.className = 'tree-editor-node' + (isRoot ? ' tree-editor-node-root' : '');
+        wrap.setAttribute('data-cidr', node.cidr);
+        wrap.style.setProperty('--depth', depth);
+
+        const card = document.createElement('div');
+        card.className = 'tree-editor-card';
+        card.setAttribute('tabindex', '0');
+        card.setAttribute('role', 'button');
+        card.setAttribute('draggable', 'true');
+
+        const cidrSpan = document.createElement('code');
+        cidrSpan.className = 'tree-editor-cidr';
+        cidrSpan.textContent = node.cidr;
+        card.appendChild(cidrSpan);
+
+        if (node.name) {
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'tree-editor-name';
+            nameSpan.textContent = node.name;
+            card.appendChild(nameSpan);
+        }
+        if (node.notes) {
+            const notesSpan = document.createElement('span');
+            notesSpan.className = 'tree-editor-notes';
+            notesSpan.textContent = node.notes;
+            card.appendChild(notesSpan);
+        }
+
+        // Pencil icon (rename)
+        const pencil = document.createElement('button');
+        pencil.type = 'button';
+        pencil.className = 'tree-editor-pencil';
+        pencil.setAttribute('aria-label', 'Rename ' + node.cidr);
+        pencil.setAttribute('data-rename', node.cidr);
+        pencil.textContent = '✎';
+        card.appendChild(pencil);
+
+        wrap.appendChild(card);
+
+        if (node.children && node.children.length) {
+            const kidsWrap = document.createElement('div');
+            kidsWrap.className = 'tree-editor-children';
+            node.children.forEach(function (c) {
+                kidsWrap.appendChild(renderNode(c, depth + 1, false));
+            });
+            wrap.appendChild(kidsWrap);
+        }
+        return wrap;
+    }
+
+    // ── Modal helpers ──────────────────────────────────────────────────────
+
+    function openModal(el) { if (el) { el.hidden = false; } }
+    function closeModal(el) { if (el) { el.hidden = true; } }
+
+    function openSplitPicker(cidr) {
+        pickerTarget = cidr;
+        const cidrSpan = splitModal.querySelector('[data-role="split-cidr"]');
+        if (cidrSpan) { cidrSpan.textContent = cidr; }
+        openModal(splitModal);
+    }
+
+    function openRenameModal(cidr) {
+        renameTarget = cidr;
+        const node = findNode(state.root, cidr);
+        if (!node) { return; }
+        renameModal.querySelector('[data-role="rename-cidr"]').textContent = cidr;
+        renameModal.querySelector('[data-role="rename-name"]').value = node.name || '';
+        renameModal.querySelector('[data-role="rename-notes"]').value = node.notes || '';
+        openModal(renameModal);
+    }
+
+    function openSheet(cidr) {
+        sheetTarget = cidr;
+        sheet.querySelector('[data-role="sheet-cidr"]').textContent = cidr;
+        openModal(sheet);
+    }
+
+    // ── Exports ────────────────────────────────────────────────────────────
+
+    function flatten(node, out) {
+        out.push(node);
+        if (node.children) { node.children.forEach(function (c) { flatten(c, out); }); }
+        return out;
+    }
+
+    function leafCidrs() {
+        return flatten(state.root, []).filter(function (n) { return !n.children || !n.children.length; }).map(function (n) { return n.cidr; });
+    }
+
+    function copyText(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).catch(function () {});
+        } else {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            document.body.appendChild(ta);
+            ta.select();
+            try { document.execCommand('copy'); } catch (e) { /* fallback failed */ }
+            document.body.removeChild(ta);
+        }
+    }
+
+    function exportCidrList() { return leafCidrs().join('\n'); }
+
+    function exportMarkdown() {
+        const lines = ['# Subnet Plan: ' + state.root.cidr, ''];
+        function walk(node, depth) {
+            const indent = '  '.repeat(depth);
+            const label = node.name ? ' — ' + node.name : '';
+            lines.push(indent + '- `' + node.cidr + '`' + label);
+            if (node.notes) { lines.push(indent + '  > ' + node.notes); }
+            if (node.children) { node.children.forEach(function (c) { walk(c, depth + 1); }); }
+        }
+        walk(state.root, 0);
+        return lines.join('\n');
+    }
+
+    function exportCisco() {
+        return leafCidrs().map(function (c) {
+            const [ip, px] = c.split('/');
+            return 'interface XX\n ip address ' + ip + ' /' + px;
+        }).join('\n!\n');
+    }
+
+    function exportCsv() {
+        const rows = [['cidr', 'name', 'notes', 'is_leaf']];
+        flatten(state.root, []).forEach(function (n) {
+            rows.push([
+                n.cidr,
+                n.name || '',
+                (n.notes || '').replace(/"/g, '""'),
+                (!n.children || !n.children.length) ? '1' : '0'
+            ]);
+        });
+        return rows.map(function (r) {
+            return r.map(function (c) { return '"' + String(c).replace(/"/g, '""') + '"'; }).join(',');
+        }).join('\n');
+    }
+
+    function exportJson() {
+        return JSON.stringify({ type: 'tree', root: state.root }, null, 2);
+    }
+
+    function downloadFile(name, mime, body) {
+        const blob = new Blob([body], { type: mime });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    function base64UrlEncode(s) {
+        return btoa(unescape(encodeURIComponent(s))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    }
+    function base64UrlDecode(s) {
+        const pad = s + '==='.slice((s.length + 3) % 4);
+        return decodeURIComponent(escape(atob(pad.replace(/-/g, '+').replace(/_/g, '/'))));
+    }
+
+    function shareUrl() {
+        const total = countNodes(state.root);
+        if (total > SHARE_NODE_CAP) {
+            return null;
+        }
+        const enc = base64UrlEncode(JSON.stringify(state.root));
+        const u = new URL(window.location.href);
+        u.searchParams.set('tab', 'ipv4');
+        u.searchParams.set('tree', enc);
+        return u.toString();
+    }
+
+    function showShare(url) {
+        const out = root.querySelector('[data-role="share-url"]');
+        if (out) { out.textContent = url; }
+        if (shareBox) { shareBox.hidden = false; }
+    }
+
+    function saveSession() {
+        try { tree_validate_client(state.root, state.family); }
+        catch (e) { setStatus('Cannot save: ' + e.message); return; }
+        fetch('api/v1/sessions', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ payload: { type: 'tree', root: state.root } })
+        }).then(function (r) { return r.json(); })
+            .then(function (json) {
+                if (json && json.ok && json.data && json.data.id) {
+                    const u = new URL(window.location.href);
+                    u.searchParams.set('tab', 'ipv4');
+                    u.searchParams.set('session_id', json.data.id);
+                    showShare(u.toString());
+                    setStatus('Saved as session ' + json.data.id);
+                } else {
+                    setStatus('Save failed: ' + ((json && json.error) || 'unknown error'));
+                }
+            }).catch(function (e) { setStatus('Save failed: ' + e.message); });
+    }
+
+    // Mirror of server tree_validate() — minimal client-side checks before
+    // POSTing.  Server is the authority; this is for UX.
+    function tree_validate_client(node, family) {
+        function visit(n, parent, depth) {
+            if (depth > 16) { throw new Error('depth exceeds 16'); }
+            if (!n.cidr) { throw new Error('node missing cidr'); }
+            if (n.name && n.name.length > 128) { throw new Error('name exceeds 128 characters'); }
+            if (n.notes && n.notes.length > 1024) { throw new Error('notes exceed 1024 characters'); }
+            if (n.children) {
+                if (n.children.length < 2) { throw new Error('children must be >=2'); }
+                if (n.children.length > 64) { throw new Error('children exceed 64'); }
+                n.children.forEach(function (c) { visit(c, n, depth + 1); });
+            }
+        }
+        visit(node, null, 0);
+    }
+
+    // ── Wiring ──────────────────────────────────────────────────────────────
+
+    function startEditor(rootCidr) {
+        const family = cidrFamily(rootCidr);
+        const canon = canonicalCidr(rootCidr, family);
+        if (canon !== rootCidr) {
+            setStatus('Normalised to ' + canon);
+            rootCidr = canon;
+        }
+        state = { root: { cidr: rootCidr }, family: family };
+
+        const draft = loadAutosave(rootCidr);
+        if (draft && draft.cidr === rootCidr) {
+            state.root = draft;
+            setStatus('Restored from autosave.');
+        }
+
+        // ?tree=… overrides autosave on first load.
+        const params = new URLSearchParams(window.location.search);
+        const treeParam = params.get('tree');
+        if (treeParam) {
+            try {
+                const decoded = JSON.parse(base64UrlDecode(treeParam));
+                if (decoded && decoded.cidr === rootCidr) {
+                    state.root = decoded;
+                    setStatus('Loaded tree from URL.');
+                }
+            } catch (e) { /* ignore bad share */ }
+        }
+
+        initForm.hidden = true;
+        editorEl.hidden = false;
+        undoStack = [];
+        redoStack = [];
+        updateUndoButtons();
+        render();
+    }
+
+    if (initForm) {
+        initForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const v = initInput.value.trim();
+            if (!v) { return; }
+            if (v.indexOf('/') === -1) {
+                setStatus('CIDR must include a prefix, e.g. 10.0.0.0/24');
+                return;
+            }
+            startEditor(v);
+        });
+    }
+
+    // Auto-start if ?tree=… and a session already running on the page,
+    // or if a session_id with type=tree was loaded by the server.
+    document.addEventListener('DOMContentLoaded', function () {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('tree') && initInput && initInput.value) {
+            startEditor(initInput.value);
+        }
+    });
+
+    // Click on a node card → split picker (desktop) or sheet (touch).
+    canvas.addEventListener('click', function (e) {
+        const pencil = e.target.closest('[data-rename]');
+        if (pencil) {
+            openRenameModal(pencil.getAttribute('data-rename'));
+            return;
+        }
+        const card = e.target.closest('.tree-editor-card');
+        if (!card) { return; }
+        const cidr = card.parentElement.getAttribute('data-cidr');
+        if (window.matchMedia('(hover: none)').matches) {
+            openSheet(cidr);
+        } else {
+            openSplitPicker(cidr);
+        }
+    });
+
+    // Drag-merge (desktop only).
+    canvas.addEventListener('dragstart', function (e) {
+        if (window.matchMedia('(hover: none)').matches) { e.preventDefault(); return; }
+        const card = e.target.closest('.tree-editor-card');
+        if (!card) { return; }
+        dragSource = card.parentElement.getAttribute('data-cidr');
+        e.dataTransfer.effectAllowed = 'move';
+    });
+    canvas.addEventListener('dragover', function (e) {
+        if (dragSource) { e.preventDefault(); }
+    });
+    canvas.addEventListener('drop', function (e) {
+        e.preventDefault();
+        if (!dragSource) { return; }
+        const card = e.target.closest('.tree-editor-card');
+        if (!card) { dragSource = null; return; }
+        const target = card.parentElement.getAttribute('data-cidr');
+        if (target === dragSource) { dragSource = null; return; }
+        // Both must share a parent → merge that parent.
+        const sourceParent = findParent(state.root, dragSource, null);
+        const targetParent = findParent(state.root, target, null);
+        if (sourceParent && sourceParent === targetParent) {
+            dispatch({ type: 'MERGE', cidr: dragSource });
+        } else {
+            setStatus('Drag-merge only works between siblings.');
+        }
+        dragSource = null;
+    });
+
+    // Modal interactions.
+    splitModal.addEventListener('click', function (e) {
+        const into = e.target.closest('[data-split-into]');
+        if (into) {
+            dispatch({ type: 'SPLIT', cidr: pickerTarget, count: parseInt(into.getAttribute('data-split-into'), 10) });
+            closeModal(splitModal);
+            return;
+        }
+        if (e.target.matches('[data-role="split-cancel"]')) { closeModal(splitModal); }
+    });
+
+    renameModal.addEventListener('click', function (e) {
+        if (e.target.matches('[data-role="rename-save"]')) {
+            const name = renameModal.querySelector('[data-role="rename-name"]').value.trim();
+            const notes = renameModal.querySelector('[data-role="rename-notes"]').value.trim();
+            dispatch({ type: 'RENAME', cidr: renameTarget, name: name, notes: notes });
+            closeModal(renameModal);
+        } else if (e.target.matches('[data-role="rename-cancel"]')) {
+            closeModal(renameModal);
+        }
+    });
+
+    sheet.addEventListener('click', function (e) {
+        const action = e.target.getAttribute && e.target.getAttribute('data-sheet-action');
+        if (action === 'split') { closeModal(sheet); openSplitPicker(sheetTarget); }
+        else if (action === 'merge') { closeModal(sheet); dispatch({ type: 'MERGE', cidr: sheetTarget }); }
+        else if (action === 'rename') { closeModal(sheet); openRenameModal(sheetTarget); }
+        else if (e.target.matches('[data-role="sheet-cancel"]')) { closeModal(sheet); }
+    });
+
+    // Toolbar buttons.
+    root.querySelectorAll('.tree-editor-toolbar [data-action]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const a = btn.getAttribute('data-action');
+            if (a === 'undo') { dispatch({ type: 'UNDO' }); }
+            else if (a === 'redo') { dispatch({ type: 'REDO' }); }
+            else if (a === 'reset') {
+                if (confirm('Reset the tree? This drops all edits but keeps autosave history.')) {
+                    dispatch({ type: 'RESET' });
+                }
+            }
+            else if (a === 'save-session') { saveSession(); }
+            else if (a === 'copy-cidr') { copyText(exportCidrList()); setStatus('Copied CIDR list.'); }
+            else if (a === 'copy-md') { copyText(exportMarkdown()); setStatus('Copied Markdown.'); }
+            else if (a === 'copy-cisco') { copyText(exportCisco()); setStatus('Copied Cisco config.'); }
+            else if (a === 'download-csv') { downloadFile('subnet-tree.csv', 'text/csv', exportCsv()); }
+            else if (a === 'download-json') { downloadFile('subnet-tree.json', 'application/json', exportJson()); }
+            else if (a === 'share-url') {
+                const u = shareUrl();
+                if (!u) {
+                    setStatus('Tree too large to share — save as session and share that URL instead.');
+                } else {
+                    showShare(u);
+                    copyText(u);
+                    setStatus('Share URL copied.');
+                }
+            }
+        });
+    });
+
+    const shareCopyBtn = root.querySelector('[data-action="copy-share"]');
+    if (shareCopyBtn) {
+        shareCopyBtn.addEventListener('click', function () {
+            const u = root.querySelector('[data-role="share-url"]');
+            if (u) { copyText(u.textContent || ''); setStatus('Share URL copied.'); }
+        });
+    }
+
+    // Keyboard: Ctrl/Cmd+Z = undo, +Shift = redo (only when editor is open
+    // and focus is inside it, to avoid clobbering page-level shortcuts).
+    document.addEventListener('keydown', function (e) {
+        if (!state || editorEl.hidden) { return; }
+        if (!root.contains(document.activeElement) && document.activeElement !== document.body) { return; }
+        if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'Z')) {
+            if (e.shiftKey) { dispatch({ type: 'REDO' }); }
+            else { dispatch({ type: 'UNDO' }); }
+            e.preventDefault();
+        }
+    });
+})();

--- a/Subnet-Calculator/includes/functions-tree.php
+++ b/Subnet-Calculator/includes/functions-tree.php
@@ -220,3 +220,302 @@ function tree_compute_gaps(string $parent, array $sorted_children): array
 
     return $gaps;
 }
+
+// ─── Tree-editor payload validation (#302, v3.0.0) ────────────────────────────
+
+/**
+ * Validate a tree-editor session payload against the rules locked in the
+ * 2026-05-03 design doc:
+ *
+ *  - root.cidr is a valid IPv4 or IPv6 CIDR with prefix.
+ *  - Each node's CIDR is canonical (host bits zeroed; for IPv6 also lower-case
+ *    compressed form).
+ *  - Each `children` array, if present, has 2..64 entries (matches schema).
+ *  - Every child is contained within its parent (network falls inside parent
+ *    and child prefix > parent prefix).
+ *  - Children are non-overlapping (gaps allowed; sibling-merge invariant).
+ *  - `name` ≤ 128 chars; `notes` ≤ 1024 chars.
+ *  - Tree depth ≤ 16.
+ *  - Total node count ≤ 1024.
+ *  - Whole tree is single-family (all-IPv4 or all-IPv6).
+ *
+ * Throws \InvalidArgumentException on the first rule violation.  The message
+ * is safe to surface in API responses (no PII, no stack info).
+ *
+ * @param array<string,mixed> $tree The full tree-session payload (with `type`
+ *                                   and `root` keys, as accepted by
+ *                                   POST /api/v1/sessions).
+ * @throws \InvalidArgumentException
+ */
+function tree_validate(array $tree): void
+{
+    if (($tree['type'] ?? null) !== 'tree') {
+        throw new \InvalidArgumentException('tree_validate: type must be "tree".');
+    }
+    if (!isset($tree['root']) || !is_array($tree['root'])) {
+        throw new \InvalidArgumentException('tree_validate: root must be an object.');
+    }
+
+    $count = 0;
+    $family = tree_node_family($tree['root']);
+    tree_validate_node($tree['root'], null, $family, 0, $count);
+}
+
+/**
+ * Detect whether the root node CIDR is IPv4 or IPv6.
+ * Throws if the root CIDR is malformed.
+ *
+ * @param array<string,mixed> $node
+ * @return 'ipv4'|'ipv6'
+ */
+function tree_node_family(array $node): string
+{
+    if (!isset($node['cidr']) || !is_string($node['cidr'])) {
+        throw new \InvalidArgumentException('tree_validate: root.cidr is required.');
+    }
+    if (strpos($node['cidr'], ':') !== false) {
+        return 'ipv6';
+    }
+    return 'ipv4';
+}
+
+/**
+ * Recursive node validator.  Mutates $count by reference for the global cap.
+ *
+ * @param array<string,mixed>      $node
+ * @param array<string,mixed>|null $parent
+ * @param 'ipv4'|'ipv6'            $family
+ */
+function tree_validate_node(array $node, ?array $parent, string $family, int $depth, int &$count): void
+{
+    $count++;
+    if ($count > 1024) {
+        throw new \InvalidArgumentException('tree_validate: total node count exceeds 1024.');
+    }
+    if ($depth > 16) {
+        throw new \InvalidArgumentException('tree_validate: tree depth exceeds 16.');
+    }
+    if (!isset($node['cidr']) || !is_string($node['cidr'])) {
+        throw new \InvalidArgumentException('tree_validate: every node requires a string cidr.');
+    }
+
+    $cidr = $node['cidr'];
+    [$ip, $px] = tree_split_cidr($cidr, $family);
+
+    // Canonical-form check + family-mismatch rejection.
+    $canonical = tree_canonical_cidr($ip, $px, $family);
+    if ($canonical !== $cidr) {
+        throw new \InvalidArgumentException(
+            'tree_validate: cidr "' . $cidr . '" is not canonical (expected "' . $canonical . '").'
+        );
+    }
+
+    // Containment: child must be inside parent, and child prefix > parent prefix.
+    if ($parent !== null) {
+        [$pip, $ppx] = tree_split_cidr((string)$parent['cidr'], $family);
+        if ($px <= $ppx) {
+            throw new \InvalidArgumentException(
+                'tree_validate: child "' . $cidr . '" prefix /' . $px
+                . ' must be longer than parent /' . $ppx . '.'
+            );
+        }
+        if (!tree_contains($pip, $ppx, $ip, $family)) {
+            throw new \InvalidArgumentException(
+                'tree_validate: child "' . $cidr . '" is not inside parent "' . $parent['cidr'] . '".'
+            );
+        }
+    }
+
+    // String length caps for name / notes.
+    if (isset($node['name'])) {
+        if (!is_string($node['name'])) {
+            throw new \InvalidArgumentException('tree_validate: name must be a string.');
+        }
+        if (strlen($node['name']) > 128) {
+            throw new \InvalidArgumentException('tree_validate: name exceeds 128 characters.');
+        }
+    }
+    if (isset($node['notes'])) {
+        if (!is_string($node['notes'])) {
+            throw new \InvalidArgumentException('tree_validate: notes must be a string.');
+        }
+        if (strlen($node['notes']) > 1024) {
+            throw new \InvalidArgumentException('tree_validate: notes exceed 1024 characters.');
+        }
+    }
+
+    // Children: ≥2 entries, no overlaps, recursively validate.
+    if (isset($node['children'])) {
+        if (!is_array($node['children']) || count($node['children']) < 2) {
+            throw new \InvalidArgumentException(
+                'tree_validate: children of "' . $cidr . '" must be a list with at least 2 entries.'
+            );
+        }
+        if (count($node['children']) > 64) {
+            throw new \InvalidArgumentException(
+                'tree_validate: children of "' . $cidr . '" exceed 64 entries.'
+            );
+        }
+
+        $ranges = []; // [ [start_gmp_or_int, end_gmp_or_int, cidr_string] ]
+        foreach ($node['children'] as $child) {
+            if (!is_array($child)) {
+                throw new \InvalidArgumentException('tree_validate: each child must be an object.');
+            }
+            $cstr = isset($child['cidr']) && is_string($child['cidr']) ? $child['cidr'] : '?';
+            [$cip, $cpx] = tree_split_cidr($cstr, $family);
+            [$start, $end] = tree_range($cip, $cpx, $family);
+
+            // Overlap check against earlier siblings.
+            foreach ($ranges as $prev) {
+                if (tree_ranges_overlap($start, $end, $prev[0], $prev[1], $family)) {
+                    throw new \InvalidArgumentException(
+                        'tree_validate: child "' . $cstr . '" overlaps sibling "' . $prev[2] . '".'
+                    );
+                }
+            }
+            $ranges[] = [$start, $end, $cstr];
+
+            tree_validate_node($child, $node, $family, $depth + 1, $count);
+        }
+    }
+}
+
+/**
+ * Split "ip/prefix" and validate the IP belongs to the expected family.
+ *
+ * @return array{0:string,1:int}
+ */
+function tree_split_cidr(string $cidr, string $family): array
+{
+    $parts = explode('/', $cidr, 2);
+    if (count($parts) !== 2) {
+        throw new \InvalidArgumentException('tree_validate: cidr "' . $cidr . '" missing prefix.');
+    }
+    [$ip, $px_str] = $parts;
+    if ($px_str === '' || !ctype_digit($px_str)) {
+        throw new \InvalidArgumentException('tree_validate: cidr "' . $cidr . '" has non-numeric prefix.');
+    }
+    $px = (int)$px_str;
+
+    if ($family === 'ipv4') {
+        if (!is_valid_ipv4($ip)) {
+            throw new \InvalidArgumentException('tree_validate: cidr "' . $cidr . '" is not a valid IPv4 address.');
+        }
+        if ($px < 0 || $px > 32) {
+            throw new \InvalidArgumentException('tree_validate: IPv4 prefix /' . $px . ' out of range (0–32).');
+        }
+    } else {
+        if (!is_valid_ipv6($ip)) {
+            throw new \InvalidArgumentException('tree_validate: cidr "' . $cidr . '" is not a valid IPv6 address.');
+        }
+        if ($px < 0 || $px > 128) {
+            throw new \InvalidArgumentException('tree_validate: IPv6 prefix /' . $px . ' out of range (0–128).');
+        }
+    }
+    return [$ip, $px];
+}
+
+/**
+ * Canonical CIDR string: host bits zeroed; IPv6 lowercased + compressed via
+ * inet_ntop().
+ */
+function tree_canonical_cidr(string $ip, int $px, string $family): string
+{
+    if ($family === 'ipv4') {
+        $long = ip2long($ip);
+        if ($long === false) {
+            throw new \InvalidArgumentException('tree_validate: ip2long failed for "' . $ip . '".');
+        }
+        $mask = $px === 0 ? 0 : ((~0 << (32 - $px)) & 0xFFFFFFFF);
+        $net  = $long & $mask;
+        $canon = long2ip($net & 0xFFFFFFFF);
+        if (!is_string($canon)) {
+            throw new \InvalidArgumentException('tree_validate: long2ip failed.');
+        }
+        return $canon . '/' . $px;
+    }
+
+    // IPv6: zero host bits via GMP.
+    $bin = inet_pton($ip);
+    if ($bin === false) {
+        throw new \InvalidArgumentException('tree_validate: inet_pton failed for "' . $ip . '".');
+    }
+    $hex = bin2hex($bin);
+    $g = gmp_init($hex, 16);
+    if ($px < 128) {
+        $shift = 128 - $px;
+        $mask = gmp_mul(gmp_sub(gmp_pow(2, $px), 1), gmp_pow(2, $shift));
+    } else {
+        $mask = gmp_sub(gmp_pow(2, 128), 1);
+    }
+    $masked = gmp_and($g, $mask);
+    $hexOut = str_pad(gmp_strval($masked, 16), 32, '0', STR_PAD_LEFT);
+    $bin = hex2bin($hexOut);
+    if ($bin === false) {
+        throw new \InvalidArgumentException('tree_validate: hex2bin failed.');
+    }
+    $canon = inet_ntop($bin);
+    if (!is_string($canon)) {
+        throw new \InvalidArgumentException('tree_validate: inet_ntop failed.');
+    }
+    return $canon . '/' . $px;
+}
+
+/**
+ * Return the [start, end] inclusive numeric range covered by a CIDR, as
+ * either two ints (IPv4) or two GMP resources (IPv6).
+ *
+ * @return array{0:int|\GMP,1:int|\GMP}
+ */
+function tree_range(string $ip, int $px, string $family): array
+{
+    if ($family === 'ipv4') {
+        $long = ip2long($ip) & 0xFFFFFFFF;
+        $size = $px === 32 ? 1 : (1 << (32 - $px));
+        return [$long, $long + $size - 1];
+    }
+    $g = ipv6_to_gmp($ip);
+    $size = gmp_pow(2, 128 - $px);
+    $end = gmp_sub(gmp_add($g, $size), 1);
+    return [$g, $end];
+}
+
+/**
+ * True when parent (pip/ppx) contains child IP.
+ */
+function tree_contains(string $pip, int $ppx, string $cip, string $family): bool
+{
+    if ($family === 'ipv4') {
+        $pmask = $ppx === 0 ? 0 : ((~0 << (32 - $ppx)) & 0xFFFFFFFF);
+        $pnet  = ip2long($pip) & $pmask;
+        $cnet  = ip2long($cip) & $pmask;
+        return $pnet === $cnet;
+    }
+    $pg = ipv6_to_gmp($pip);
+    $cg = ipv6_to_gmp($cip);
+    if ($ppx === 0) {
+        return true;
+    }
+    $shift = 128 - $ppx;
+    $mask = gmp_mul(gmp_sub(gmp_pow(2, $ppx), 1), gmp_pow(2, $shift));
+    return gmp_cmp(gmp_and($pg, $mask), gmp_and($cg, $mask)) === 0;
+}
+
+/**
+ * @param int|\GMP $a_start
+ * @param int|\GMP $a_end
+ * @param int|\GMP $b_start
+ * @param int|\GMP $b_end
+ */
+function tree_ranges_overlap($a_start, $a_end, $b_start, $b_end, string $family): bool
+{
+    if ($family === 'ipv4') {
+        return !($a_end < $b_start || $b_end < $a_start);
+    }
+    /** @var \GMP $a_start */
+    /** @var \GMP $a_end */
+    /** @var \GMP $b_start */
+    /** @var \GMP $b_end */
+    return !(gmp_cmp($a_end, $b_start) < 0 || gmp_cmp($b_end, $a_start) < 0);
+}

--- a/Subnet-Calculator/includes/functions-tree.php
+++ b/Subnet-Calculator/includes/functions-tree.php
@@ -257,8 +257,10 @@ function tree_validate(array $tree): void
     }
 
     $count = 0;
-    $family = tree_node_family($tree['root']);
-    tree_validate_node($tree['root'], null, $family, 0, $count);
+    /** @var array<string,mixed> $root */
+    $root = $tree['root'];
+    $family = tree_node_family($root);
+    tree_validate_node($root, null, $family, 0, $count);
 }
 
 /**
@@ -312,7 +314,8 @@ function tree_validate_node(array $node, ?array $parent, string $family, int $de
 
     // Containment: child must be inside parent, and child prefix > parent prefix.
     if ($parent !== null) {
-        [$pip, $ppx] = tree_split_cidr((string)$parent['cidr'], $family);
+        $parent_cidr = isset($parent['cidr']) && is_string($parent['cidr']) ? $parent['cidr'] : '';
+        [$pip, $ppx] = tree_split_cidr($parent_cidr, $family);
         if ($px <= $ppx) {
             throw new \InvalidArgumentException(
                 'tree_validate: child "' . $cidr . '" prefix /' . $px
@@ -321,7 +324,7 @@ function tree_validate_node(array $node, ?array $parent, string $family, int $de
         }
         if (!tree_contains($pip, $ppx, $ip, $family)) {
             throw new \InvalidArgumentException(
-                'tree_validate: child "' . $cidr . '" is not inside parent "' . $parent['cidr'] . '".'
+                'tree_validate: child "' . $cidr . '" is not inside parent "' . $parent_cidr . '".'
             );
         }
     }

--- a/Subnet-Calculator/templates/_tree_editor.php
+++ b/Subnet-Calculator/templates/_tree_editor.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tree-editor partial (#302, v3.0.0 PR3b).
+ *
+ * Rendered inside the IPv4 Tools drawer as a `<div class="tool-panel"
+ * data-tool="tree-editor">`.  All editing state lives client-side; this
+ * partial provides only the static markup that app.js attaches behaviour to.
+ *
+ * Variables expected from request.php / layout.php:
+ *   $tree_editor_initial_cidr (string, may be empty)
+ *
+ * @var string $tree_editor_initial_cidr
+ */
+?>
+<div class="overlap-panel tree-editor-panel">
+    <div class="overlap-title">Subnet Tree Editor<?= help_bubble('tree-editor', 'Interactive subnet planner. Click a node to split it. Drag onto a sibling to merge. Edits autosave to your browser; use Save Session to share across devices.') ?></div>
+
+    <form id="tree-editor-init" class="tree-editor-init">
+        <label for="tree_editor_cidr" class="tree-parent-label">Root CIDR</label>
+        <input type="text" id="tree_editor_cidr" name="tree_editor_cidr"
+               value="<?= htmlspecialchars($tree_editor_initial_cidr ?? '') ?>"
+               placeholder="10.0.0.0/24" autocomplete="off" spellcheck="false">
+        <button type="submit" class="splitter-btn">Start Editing</button>
+    </form>
+
+    <div class="tree-editor" hidden aria-live="polite">
+        <div class="tree-editor-toolbar" role="toolbar" aria-label="Tree editor controls">
+            <button type="button" class="tree-editor-btn" data-action="undo" aria-label="Undo (Ctrl+Z)" title="Undo (Ctrl+Z)" disabled>Undo</button>
+            <button type="button" class="tree-editor-btn" data-action="redo" aria-label="Redo (Ctrl+Shift+Z)" title="Redo (Ctrl+Shift+Z)" disabled>Redo</button>
+            <span class="tree-editor-spacer"></span>
+            <button type="button" class="tree-editor-btn" data-action="save-session">Save Session</button>
+            <button type="button" class="tree-editor-btn" data-action="copy-cidr">Copy CIDR</button>
+            <button type="button" class="tree-editor-btn" data-action="copy-md">Copy Markdown</button>
+            <button type="button" class="tree-editor-btn" data-action="copy-cisco">Copy Cisco</button>
+            <button type="button" class="tree-editor-btn" data-action="download-csv">CSV</button>
+            <button type="button" class="tree-editor-btn" data-action="download-json">JSON</button>
+            <button type="button" class="tree-editor-btn" data-action="share-url">Share URL</button>
+            <span class="tree-editor-spacer"></span>
+            <button type="button" class="tree-editor-btn tree-editor-btn-danger" data-action="reset">Reset</button>
+        </div>
+
+        <div class="tree-editor-status" data-role="status" aria-live="polite"></div>
+        <div class="tree-editor-canvas" data-role="canvas"></div>
+        <div class="tree-editor-share" data-role="share" hidden>
+            <span class="tree-editor-share-label">Share</span>
+            <code class="tree-editor-share-url" data-role="share-url"></code>
+            <button type="button" class="tree-editor-share-copy" data-action="copy-share">Copy</button>
+        </div>
+    </div>
+
+    <!-- Split picker modal -->
+    <div class="tree-modal" data-role="split-modal" role="dialog" aria-modal="true" aria-labelledby="tree-split-title" hidden>
+        <div class="tree-modal-backdrop" data-role="split-cancel"></div>
+        <div class="tree-modal-card">
+            <h3 id="tree-split-title">Split <span data-role="split-cidr"></span></h3>
+            <p class="tree-modal-help">Choose how many equal children to create.</p>
+            <div class="tree-modal-actions">
+                <button type="button" class="splitter-btn" data-split-into="2">2</button>
+                <button type="button" class="splitter-btn" data-split-into="4">4</button>
+                <button type="button" class="splitter-btn" data-split-into="8">8</button>
+                <button type="button" class="splitter-btn" data-split-into="16">16</button>
+            </div>
+            <button type="button" class="tree-modal-cancel" data-role="split-cancel">Cancel</button>
+        </div>
+    </div>
+
+    <!-- Rename / notes modal -->
+    <div class="tree-modal" data-role="rename-modal" role="dialog" aria-modal="true" aria-labelledby="tree-rename-title" hidden>
+        <div class="tree-modal-backdrop" data-role="rename-cancel"></div>
+        <div class="tree-modal-card">
+            <h3 id="tree-rename-title">Edit <span data-role="rename-cidr"></span></h3>
+            <label class="tree-modal-label">
+                Name
+                <input type="text" data-role="rename-name" maxlength="128" autocomplete="off" spellcheck="false">
+            </label>
+            <label class="tree-modal-label">
+                Notes
+                <textarea data-role="rename-notes" maxlength="1024" rows="3" autocomplete="off" spellcheck="false"></textarea>
+            </label>
+            <div class="tree-modal-actions">
+                <button type="button" class="splitter-btn" data-role="rename-save">Save</button>
+                <button type="button" class="tree-modal-cancel" data-role="rename-cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Mobile action sheet (touch only via @media (hover: none)) -->
+    <div class="tree-action-sheet" data-role="action-sheet" role="dialog" aria-modal="true" aria-labelledby="tree-sheet-title" hidden>
+        <div class="tree-modal-backdrop" data-role="sheet-cancel"></div>
+        <div class="tree-action-sheet-card">
+            <h3 id="tree-sheet-title">Node <span data-role="sheet-cidr"></span></h3>
+            <button type="button" class="tree-action-sheet-btn" data-sheet-action="split">Split</button>
+            <button type="button" class="tree-action-sheet-btn" data-sheet-action="merge">Merge with sibling</button>
+            <button type="button" class="tree-action-sheet-btn" data-sheet-action="rename">Rename / Notes</button>
+            <button type="button" class="tree-action-sheet-btn tree-action-sheet-btn-cancel" data-role="sheet-cancel">Cancel</button>
+        </div>
+    </div>
+</div>

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -255,6 +255,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="supernet" aria-expanded="false">Supernet</button>
             <button type="button" class="tool-trigger" data-tool="range" aria-expanded="false">Range&rarr;CIDR</button>
             <button type="button" class="tool-trigger" data-tool="tree" aria-expanded="false">Subnet Tree</button>
+            <button type="button" class="tool-trigger" data-tool="tree-editor" aria-expanded="false">Tree Editor</button>
             <button type="button" class="tool-trigger" data-tool="wildcard" aria-expanded="false">Wildcard&harr;CIDR</button>
             <button type="button" class="tool-trigger" data-tool="lookup" aria-expanded="false">IP Lookup</button>
             <button type="button" class="tool-trigger" data-tool="diff" aria-expanded="false">Subnet Diff</button>
@@ -439,6 +440,13 @@ if ($i < 3) {
                         </div>
                     <?php endif; ?>
                 </div>
+            </div>
+
+            <div class="tool-panel" data-tool="tree-editor">
+                <?php
+                $tree_editor_initial_cidr = $result['cidr'] ?? '';
+                require __DIR__ . '/_tree_editor.php';
+                ?>
             </div>
 
             <div class="tool-panel" data-tool="wildcard">

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -50,6 +50,29 @@ The payload accepts a `type` discriminator (v3.0.0+):
 }
 ```
 
-`type` defaults to `'ipv4'` when omitted, so v2.x callers keep working unchanged. Allowed values: `'ipv4'`, `'ipv6'`, `'tree'` (the tree form is reserved for the v3.0.0 #302 interactive editor and lands in PR3).
+`type` defaults to `'ipv4'` when omitted, so v2.x callers keep working unchanged. Allowed values: `'ipv4'`, `'ipv6'`, `'tree'`.
+
+### `type: 'tree'` (v3.0.0+)
+
+The tree form is the persistence path for the [interactive Tree Editor](tree.md#interactive-tree-editor-v300). The payload mirrors the editor state directly:
+
+```json
+{
+  "payload": {
+    "type": "tree",
+    "root": {
+      "cidr": "10.0.0.0/16",
+      "name": "Corp HQ",
+      "notes": "WAN edge → distribution",
+      "children": [
+        {"cidr": "10.0.0.0/17", "name": "Production"},
+        {"cidr": "10.0.128.0/17", "name": "Lab"}
+      ]
+    }
+  }
+}
+```
+
+Server-side validation (`tree_validate()`) enforces canonical CIDR form (host bits zeroed; IPv6 lower-case compressed), containment (children fall inside their parent), non-overlap (siblings may have gaps but cannot overlap), `name` ≤128 / `notes` ≤1024 chars, tree depth ≤16, and total nodes ≤1024. Trees are single-family (all-IPv4 or all-IPv6).
 
 See [REST API](api.md#post-apiv1sessions) for curl examples.

--- a/docs/superpowers/plans/v3.0.0-living-doc.md
+++ b/docs/superpowers/plans/v3.0.0-living-doc.md
@@ -36,7 +36,7 @@ across 4 sessions, each owning one PR. Every session must:
 | **A** | PR1 — Foundations | #315, #312, #306, #307 | ✅ Merged (PR #317) | Largely backend; low UI risk |
 | **B** | PR2 — Admin hardening | #311, #313, #307 (matrix) | 🟡 In review (PR pending) | Auth-touching; needs careful review |
 | **C** | PR3a — Keyboard + history | #300, #301 | 🟡 In review (PR pending) | Split agreed: tree editor (#302) is its own PR3b |
-| **C₂** | PR3b — Tree editor | #302 | ⬜ Not started | Headline feature; depends on PR1 schema bump (already merged); follows design lock |
+| **C₂** | PR3b — Tree editor | #302 | 🟡 In review (PR pending) | Headline feature; depends on PR1 schema bump (already merged); follows design lock |
 | **D** | PR4 — Release cut | — | ⬜ Not started | Version bump, CHANGELOG, README, mkdocs, tarball, dev→main PR |
 
 After Session A, PR1 must be merged into `release/v3.0.0` before Session B starts
@@ -309,8 +309,112 @@ New gaps surfaced:
   targets — but it could theoretically conflict with a future button that wants to consume
   raw `H` keys. Not a concern in current UI.
 
-### Session C₂ — _date_ — PR3b Tree editor
-_(template — implements #302 against the locked design doc)_
+### Session C₂ — 2026-05-04 — PR3b Tree editor
+**PR:** _(open — see PR link stamped after merge)_ (open against `release/v3.0.0`)
+
+Implements #302 against the locked design doc
+(`2026-05-03-v3.0.0-tree-editor-design.md`). The design is a contract; this
+session implemented every section without deviating on the contract surface.
+
+Delivered:
+- **Server-side `tree_validate()`** — new helpers in `includes/functions-tree.php`
+  (`tree_validate`, `tree_node_family`, `tree_validate_node`, `tree_split_cidr`,
+  `tree_canonical_cidr`, `tree_range`, `tree_contains`, `tree_ranges_overlap`).
+  Enforces every rule from the design lock: canonical CIDR (host bits zeroed,
+  IPv6 lower-case compressed), containment with prefix > parent, non-overlapping
+  siblings (gaps allowed), `name` ≤128 / `notes` ≤1024, depth ≤16, total nodes
+  ≤1024, single-family per tree. PR1 left a stub on the `type: 'tree'` branch
+  in `api/v1/handlers/sessions.php`; this session replaced it with the real
+  `tree_validate()` invocation. PHPUnit: +19 cases (`TreeValidateTest`).
+- **Editor partial** — new `templates/_tree_editor.php` containing the toolbar,
+  canvas, split picker modal, rename modal, and mobile action sheet. Wired
+  into `templates/layout.php` as a new `tool-panel[data-tool="tree-editor"]`
+  on the IPv4 Tools drawer (added next to the existing read-only Subnet Tree
+  tool — they coexist).
+- **JS module** — appended ~676 LOC to `assets/app.js` as a self-contained
+  IIFE. Plain JS (no new deps); BigInt for unified IPv4 / IPv6 CIDR math.
+  Reducer with seven actions (SPLIT / MERGE / RENAME / UNDO / REDO / LOAD /
+  RESET); 300 ms-debounced autosave to `localStorage` under
+  `sc.tree.draft.<rootCidr>`; undo stack capped at 50; click-split picker;
+  desktop drag-merge with sibling-only check; rename modal with name + notes;
+  mobile action sheet gated on `@media (hover: none)` via `matchMedia`;
+  exports for CIDR list / Markdown / Cisco / CSV / JSON; share URL (base64url
+  JSON in `?tree=…`) with 50-node soft cap; Save Session POST to
+  `/api/v1/sessions`; `Ctrl/Cmd+Z` / `+Shift` keyboard handlers scoped to the
+  editor.
+- **CSS** — appended ~210 LOC to `assets/app.css` for the toolbar, node
+  cards (with depth-indented children via `--depth` custom property), modal
+  overlays, mobile action sheet, share-URL bar. All theming uses existing CSS
+  tokens — `--color-bg` and `--color-btn-text` were not touched.
+- **Playwright groups** — 10 new tests in `testing/scripts/playwright_test.py`:
+  split (root → 4 children), drag-merge, rename, Ctrl+Z undo, autosave
+  round-trip across reload, save session POST, share URL `?tree=…`, copy
+  formats (CIDR / Markdown / Cisco via `add_init_script` clipboard stub
+  installed with `Object.defineProperty` for robust insecure-HTTP override),
+  mobile action sheet (matchMedia override), share-URL too-large fallback.
+- **Docs** — `docs/tree.md` gained an "Interactive Tree Editor (v3.0.0+)"
+  section covering operations, persistence, exports, and mobile model.
+  `docs/sessions.md` gained a `type: 'tree'` subsection with the full payload
+  shape and the server validation contract.
+
+QA gates (all green on fresh containers):
+- PHPUnit: 325 / 664 / 14 skipped (was 306 / 636 — +19 TreeValidateTest cases)
+- PHPStan L9: clean
+- PHPCS PSR-12: clean on `includes/` and `api/`
+- Spectral OpenAPI lint: clean (no spec changes)
+- Semgrep (php + owasp + sql-injection): 0 findings on 52 files
+- ESLint + Stylelint: clean (warnings only — pre-existing pattern)
+- Playwright (docker, fresh containers): 840/840 (was 814 — +26 assertions across 10 new tests)
+
+Files added:
+- `Subnet-Calculator/templates/_tree_editor.php`
+- `testing/unit/TreeValidateTest.php`
+
+Files modified:
+- `Subnet-Calculator/includes/functions-tree.php` (+`tree_validate()` + helpers)
+- `Subnet-Calculator/api/v1/handlers/sessions.php` (real validation for `type=tree`)
+- `Subnet-Calculator/templates/layout.php` (new tool trigger + panel include)
+- `Subnet-Calculator/assets/app.js` (+676 LOC editor module)
+- `Subnet-Calculator/assets/app.css` (+210 LOC editor styles)
+- `testing/scripts/playwright_test.py` (10 new test groups)
+- `docs/tree.md` (interactive editor section)
+- `docs/sessions.md` (type:tree subsection)
+
+Deviations from the design lock:
+- **None on the contract surface.** The editor was added as a new Tools-drawer
+  panel on the IPv4 tab next to the existing read-only Subnet Tree tool rather
+  than replacing it — the design doc lists files to touch but does not require
+  removing the existing tool, and keeping both lets users build a tree from a
+  CIDR list AND interactively edit one in the same drawer.
+- **Single-family per tree was made an explicit `tree_validate()` rule.**
+  The design doc didn't call this out one way or the other; rejecting mixed
+  v4/v6 trees during validation seemed strictly safer than allowing them.
+
+New gaps surfaced:
+- **`.share-url` was a global CSS class collision risk.** The existing VLSM
+  share bar uses `.share-url`, and my first pass on the editor partial reused
+  the same class for the editor's share output. `test_vlsm_shareable_url`
+  matches the first `.share-url` on the page and silently returned the empty
+  editor element instead of the VLSM one. Fixed by namespacing the editor's
+  classes (`.tree-editor-share-*`). **Lesson:** before introducing a class
+  with a generic name (`.share-*`, `.copy-*`, `.modal-*`), grep the test
+  suite for that selector.
+- **The persistent docker webapp container leaks `api_keys` rows across runs.**
+  Admin tests mint keys; the cleanup test drains them; but if any test in
+  between crashes, the cleanup is skipped and the next run finds the open API
+  gated. The fix used here was `docker compose down -v` between runs. This
+  is pre-existing and not unique to PR3b — flagging it for a future test-rig
+  hardening pass (a `setUp` step that truncates `api_keys` would be cleaner).
+- **Schema-level `oneOf` validation is permissive on the tree branch.** PR1
+  intentionally left it that way to avoid a second schema bump mid-release;
+  `tree_validate()` is now the strict gate. If a future caller bypasses our
+  handler (e.g. writes directly to the SQLite store) the schema alone won't
+  catch overlap / containment violations. Acceptable for v3.0.0.
+- **No Playwright group for IPv6 trees.** All 10 groups exercise IPv4 paths;
+  v6 is exercised by `TreeValidateTest::testAcceptsIpv6NestedTwoLevels` and
+  `testRejectsIpv6NonCanonical` on the server side. A Playwright v6 group
+  would have added ~4 minutes to test-rig runtime for marginal incremental
+  coverage.
 
 ### Session D — _date_ — PR4 Release cut
 _(template — same shape as Session A; ends with merged dev→main PR + release tag)_

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -30,3 +30,46 @@ The tree shows:
 ## REST API
 
 `POST /api/v1/tree` — see [REST API](api.md#post-apiv1tree).
+
+## Interactive Tree Editor (v3.0.0+)
+
+The **Tree Editor** is a separate Tools-drawer panel on the IPv4 tab. It lets you
+build and edit a hierarchical subnet plan in your browser without round-tripping
+to the server for each edit.
+
+### Operations
+
+- **Click a node** to open the split picker; choose 2 / 4 / 8 / 16 equal children.
+- **Drag a node onto a sibling** (desktop) to merge the two back into the parent.
+- **Tap a node** on a touch device to open an action sheet with Split, Merge,
+  and Rename actions (drag-merge is disabled on touch).
+- **Click the pencil icon** on any node to set a name and free-form notes.
+- **`Ctrl/Cmd+Z`** undoes the last edit; **`Ctrl/Cmd+Shift+Z`** redoes it. The
+  undo stack is capped at 50 entries.
+
+### Persistence
+
+- **Autosave** — every edit is written to `localStorage` under
+  `sc.tree.draft.<rootCidr>` after a 300 ms debounce. Reloading the page
+  restores the in-progress tree.
+- **Save Session** — POSTs a `type: 'tree'` payload to `/api/v1/sessions`. The
+  returned 8-hex-char ID is appended to the page URL so you can bookmark it
+  or share it. Server-side validation runs `tree_validate()` (canonical-form
+  CIDR, containment, non-overlap with gaps allowed, name ≤128 / notes ≤1024,
+  depth ≤16, total nodes ≤1024).
+
+### Exports
+
+- **Copy as CIDR / Markdown / Cisco** — clipboard copies for the leaf set or
+  full annotated tree.
+- **CSV / JSON download** — CSV is lossy (one row per node, name + notes
+  flattened); JSON is the full lossless `type: 'tree'` payload.
+- **Share URL** — base64url-encodes the tree state into `?tree=…`. Soft-cap
+  is 50 nodes (~3 KB after encoding); above that, the editor prompts you to
+  Save Session and share the session URL instead.
+
+### Mobile
+
+The mobile interaction model is desktop-first with a touch fallback: on
+`@media (hover: none)` devices, tapping a node opens a bottom action sheet
+instead of the click-split picker, and drag-merge is disabled.

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -4509,6 +4509,202 @@ async def test_vlsm_keyboard_delete(page: Page) -> None:
     )
 
 
+async def _open_tree_editor(page: Page, root_cidr: str = "10.0.0.0/24") -> None:
+    """Open the IPv4 tab, expand the Tree Editor tool drawer, and start editing."""
+    await navigate(page, APP_URL)
+    await page.evaluate("() => localStorage.clear()")
+    await page.click("#panel-ipv4 .tool-trigger[data-tool='tree-editor']")
+    await page.wait_for_selector("#panel-ipv4 .tool-drawer.open")
+    await page.fill("#tree_editor_cidr", root_cidr)
+    await page.click("#tree-editor-init button[type='submit']")
+    await page.wait_for_selector(".tree-editor-canvas .tree-editor-card")
+
+
+async def test_tree_editor_split(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — split root into 4 children")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    await page.wait_for_selector("[data-role='split-modal']:not([hidden])")
+    await page.click("[data-split-into='4']")
+    cidrs = await page.evaluate(
+        "() => Array.from(document.querySelectorAll('.tree-editor-cidr')).map(e=>e.textContent)"
+    )
+    assert_eq("split /24 into 4 → 5 nodes total", str(len(cidrs)), "5")
+    assert_true("first child is 10.0.0.0/26", "10.0.0.0/26" in cidrs)
+    assert_true("last child is 10.0.0.192/26", "10.0.0.192/26" in cidrs)
+
+
+async def test_tree_editor_merge_via_drag(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — drag-merge sibling restores parent")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    await page.click("[data-split-into='2']")
+    # Verify split happened.
+    initial = await page.locator(".tree-editor-cidr").count()
+    assert_true("split occurred before merge", initial == 3)
+    # Drag first child onto second.
+    children = page.locator(".tree-editor-children .tree-editor-card")
+    src = await children.nth(0).bounding_box()
+    dst = await children.nth(1).bounding_box()
+    if src and dst:
+        await page.mouse.move(src["x"] + 5, src["y"] + 5)
+        await page.mouse.down()
+        await page.mouse.move(dst["x"] + 5, dst["y"] + 5, steps=5)
+        await page.mouse.up()
+    after = await page.locator(".tree-editor-cidr").count()
+    assert_eq("after drag-merge → 1 node remains", str(after), "1")
+
+
+async def test_tree_editor_rename(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — rename + notes persist")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-pencil")
+    await page.wait_for_selector("[data-role='rename-modal']:not([hidden])")
+    await page.fill("[data-role='rename-name']", "Corp HQ")
+    await page.fill("[data-role='rename-notes']", "edge router")
+    await page.click("[data-role='rename-save']")
+    name = await page.locator(".tree-editor-name").first.text_content()
+    notes = await page.locator(".tree-editor-notes").first.text_content()
+    assert_eq("name renders", name, "Corp HQ")
+    assert_eq("notes render", notes, "edge router")
+
+
+async def test_tree_editor_undo(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — Ctrl+Z reverts last edit")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    await page.click("[data-split-into='2']")
+    assert_true("split happened", await page.locator(".tree-editor-cidr").count() == 3)
+    await page.locator(".tree-editor-canvas").click()  # focus inside editor
+    await page.keyboard.press("Control+z")
+    after = await page.locator(".tree-editor-cidr").count()
+    assert_eq("after undo → 1 node", str(after), "1")
+
+
+async def test_tree_editor_autosave_round_trip(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — localStorage autosave restores on reload")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    await page.click("[data-split-into='2']")
+    # autosave is debounced 300 ms.
+    await page.wait_for_timeout(400)
+    stored = await page.evaluate("() => localStorage.getItem('sc.tree.draft.10.0.0.0/24')")
+    assert_true("autosave wrote a draft", stored is not None and "10.0.0.0/25" in stored)
+    # Reload and verify the editor restores from autosave.
+    await navigate(page, APP_URL)
+    await page.click("#panel-ipv4 .tool-trigger[data-tool='tree-editor']")
+    await page.fill("#tree_editor_cidr", "10.0.0.0/24")
+    await page.click("#tree-editor-init button[type='submit']")
+    await page.wait_for_selector(".tree-editor-canvas .tree-editor-card")
+    cidrs = await page.evaluate(
+        "() => Array.from(document.querySelectorAll('.tree-editor-cidr')).map(e=>e.textContent)"
+    )
+    assert_true("reload: split children present", "10.0.0.0/25" in cidrs and "10.0.0.128/25" in cidrs)
+
+
+async def test_tree_editor_save_session(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — Save Session POSTs and returns id")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    await page.click("[data-split-into='2']")
+    await page.click("[data-action='save-session']")
+    # status banner shows "Saved as session XXXXXXXX".
+    await page.wait_for_function(
+        "() => /Saved as session [0-9a-f]{8}/.test(document.querySelector('.tree-editor-status').textContent || '')",
+        timeout=5000,
+    )
+    status = await page.locator(".tree-editor-status").text_content()
+    assert_true("save status surfaces session id", bool(status) and "Saved as session" in (status or ""))
+
+
+async def test_tree_editor_share_url(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — Share URL emits ?tree=… and is copyable")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    await page.click("[data-split-into='2']")
+    # Stub clipboard so the test never depends on a real clipboard surface.
+    await page.add_init_script(
+        "window.__lastClipboard = null; "
+        "navigator.clipboard = navigator.clipboard || {}; "
+        "navigator.clipboard.writeText = function(t){ window.__lastClipboard = t; return Promise.resolve(); };"
+    )
+    await page.click("[data-action='share-url']")
+    share_url = await page.locator("[data-role='share-url']").text_content()
+    assert_true("share URL contains ?tree=", bool(share_url) and "tree=" in (share_url or ""))
+
+
+async def test_tree_editor_copy_formats(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — copy CIDR / Markdown / Cisco")
+    # Install clipboard stub BEFORE app.js boots. On insecure HTTP
+    # (test rig) navigator.clipboard is undefined and a plain assignment
+    # is silently swallowed; defineProperty with configurable:true wins.
+    await page.add_init_script(
+        "window.__clip = [];"
+        "try {"
+        "  Object.defineProperty(navigator, 'clipboard', {"
+        "    value: { writeText: function(t){ window.__clip.push(t); return Promise.resolve(); } },"
+        "    configurable: true,"
+        "    writable: true"
+        "  });"
+        "} catch (e) {}"
+    )
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    await page.click("[data-split-into='2']")
+    await page.click("[data-action='copy-cidr']")
+    await page.click("[data-action='copy-md']")
+    await page.click("[data-action='copy-cisco']")
+    captured = await page.evaluate("() => window.__clip || []")
+    assert_eq("3 clipboard payloads recorded", str(len(captured)), "3")
+    assert_true("CIDR list contains /25 children", "10.0.0.0/25" in captured[0] and "10.0.0.128/25" in captured[0])
+    assert_true("Markdown export starts with heading", captured[1].startswith("# Subnet Plan"))
+    assert_true("Cisco export contains interface stanza", "interface XX" in captured[2])
+
+
+async def test_tree_editor_action_sheet_on_touch(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — action sheet appears on touch (hover:none)")
+    # Force the (hover:none) media-query branch to activate.
+    await page.emulate_media(reduced_motion=None)
+    # Playwright does not directly emulate hover:none, but matchMedia can be overridden
+    # via add_init_script — test the actual branch path.
+    await page.add_init_script(
+        "(() => { const orig = window.matchMedia.bind(window);"
+        " window.matchMedia = function(q){ if (q.indexOf('hover: none') !== -1) "
+        "{ return { matches: true, media: q, addListener:()=>{}, removeListener:()=>{}, "
+        "addEventListener:()=>{}, removeEventListener:()=>{}, onchange: null, dispatchEvent: ()=>true }; } "
+        "return orig(q); }; })();"
+    )
+    await _open_tree_editor(page, "10.0.0.0/24")
+    await page.click(".tree-editor-canvas .tree-editor-card")
+    visible = await page.locator("[data-role='action-sheet']").is_visible()
+    assert_true("touch: tap opens action sheet (not split modal)", visible)
+    split_visible = await page.locator("[data-role='split-modal']").is_visible()
+    assert_true("touch: split modal stays closed on initial tap", not split_visible)
+
+
+async def test_tree_editor_share_too_large_fallback(page: Page) -> None:
+    section("v3.0.0 #302 tree editor — share-URL fallback when >50 nodes")
+    await _open_tree_editor(page, "10.0.0.0/24")
+    # Inject a large fake state with >50 nodes via the public-ish localStorage path,
+    # then re-open the editor so it loads the autosave.
+    big_root = '{"cidr":"10.0.0.0/24","children":[' + ','.join(
+        ['{"cidr":"10.0.0.' + str(i) + '/32"}' for i in range(0, 60)]
+    ) + ']}'
+    await page.evaluate(f"() => localStorage.setItem('sc.tree.draft.10.0.0.0/24', {big_root!r})")
+    await navigate(page, APP_URL)
+    await page.click("#panel-ipv4 .tool-trigger[data-tool='tree-editor']")
+    await page.fill("#tree_editor_cidr", "10.0.0.0/24")
+    await page.click("#tree-editor-init button[type='submit']")
+    await page.wait_for_selector(".tree-editor-canvas .tree-editor-card")
+    await page.click("[data-action='share-url']")
+    status = await page.locator(".tree-editor-status").text_content()
+    assert_true(
+        "share-url too-large fallback message surfaces",
+        bool(status) and "too large" in (status or "").lower(),
+        str(status),
+    )
+
+
 async def test_v290_typography(page: Page) -> None:
     """v2.9.0: Verify Space Grotesk, Plus Jakarta Sans, and Fira Code are loaded."""
     section("v2.9.0 — typography verification")
@@ -4764,6 +4960,17 @@ async def main() -> None:
             await test_history_opt_in_records_calculation(page)
             await test_history_clear_removes_entries(page)
             await test_history_h_key_opens(page)
+            # v3.0.0 PR3b — interactive subnet tree editor (#302)
+            await test_tree_editor_split(page)
+            await test_tree_editor_merge_via_drag(page)
+            await test_tree_editor_rename(page)
+            await test_tree_editor_undo(page)
+            await test_tree_editor_autosave_round_trip(page)
+            await test_tree_editor_save_session(page)
+            await test_tree_editor_share_url(page)
+            await test_tree_editor_copy_formats(page)
+            await test_tree_editor_action_sheet_on_touch(page)
+            await test_tree_editor_share_too_large_fallback(page)
             await test_v290_typography(page)
         finally:
             await context.close()

--- a/testing/unit/TreeValidateTest.php
+++ b/testing/unit/TreeValidateTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validates tree_validate() — the server-side rule enforcement for
+ * `type: 'tree'` session payloads (v3.0.0, #302).
+ *
+ * The schema (vlsm-session.schema.json v2) is permissive on the tree branch
+ * because it has to coexist with v2 from PR1; the runtime contract is enforced
+ * by tree_validate() and exercised here.
+ */
+class TreeValidateTest extends TestCase
+{
+    /**
+     * @return array<string,mixed>
+     */
+    private function payload(array $root): array
+    {
+        return ['type' => 'tree', 'root' => $root];
+    }
+
+    public function testRejectsWrongType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        tree_validate(['type' => 'ipv4', 'root' => ['cidr' => '10.0.0.0/24']]);
+    }
+
+    public function testRejectsMissingRoot(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        tree_validate(['type' => 'tree']);
+    }
+
+    public function testAcceptsLeafIpv4(): void
+    {
+        tree_validate($this->payload(['cidr' => '10.0.0.0/24']));
+        $this->assertTrue(true); // no throw = pass
+    }
+
+    public function testAcceptsLeafIpv6(): void
+    {
+        tree_validate($this->payload(['cidr' => '2001:db8::/32']));
+        $this->assertTrue(true);
+    }
+
+    public function testAcceptsTwoChildren(): void
+    {
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'children' => [
+                ['cidr' => '10.0.0.0/25'],
+                ['cidr' => '10.0.0.128/25'],
+            ],
+        ]));
+        $this->assertTrue(true);
+    }
+
+    public function testAcceptsGapBetweenSiblings(): void
+    {
+        // Children may have gaps (intentional reserves) — the design lock allows this.
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'children' => [
+                ['cidr' => '10.0.0.0/26'],
+                ['cidr' => '10.0.0.192/26'],
+            ],
+        ]));
+        $this->assertTrue(true);
+    }
+
+    public function testRejectsSingleChild(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/at least 2/');
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'children' => [['cidr' => '10.0.0.0/25']],
+        ]));
+    }
+
+    public function testRejectsOverlappingSiblings(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/overlaps/');
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'children' => [
+                ['cidr' => '10.0.0.0/25'],
+                ['cidr' => '10.0.0.0/26'], // sub-range of sibling
+            ],
+        ]));
+    }
+
+    public function testRejectsChildOutsideParent(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/not inside parent/');
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'children' => [
+                ['cidr' => '10.0.0.0/25'],
+                ['cidr' => '10.0.1.0/25'], // outside /24
+            ],
+        ]));
+    }
+
+    public function testRejectsNonCanonicalCidr(): void
+    {
+        // Host bits set on the network address.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/canonical/');
+        tree_validate($this->payload(['cidr' => '10.0.0.5/24']));
+    }
+
+    public function testRejectsChildPrefixNotLongerThanParent(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/longer than parent/');
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'children' => [
+                ['cidr' => '10.0.0.0/24'], // same prefix as parent
+                ['cidr' => '10.0.1.0/24'],
+            ],
+        ]));
+    }
+
+    public function testRejectsInvalidCidr(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        tree_validate($this->payload(['cidr' => '999.0.0.0/24']));
+    }
+
+    public function testRejectsMissingPrefix(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        tree_validate($this->payload(['cidr' => '10.0.0.0']));
+    }
+
+    public function testRejectsNameTooLong(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/name exceeds/');
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'name' => str_repeat('a', 129),
+        ]));
+    }
+
+    public function testRejectsNotesTooLong(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/notes exceed/');
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'notes' => str_repeat('a', 1025),
+        ]));
+    }
+
+    public function testAcceptsNameAndNotesAtBoundary(): void
+    {
+        tree_validate($this->payload([
+            'cidr' => '10.0.0.0/24',
+            'name' => str_repeat('a', 128),
+            'notes' => str_repeat('a', 1024),
+        ]));
+        $this->assertTrue(true);
+    }
+
+    public function testRejectsTreeDepthExceeded(): void
+    {
+        // Build /1 → /2 → … → /17 — depth 17 must be rejected.
+        $node = ['cidr' => '0.0.0.0/17'];
+        for ($p = 16; $p >= 0; $p--) {
+            $node = [
+                'cidr' => '0.0.0.0/' . $p,
+                'children' => [
+                    $node,
+                    ['cidr' => tree_canonical_cidr_helper($p) . '/' . ($p + 1)],
+                ],
+            ];
+        }
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/depth exceeds/');
+        tree_validate(['type' => 'tree', 'root' => $node]);
+    }
+
+    public function testAcceptsIpv6NestedTwoLevels(): void
+    {
+        tree_validate($this->payload([
+            'cidr' => '2001:db8::/32',
+            'children' => [
+                [
+                    'cidr' => '2001:db8::/33',
+                    'children' => [
+                        ['cidr' => '2001:db8::/34'],
+                        ['cidr' => '2001:db8:4000::/34'],
+                    ],
+                ],
+                ['cidr' => '2001:db8:8000::/33'],
+            ],
+        ]));
+        $this->assertTrue(true);
+    }
+
+    public function testRejectsIpv6NonCanonical(): void
+    {
+        // Uppercase + uncompressed.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/canonical/');
+        tree_validate($this->payload(['cidr' => '2001:DB8:0:0:0:0:0:0/32']));
+    }
+}
+
+/**
+ * Helper for the depth test — produces the second sibling's network
+ * address at prefix p+1 (the upper half of /p).
+ */
+function tree_canonical_cidr_helper(int $parent_prefix): string
+{
+    if ($parent_prefix < 0) {
+        $parent_prefix = 0;
+    }
+    if ($parent_prefix >= 32) {
+        return '0.0.0.0';
+    }
+    $bit = 1 << (31 - $parent_prefix);
+    return long2ip($bit) ?: '0.0.0.0';
+}


### PR DESCRIPTION
## Summary

PR3b of the v3.0.0 release: interactive subnet tree editor (#302). Implements the
[locked design](../blob/release/v3.0.0/docs/superpowers/plans/2026-05-03-v3.0.0-tree-editor-design.md)
without deviating on the contract surface.

## What ships

- **Editor panel** on the IPv4 Tools drawer (next to the existing read-only Subnet Tree
  tool — they coexist):
  - click-split picker (2/4/8/16 children)
  - drag-merge between siblings (desktop)
  - inline rename + notes
  - undo / redo (`Ctrl/Cmd+Z`, `+Shift`; 50-deep stack)
  - 300 ms-debounced `localStorage` autosave under `sc.tree.draft.<rootCidr>`
  - exports: copy CIDR / Markdown / Cisco; CSV (lossy) / JSON (lossless) download;
    base64url share URL (`?tree=…`) with 50-node soft cap
  - Save Session: POST to `/api/v1/sessions` with `type: 'tree'`
  - mobile: `@media (hover: none)` opens an action sheet on tap; drag-merge disabled
  - plain JS (~676 LOC), no new runtime deps; BigInt for unified IPv4/IPv6 CIDR math

- **Server `tree_validate()`** in `functions-tree.php` enforces every rule from the
  design lock §"Session schema" — canonical CIDR form, containment, sibling
  non-overlap (gaps allowed), `name` ≤128 / `notes` ≤1024, depth ≤16, total nodes ≤1024,
  single-family. PR1 left a stub on the `type: 'tree'` branch in
  `api/v1/handlers/sessions.php`; this PR replaces it with the real validator.

- **Tests:** +19 PHPUnit cases (`TreeValidateTest`); +10 Playwright groups (split,
  drag-merge, rename, Ctrl+Z undo, autosave round-trip across reload, save session,
  share URL, copy formats with `add_init_script` clipboard stub, mobile action sheet
  via `matchMedia` override, share-URL too-large fallback).

- **Docs:** `docs/tree.md` gained "Interactive Tree Editor (v3.0.0+)";
  `docs/sessions.md` gained the `type: 'tree'` payload subsection.

## QA gates (fresh containers)

| Gate | Result |
|---|---|
| PHPUnit | 325 / 664 / 14 skipped (was 306) |
| PHPStan L9 | clean |
| PHPCS PSR-12 | clean (`includes/` + `api/`) |
| Spectral OpenAPI | clean (no spec changes) |
| Semgrep (php + owasp + sql-injection) | 0 findings on 52 files |
| ESLint + Stylelint | clean (warnings are pre-existing pattern) |
| Playwright (docker) | **840 / 840** (was 814 — +26 assertions across 10 new tests) |

## Deviations from the design lock

- **None on the contract surface.** Editor coexists with the existing read-only
  Subnet Tree tool rather than replacing it (lets users build a tree from a CIDR list
  *and* interactively edit one in the same drawer).
- **Single-family per tree** was made explicit in `tree_validate()` (the design doc
  didn't specify either way; rejecting mixed v4/v6 trees seemed strictly safer).

## New gaps surfaced (logged in living-doc)

- **`.share-url` global class collision** caught during integration testing — the
  editor's first-pass partial reused the existing VLSM `.share-url` class and silently
  broke `test_vlsm_shareable_url`. Fixed by namespacing to `.tree-editor-share-*`.
  Lesson: grep the test suite before introducing new classes with generic names.
- **Persistent docker webapp container leaks `api_keys` rows** if any test crashes
  before the admin cleanup test runs, gating the open API on subsequent runs. Pre-existing,
  not introduced by this PR. Workaround: `docker compose down -v` between runs.
- **No Playwright group for IPv6 trees.** v6 is exercised by PHPUnit
  (`testAcceptsIpv6NestedTwoLevels`, `testRejectsIpv6NonCanonical`).

## Test plan

- [ ] Open the IPv4 tab → Tools → "Tree Editor"
- [ ] Enter `10.0.0.0/24` → Start Editing
- [ ] Click root → choose 4 → see 4 `/26` children
- [ ] Click pencil → set name + notes → save → verify rendered
- [ ] Drag one child onto its sibling → verify merge restores parent
- [ ] `Ctrl+Z` → verify last edit reverted
- [ ] Reload the page → verify autosave restored
- [ ] Save Session → verify session ID in URL
- [ ] Share URL → verify `?tree=…` opens identical state in a new tab
- [ ] Copy as CIDR / Markdown / Cisco → verify clipboard
- [ ] CSV / JSON download → verify file contents
- [ ] On a touch device (or DevTools mobile emulation), tap a node → verify action sheet

After this PR merges, only **PR4 (release cut)** remains for v3.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)