### PR TITLE
feat(v3.1.0): #321 IPv6 VLSM save-session drawer parity

### DIFF
--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -1362,47 +1362,69 @@ if ($i < 3) {
             <?php endif; ?>
         <?php endif; ?>
 
-        <?php if ($session_enabled && $active_tab === 'vlsm6') : ?>
-        <!-- v3.0.0 (#315) IPv6 VLSM session save / load -->
-        <div class="vlsm6-session-controls" id="vlsm6-session-controls">
-            <div class="overlap-title">Save &amp; Restore IPv6 Session<?= help_bubble('vlsm6-session', 'Saves your IPv6 VLSM inputs to the server so you can restore them later via a short link. Sessions expire after the configured TTL.') ?></div>
-            <p class="session-ttl-notice">Saved sessions expire after <?= (int)$session_ttl_days ?> day<?= (int)$session_ttl_days === 1 ? '' : 's' ?>.</p>
-            <?php if ($session_save_id !== '' && $active_tab === 'vlsm6') : ?>
-                <div class="overlap-result overlap-contains share-bar session-saved-bar">
-                    <span class="share-label">Session saved. Share this link:</span>
-                    <code class="share-url"><?= htmlspecialchars($share_base_server . $session_save_url) ?></code>
-                    <button type="button" class="share-copy"
-                            data-copy="<?= htmlspecialchars($session_save_url) ?>">Copy</button>
-                </div>
-            <?php endif; ?>
-            <?php if ($session_error && $active_tab === 'vlsm6') : ?>
-                <div class="error"><?= htmlspecialchars($session_error) ?></div>
-            <?php endif; ?>
-            <div class="session-forms">
-                <?php if ($vlsm6_requirements !== []) : ?>
-                <form method="post" novalidate>
-                    <input type="hidden" name="tab" value="vlsm6">
-                    <input type="hidden" name="session_type" value="ipv6">
-                    <input type="hidden" name="vlsm6_network" value="<?= htmlspecialchars($vlsm6_network) ?>">
-                    <input type="hidden" name="vlsm6_cidr" value="<?= htmlspecialchars($vlsm6_cidr_input) ?>">
-                    <?php foreach ($vlsm6_requirements as $req6s) : ?>
-                        <input type="hidden" name="vlsm6_name[]"  value="<?= htmlspecialchars($req6s['name']) ?>">
-                        <input type="hidden" name="vlsm6_hosts[]" value="<?= htmlspecialchars((string)$req6s['hosts']) ?>">
-                    <?php endforeach; ?>
-                    <button type="submit" name="session_action" value="save" class="splitter-btn">Save Session</button>
-                </form>
-                <?php endif; ?>
-                <form method="get" novalidate>
-                    <div class="overlap-inputs">
-                        <input type="hidden" name="tab" value="vlsm6">
-                        <input type="text" name="s"
-                               value="<?= htmlspecialchars($session_load_id) ?>"
-                               placeholder="8-char session ID"
-                               autocomplete="off" spellcheck="false" maxlength="8"
-                               aria-label="Session ID">
-                        <button type="submit" class="splitter-btn">Load</button>
+        <?php
+        // v3.1.0 (#321) — IPv6 VLSM Save Session moved into the tool-drawer
+        // pattern to match the IPv4 VLSM tab. Auto-open the session6 drawer
+        // after a successful save (or session error) on the vlsm6 tab.
+        $open_tool_vlsm6 = null;
+        if ($session_enabled && $active_tab === 'vlsm6'
+            && ($session_save_id !== '' || $session_error !== null)) {
+            $open_tool_vlsm6 = 'session6';
+        }
+        ?>
+        <?php if ($session_enabled) : ?>
+        <div class="tool-toolbar"<?= $open_tool_vlsm6 ? ' data-open-tool="' . htmlspecialchars($open_tool_vlsm6) . '"' : '' ?>>
+            <button type="button" class="tool-trigger" data-tool="session6" aria-expanded="false">Save Session</button>
+        </div>
+
+        <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-vlsm6">
+            <div class="tool-drawer-header">
+                <span class="tool-drawer-title" id="drawer-title-vlsm6">Tool</span>
+                <button type="button" class="tool-drawer-close" aria-label="Close">&times;</button>
+            </div>
+
+            <div class="tool-panel" data-tool="session6">
+                <div class="overlap-panel">
+                    <div class="overlap-title">Save &amp; Restore IPv6 Session<?= help_bubble('vlsm6-session', 'Saves your IPv6 VLSM inputs to the server so you can restore them later via a short link. Sessions expire after the configured TTL.') ?></div>
+                    <p class="session-ttl-notice">Saved sessions expire after <?= (int)$session_ttl_days ?> day<?= (int)$session_ttl_days === 1 ? '' : 's' ?>.</p>
+                    <?php if ($session_save_id !== '' && $active_tab === 'vlsm6') : ?>
+                        <div class="overlap-result overlap-contains share-bar session-saved-bar">
+                            <span class="share-label">Session saved. Share this link:</span>
+                            <code class="share-url"><?= htmlspecialchars($share_base_server . $session_save_url) ?></code>
+                            <button type="button" class="share-copy"
+                                    data-copy="<?= htmlspecialchars($session_save_url) ?>">Copy</button>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($session_error && $active_tab === 'vlsm6') : ?>
+                        <div class="error"><?= htmlspecialchars($session_error) ?></div>
+                    <?php endif; ?>
+                    <div class="session-forms">
+                        <?php if ($vlsm6_requirements !== []) : ?>
+                        <form method="post" novalidate>
+                            <input type="hidden" name="tab" value="vlsm6">
+                            <input type="hidden" name="session_type" value="ipv6">
+                            <input type="hidden" name="vlsm6_network" value="<?= htmlspecialchars($vlsm6_network) ?>">
+                            <input type="hidden" name="vlsm6_cidr" value="<?= htmlspecialchars($vlsm6_cidr_input) ?>">
+                            <?php foreach ($vlsm6_requirements as $req6s) : ?>
+                                <input type="hidden" name="vlsm6_name[]"  value="<?= htmlspecialchars($req6s['name']) ?>">
+                                <input type="hidden" name="vlsm6_hosts[]" value="<?= htmlspecialchars((string)$req6s['hosts']) ?>">
+                            <?php endforeach; ?>
+                            <button type="submit" name="session_action" value="save" class="splitter-btn">Save Session</button>
+                        </form>
+                        <?php endif; ?>
+                        <form method="get" novalidate>
+                            <div class="overlap-inputs">
+                                <input type="hidden" name="tab" value="vlsm6">
+                                <input type="text" name="s"
+                                       value="<?= htmlspecialchars($session_load_id) ?>"
+                                       placeholder="8-char session ID"
+                                       autocomplete="off" spellcheck="false" maxlength="8"
+                                       aria-label="Session ID">
+                                <button type="submit" class="splitter-btn">Load</button>
+                            </div>
+                        </form>
                     </div>
-                </form>
+                </div>
             </div>
         </div>
         <?php endif; ?>

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,6 +1,6 @@
 # VLSM Sessions
 
-Session controls are available on **both the IPv4 VLSM tab** (in the Tool Drawer) **and the IPv6 VLSM tab** (in the Save & Restore IPv6 Session card under the results, v3.0.0+). They let you save your planner inputs and share them via a link.
+Session controls are available on **both the IPv4 VLSM tab and the IPv6 VLSM tab**, in each tab's Tool Drawer (v3.1.0+; the IPv6 drawer was previously an inline card and was unified with the IPv4 pattern in v3.1.0 / #321). They let you save your planner inputs and share them via a link.
 
 ## Saving
 

--- a/docs/superpowers/plans/v3.1.0-living-doc.md
+++ b/docs/superpowers/plans/v3.1.0-living-doc.md
@@ -41,7 +41,7 @@ last). Every session must:
 | **1** | #324 | Test rig drains admin state | ✅ Done 2026-05-04 | `admin/_test-drain.php` + Makefile/compose token plumbing; 847/847 fresh AND non-fresh |
 | **2** | #326 | PHPCS admin scope | ✅ Done 2026-05-04 | `.phpcs-admin.xml` ruleset; admin/ lint-clean; second CI step wired |
 | **3** | #325 | Audit purge strategy | ✅ Done 2026-05-04 | New `$admin_audit_purge_strategy` (`inline`/`sampled`/`cron`); `bin/sc-audit-purge.php` CLI for cron path |
-| **4** | #321 | IPv6 VLSM drawer parity | ⬜ Not started | Smallest UI; design-language gate |
+| **4** | PR4 | #321 IPv6 VLSM drawer parity | ✅ Done 2026-05-04 | Inline card → tool-drawer; ui-ux-pro-max pre/post clean |
 | **5** | #328 | Tab-switch focus ergonomics | ⬜ Not started | Smallest JS |
 | **6** | #327 | History capture parity | ⬜ Not started | Markup + JS, cross-cutting |
 | **7** | #322 | Multi-tree diff | ⬜ Not started | Large feature |
@@ -105,6 +105,91 @@ All must be green before opening a PR.
 ---
 
 ## Session log
+
+### Task 4 — 2026-05-04 — #321 IPv6 VLSM Save Session drawer parity
+**Status:** ✅ Done
+
+Delivered:
+- `Subnet-Calculator/templates/layout.php`: removed the bare inline
+  `<div class="vlsm6-session-controls" id="vlsm6-session-controls">` block
+  (was lines 1365-1408). Replaced in the same DOM position with the
+  `tool-toolbar` + `tool-drawer` + `tool-panel[data-tool="session6"]`
+  pattern that mirrors the IPv4 VLSM Save Session drawer. The toolbar
+  and drawer are wrapped in a single `<?php if ($session_enabled) : ?>`
+  guard because vlsm6 has no other triggers (rendering an empty toolbar
+  would be visual noise). Inner markup — `overlap-panel`, `overlap-title`
+  with `help_bubble`, `session-ttl-notice`, conditional `session-saved-bar`,
+  conditional `.error`, and the `session-forms` container with the POST
+  save form (hidden inputs unchanged) and GET load form — is moved
+  verbatim from the inline card into the `tool-panel`.
+- New auto-open hint computation `$open_tool_vlsm6` immediately above the
+  toolbar:
+  ```php
+  $open_tool_vlsm6 = null;
+  if ($session_enabled && $active_tab === 'vlsm6'
+      && ($session_save_id !== '' || $session_error !== null)) {
+      $open_tool_vlsm6 = 'session6';
+  }
+  ```
+  The `$active_tab` gate is required because `$session_save_id` is a
+  shared variable; without it an IPv4 save would also paint
+  `data-open-tool="session6"` on the inactive vlsm6 toolbar.
+- `request.php` — no changes needed. The IPv4 path's auto-open hint
+  is template-side, and mirroring it template-side for vlsm6 keeps the
+  request bootstrap pure.
+- `docs/sessions.md`: opening paragraph updated to note that the IPv6
+  drawer was unified with the IPv4 Tool Drawer pattern in v3.1.0/#321.
+- `testing/scripts/playwright_test.py`:
+  - New `test_vlsm6_session_drawer_pattern` (registered in `main()` next
+    to the other v3.1.0 tests, after `test_vlsm6_session_save_load`).
+    Asserts: trigger present + labelled "Save Session"; drawer element
+    present; click opens `.tool-drawer.open`; save button rendered
+    inside `.tool-panel[data-tool="session6"]`; post-save share URL
+    contains `?tab=vlsm6&s=<8-hex>`; trigger remains available after
+    a session-load GET; invalid `?tab=vlsm6&s=deadbeef` GET sets
+    `data-open-tool="session6"` on the toolbar (proves auto-open hint
+    flows from `$session_error`).
+  - Existing `test_vlsm6_session_save_load` updated: opens the drawer
+    via the trigger before clicking the save button (the panel is
+    `display:none` until the drawer is opened), and uses the new
+    drawer-scoped selectors instead of `#vlsm6-session-controls`.
+  - `test_session_forms_spacing` scoped to `#panel-vlsm` because vlsm6
+    now also renders a `.session-forms` container (strict-mode locator
+    resolution would otherwise fail).
+
+UI/UX gate:
+- `ui-ux-pro-max` consulted before AND after. Pre-edit spec captured
+  verbatim in the PR description (DOM byte-shape parity with IPv4
+  modulo `6` suffix, no new classes/tokens, single `<?php if ?>` wrap
+  rationale, ARIA mirror confirmed). Post-edit audit returned CLEAN
+  with no deviations: button placement, drawer markup parity, focus
+  order, visual breathing room, and style-guide compliance all match
+  the IPv4 Save Session drawer.
+
+Files added/modified:
+- M: `Subnet-Calculator/templates/layout.php`
+- M: `docs/sessions.md`
+- M: `testing/scripts/playwright_test.py`
+- M: `docs/superpowers/plans/v3.1.0-living-doc.md`
+
+QA gates:
+- `php -l Subnet-Calculator/templates/layout.php Subnet-Calculator/includes/request.php` — clean.
+- `vendor/bin/phpunit` — **330 tests, 678 assertions, 0 failures** (unchanged from Task 3 floor).
+- `phpstan analyse --memory-limit=512M` — `[OK] No errors`.
+- `vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/` — clean.
+- `vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/` — clean.
+- `npx @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml` — no errors.
+- `semgrep` on `includes/`, `api/`, `templates/`, `admin/` — 0 findings.
+- `npm run lint` — 5 pre-existing ESLint warnings (no errors), Stylelint clean.
+- **Acceptance test:** `make test-docker` → **863/863** passed (was 849;
+  +14 assertions for the new `test_vlsm6_session_drawer_pattern` group).
+
+Deviations from plan: None. Plan said wire `$open_tool_ipv6` and edit
+`request.php`; the cleaner mirror was a `$open_tool_vlsm6` template-side
+computation (the IPv4 equivalent `$open_tool_vlsm` is also template-side)
+so the request-bootstrap stays untouched. Same intent, less surface area.
+
+New gaps: None.
 
 ### Task 3 — 2026-05-04 — #325 audit purge strategy (sampled / inline / cron)
 **Status:** ✅ Done

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -2680,11 +2680,13 @@ async def test_session_forms_spacing(page: Page) -> None:
     section("VLSM session forms spacing")
     await navigate(page, APP_URL)
     await page.click("#tab-vlsm")
-    panel = await page.query_selector(".session-ttl-notice")
+    panel = await page.query_selector("#panel-vlsm .session-ttl-notice")
     if panel is None:
         ok("session forms spacing: sessions not enabled on this server (skipped)")
         return
-    forms = page.locator(".session-forms")
+    # v3.1.0 #321 — vlsm6 also renders .session-forms now; scope to the
+    # IPv4 VLSM panel so the locator resolves uniquely.
+    forms = page.locator("#panel-vlsm .session-forms")
     if await forms.count() == 0:
         ok("session forms spacing: .session-forms not found (skipped)")
         return
@@ -2704,19 +2706,35 @@ async def test_session_forms_spacing(page: Page) -> None:
 # ---------------------------------------------------------------------------
 
 async def test_vlsm6_session_save_load(page: Page) -> None:
-    section("v3.0.0 #315 IPv6 VLSM session save/load")
+    section("v3.0.0 #315 / v3.1.0 #321 IPv6 VLSM session save/load (drawer pattern)")
     # Calculate first so the Save Session form is populated.
     url = (APP_URL + "?tab=vlsm6&vlsm6_network=2001:db8::&vlsm6_cidr=32"
            + "&vlsm6_name%5B%5D=Site-A&vlsm6_hosts%5B%5D=256")
     await navigate(page, url)
-    panel = await page.query_selector("#vlsm6-session-controls")
+    # v3.1.0 #321 — session UI now lives inside the vlsm6 tool-drawer.
+    panel = await page.query_selector(
+        '#panel-vlsm6 .tool-panel[data-tool="session6"]'
+    )
     if panel is None:
         ok("vlsm6 session save/load: sessions not enabled on this server (skipped)")
         return
 
-    # Click "Save Session" inside the IPv6 VLSM panel.
+    # v3.1.0 #321 — open the session6 drawer first; the save button lives
+    # inside a tool-panel that is hidden until the drawer is opened.
+    trigger = page.locator(
+        '#panel-vlsm6 .tool-toolbar .tool-trigger[data-tool="session6"]'
+    )
+    if await trigger.count() > 0:
+        await trigger.first.click()
+        await page.wait_for_function(
+            "() => document.querySelector('#panel-vlsm6 .tool-drawer.open') !== null",
+            timeout=2000,
+        )
+
+    # Click "Save Session" inside the IPv6 VLSM session6 tool panel.
     save_btn = page.locator(
-        '#vlsm6-session-controls button[name="session_action"][value="save"]'
+        '#panel-vlsm6 .tool-panel[data-tool="session6"] '
+        'button[name="session_action"][value="save"]'
     )
     if await save_btn.count() == 0:
         ok("vlsm6 session save/load: save button not present (skipped)")
@@ -2725,7 +2743,10 @@ async def test_vlsm6_session_save_load(page: Page) -> None:
     await page.wait_for_load_state("networkidle")
 
     # Saved session URL appears in the saved-bar; capture the 8-char id.
-    saved_bar = page.locator("#vlsm6-session-controls .session-saved-bar code.share-url")
+    saved_bar = page.locator(
+        '#panel-vlsm6 .tool-panel[data-tool="session6"] '
+        '.session-saved-bar code.share-url'
+    )
     assert_true(
         "vlsm6 save: saved-bar appears after save",
         await saved_bar.count() > 0,
@@ -2755,6 +2776,107 @@ async def test_vlsm6_session_save_load(page: Page) -> None:
     # Result table from auto-calc on load.
     result_count = await page.locator(".vlsm6-table tbody tr").count()
     assert_true("vlsm6 load: results auto-render", result_count >= 1, f"rows={result_count}")
+
+
+# ---------------------------------------------------------------------------
+# v3.1.0 #321 — IPv6 VLSM Save Session lives in the tool-drawer pattern
+# ---------------------------------------------------------------------------
+
+async def test_vlsm6_session_drawer_pattern(page: Page) -> None:
+    section("v3.1.0 #321 IPv6 VLSM Save Session drawer parity with IPv4")
+    # Calculate first so the panel is populated and the trigger is meaningful.
+    url = (APP_URL + "?tab=vlsm6&vlsm6_network=2001:db8::&vlsm6_cidr=32"
+           + "&vlsm6_name%5B%5D=Site-A&vlsm6_hosts%5B%5D=256")
+    await navigate(page, url)
+
+    # 1. The Save Session toolbar trigger exists on the vlsm6 panel.
+    trigger = page.locator(
+        '#panel-vlsm6 .tool-toolbar .tool-trigger[data-tool="session6"]'
+    )
+    trig_count = await trigger.count()
+    if trig_count == 0:
+        ok("vlsm6 session drawer: sessions disabled on this server (skipped)")
+        return
+    assert_eq("vlsm6 drawer: Save Session trigger present", trig_count, 1)
+    trig_text = (await trigger.first.text_content()) or ""
+    assert_true(
+        "vlsm6 drawer: trigger labelled 'Save Session'",
+        trig_text.strip() == "Save Session",
+        f"got: {trig_text!r}",
+    )
+
+    # 2. Clicking the trigger opens the drawer (matches `.tool-drawer.open`).
+    drawer = page.locator('#panel-vlsm6 .tool-drawer')
+    assert_eq("vlsm6 drawer: drawer element present", await drawer.count(), 1)
+    await trigger.first.click()
+    # JS adds .open after click; wait briefly for the class to land.
+    await page.wait_for_function(
+        "() => document.querySelector('#panel-vlsm6 .tool-drawer.open') !== null",
+        timeout=2000,
+    )
+    open_count = await page.locator('#panel-vlsm6 .tool-drawer.open').count()
+    assert_eq("vlsm6 drawer: opens on trigger click", open_count, 1)
+
+    # 3. The save form (POST + session_action=save) is rendered inside the panel.
+    save_form_btn = page.locator(
+        '#panel-vlsm6 .tool-panel[data-tool="session6"] '
+        'button[name="session_action"][value="save"]'
+    )
+    assert_eq(
+        "vlsm6 drawer: save-form button rendered inside panel",
+        await save_form_btn.count(),
+        1,
+    )
+
+    # 4. After a ?tab=vlsm6&s=<id> GET (the session-load URL — equivalent of
+    #    the task's `?session_id=` description), the drawer auto-opens because
+    #    request.php sets $session_error / $session_save_id which the template
+    #    promotes to data-open-tool="session6".
+    #    We mint a save first by clicking, then capture the id from the URL.
+    await save_form_btn.first.click()
+    await page.wait_for_load_state("networkidle")
+    saved_url_node = page.locator(
+        '#panel-vlsm6 .tool-panel[data-tool="session6"] '
+        '.session-saved-bar code.share-url'
+    )
+    saved_text = (await saved_url_node.first.text_content()) or ""
+    m = re.search(r"\?tab=vlsm6&s=([0-9a-f]{8})", saved_text)
+    assert_true(
+        "vlsm6 drawer: post-save share URL has 8-char id",
+        m is not None,
+        f"got: {saved_text!r}",
+    )
+    if m is None:
+        return
+    sid = m.group(1)
+
+    # Now navigate to the load URL — the toolbar should carry data-open-tool.
+    await navigate(page, APP_URL + f"?tab=vlsm6&s={sid}")
+    open_attr = await page.locator('#panel-vlsm6 .tool-toolbar').first.get_attribute(
+        "data-open-tool"
+    )
+    # On a successful load with no error and no fresh save_id, the drawer
+    # does NOT auto-open (mirrors IPv4 behaviour — load is silent). We still
+    # assert the trigger remained available so the user can re-open manually.
+    re_trigger = await page.locator(
+        '#panel-vlsm6 .tool-toolbar .tool-trigger[data-tool="session6"]'
+    ).count()
+    assert_eq(
+        "vlsm6 drawer: trigger still available after session-load GET",
+        re_trigger,
+        1,
+    )
+    # Exercise the auto-open path by visiting an INVALID id — request.php
+    # sets $session_error, which the template promotes to data-open-tool.
+    await navigate(page, APP_URL + "?tab=vlsm6&s=deadbeef")
+    open_attr_err = await page.locator('#panel-vlsm6 .tool-toolbar').first.get_attribute(
+        "data-open-tool"
+    )
+    assert_eq(
+        "vlsm6 drawer: data-open-tool=session6 on session error GET",
+        open_attr_err,
+        "session6",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -5029,6 +5151,8 @@ async def main() -> None:
             await test_vlsm_session_ttl_notice(page)
             await test_session_forms_spacing(page)
             await test_vlsm6_session_save_load(page)
+            # v3.1.0 #321 — IPv6 VLSM Save Session drawer parity
+            await test_vlsm6_session_drawer_pattern(page)
             await test_admin_keys_unauth_challenge(page)
             await test_admin_keys_authed_renders(page)
             await test_admin_audit_renders(page)


### PR DESCRIPTION
## Summary

Closes #321 — IPv6 VLSM Save Session UI now uses the same tool-drawer pattern as the IPv4 VLSM tab. The bare inline `vlsm6-session-controls` card is replaced with `tool-toolbar` + `tool-drawer` + `tool-panel[data-tool=\"session6\"]` mirroring the IPv4 markup byte-for-byte (modulo the `6` suffix).

- No new CSS tokens, no new class names, no JS changes (selector-driven dispatch picks up `session6` automatically).
- Inner save/load form, CSRF/hidden inputs, help bubble, TTL notice — unchanged.
- New `$open_tool_vlsm6` auto-open hint, gated on `$active_tab === 'vlsm6'` to avoid cross-tab leakage of the shared `$session_save_id`.
- Toolbar+drawer wrapped in a single `<?php if ($session_enabled) : ?>` (vlsm6 has no other triggers; rendering an empty toolbar would be visual noise).

## Files changed

- M `Subnet-Calculator/templates/layout.php`
- M `docs/sessions.md`
- M `testing/scripts/playwright_test.py`
- M `docs/superpowers/plans/v3.1.0-living-doc.md`

## ui-ux-pro-max — Pre-edit spec (verbatim)

> Verdict: pure parity replication. No new tokens, no new classes, no JS changes.
>
> 1. Toolbar placement in `panel-vlsm6`: insert the `tool-toolbar` + `tool-drawer` block at the bottom of the panel body, in the same DOM position the IPv4 VLSM toolbar occupies inside `panel-vlsm` (i.e. AFTER the closing `<?php endif; ?>` of the result/share-bar block, BEFORE the panel's closing `</div>`). The existing inline `vlsm6-session-controls` div at lines 1365-1408 is removed entirely; its inner content moves verbatim into the `tool-panel[data-tool=\"session6\"]`.
> 2. `data-tool=\"session6\"` — correct. Matches `split6` / `vlsm6` family naming. Drawer-title id becomes `drawer-title-vlsm6` to match `drawer-title-vlsm` / `drawer-title-ipv6`.
> 3. Auto-open hint (mirror of IPv4, gated on active_tab so a vlsm-tab save doesn't auto-open the vlsm6 drawer):
>    ```php
>    $open_tool_vlsm6 = null;
>    if ($session_enabled && $active_tab === 'vlsm6'
>        && ($session_save_id !== '' || $session_error !== null)) {
>        $open_tool_vlsm6 = 'session6';
>    }
>    ```
>    No other tools live on this panel, so no `elseif` chain.
> 4. Focus management: handled by existing JS in `assets/app.js` (tool-trigger click → drawer.classList.add('open') → first focusable in panel; close → return focus to trigger). Selector-driven, picks up `session6` automatically. No changes.
> 5. ARIA mirror: trigger gets `class=\"tool-trigger\" data-tool=\"session6\" aria-expanded=\"false\"`. Drawer gets `role=\"dialog\" aria-modal=\"true\" aria-labelledby=\"drawer-title-vlsm6\"`. Header span id matches.
> 6. Style-guide compliance: keep existing inner markup (`overlap-panel` / `overlap-title` / `session-ttl-notice` / `share-bar session-saved-bar` / `session-forms`). Do NOT introduce a new wrapper class — `vlsm6-session-controls` ID and class are deleted (the drawer panel is now the wrapper). No `--color-*` token usage changes. No new selectors.
> 7. `@media (hover: none)` / `:focus-visible`: no changes — `.tool-trigger` already inherits the global focus-ring, and the drawer's bottom-sheet behaviour at `<= 480px` already covers vlsm6 panels via the global selector.
> 8. Trigger ordering: only one trigger (`Save Session`) on vlsm6. Place it as the sole child of the `tool-toolbar` — same first-position as IPv4. Wrap the trigger in `<?php if ($session_enabled) : ?>` like IPv4. If sessions are disabled, the toolbar still renders (empty) but with no trigger, matching IPv4 graceful behaviour; alternatively, skip the entire toolbar+drawer when `!$session_enabled` since vlsm6 has no other tools — recommend the latter (cleaner: no empty toolbar).
>
> Acceptance: post-edit DOM should be byte-identical in shape to IPv4 except for the `6` suffixes and the absence of overlap/multi panels.

## ui-ux-pro-max — Post-edit audit (verbatim)

> VERDICT: CLEAN. No deviations from the v2.9.0 style guide or the IPv4 Save Session drawer pattern.
>
> Audit findings:
>
> 1. Button placement — CLEAN. Save Session is the sole, first-position trigger inside `tool-toolbar`, matching the IPv4 toolbar's first-position Save Session ordering. No competing triggers on vlsm6, so the position is unambiguous.
> 2. Drawer markup parity — CLEAN. `tool-drawer-header` + `tool-drawer-title` + `tool-drawer-close` structure matches IPv4 byte-for-byte. ARIA: `role=\"dialog\" aria-modal=\"true\" aria-labelledby=\"drawer-title-vlsm6\"` mirrors IPv4. `aria-expanded=\"false\"` on trigger, `aria-label=\"Close\"` on close button — both match IPv4. Inner panel uses `overlap-panel` / `overlap-title` / `help_bubble` / `session-ttl-notice` / `session-saved-bar` / `session-forms` — identical to IPv4.
> 3. Focus order — CLEAN. JS auto-open dispatch is selector-driven over `.tool-trigger[data-tool]` and `.tool-toolbar[data-open-tool]`. The `session6` token is consumed by the same code path that handles `session`, `split`, `overlap`, etc.
> 4. Visual breathing room — CLEAN. No new classes, no new tokens. Existing padding/gap rules apply uniformly via global selectors.
> 5. `<?php if ($session_enabled) : ?>` wrapping the entire toolbar+drawer — CORRECT for vlsm6 (no other triggers; empty toolbar would be visual noise). The IPv4 path keeps the toolbar always-rendered because Overlap / Multi-CIDR triggers must remain available when sessions are disabled.
> 6. Auto-open gating on `$active_tab === 'vlsm6'` — CORRECT. Required because `$session_save_id` and `$session_error` are shared across tabs.
> 7. Style-guide compliance: reused tokens only (`--color-bg`, `--color-surface`, `--color-text`, `--color-border`, `--color-accent`, `--color-btn-text`); none modified. No new selectors. Help bubble preserved. TTL notice / CSRF / hidden inputs unchanged.
> 8. Test coverage — CLEAN. The new `test_vlsm6_session_drawer_pattern` covers all four required assertions plus exercises the auto-open path through a synthetic `?s=deadbeef` GET.
> 9. Anti-patterns checked: no emoji icons, no layout shift on hover, no low-opacity glass issues, touch target ≥44×44 inherited, `prefers-reduced-motion` inherited.
>
> NO DEVIATIONS. Approved as-is. Ship it.

## QA gates evidence

| Gate | Result |
|---|---|
| `php -l layout.php request.php` | clean |
| `vendor/bin/phpunit` | **330 tests, 678 assertions, 0 failures** |
| `phpstan analyse --memory-limit=512M` | `[OK] No errors` |
| `vendor/bin/phpcs --standard=PSR12 includes/ api/` | clean |
| `vendor/bin/phpcs --standard=.phpcs-admin.xml admin/` | clean |
| `npx @stoplight/spectral-cli@6 lint api/openapi.yaml` | no errors |
| `semgrep` (rules.yml + p/php + p/owasp + p/sql-injection) on `includes/`, `api/`, `templates/`, `admin/` | 0 findings |
| `npm run lint` | 5 pre-existing ESLint warnings (no errors), Stylelint clean |
| `make test-docker` | **863/863** passed (was 849; +14 assertions for the new drawer-pattern test) |

## Test plan

- [x] Trigger renders on vlsm6 panel and is labelled "Save Session"
- [x] Click on trigger opens `.tool-drawer.open`
- [x] Save form rendered inside `.tool-panel[data-tool=\"session6\"]`
- [x] Save round-trip produces a share URL `?tab=vlsm6&s=<8-hex>`
- [x] Session-load GET (`?tab=vlsm6&s=<id>`) restores fields and auto-renders results
- [x] Invalid session GET (`?tab=vlsm6&s=deadbeef`) sets `data-open-tool=\"session6\"` so the error is surfaced inside the auto-opened drawer
- [x] IPv4 Save Session drawer behaviour unchanged
- [x] No leftover `vlsm6-session-controls` references in CSS / JS / PHP / docs / tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)