### PR TITLE
feat(v3.1.0): PR6 #328 — tab-switch digits focus first input on destination panel

### DIFF
--- a/Subnet-Calculator/assets/app.js
+++ b/Subnet-Calculator/assets/app.js
@@ -1200,6 +1200,16 @@ if (window.self === window.top && 'serviceWorker' in navigator) {
             if (btn) {
                 btn.click();
                 btn.focus();
+                // v3.1.0 (#328): after the tab switch settles, move focus to the
+                // first text input on the newly active panel so the user can
+                // start typing immediately. rAF fences against any deferred
+                // .panel.active toggling inside the tab click handler.
+                requestAnimationFrame(() => {
+                    const firstInput = document.querySelector(
+                        '.panel.active input[type="text"], .panel.active input:not([type]), .panel.active textarea'
+                    );
+                    if (firstInput) firstInput.focus();
+                });
                 e.preventDefault();
             }
             return;

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -1450,7 +1450,7 @@ if ($i < 3) {
             <dl class="kbd-list">
                 <dt><kbd>?</kbd></dt><dd>Show this help</dd>
                 <dt><kbd>Esc</kbd></dt><dd>Close any open overlay or tool drawer</dd>
-                <dt><kbd>1</kbd> &hellip; <kbd>4</kbd></dt><dd>Switch to tab (IPv4, IPv6, VLSM, VLSM IPv6)</dd>
+                <dt><kbd>1</kbd> &hellip; <kbd>4</kbd></dt><dd>Switch tabs (IPv4, IPv6, VLSM, VLSM IPv6) and focus the first input</dd>
                 <dt><kbd>/</kbd></dt><dd>Focus the first input on the active tab</dd>
                 <dt><kbd>Enter</kbd></dt><dd>Submit the current form (native; from any input)</dd>
                 <dt><kbd>Ctrl</kbd>+<kbd>R</kbd> / <kbd>Cmd</kbd>+<kbd>R</kbd></dt><dd>Reset the active tab (intercepts browser reload)</dd>

--- a/docs/superpowers/plans/v3.1.0-living-doc.md
+++ b/docs/superpowers/plans/v3.1.0-living-doc.md
@@ -42,7 +42,7 @@ last). Every session must:
 | **2** | #326 | PHPCS admin scope | ✅ Done 2026-05-04 | `.phpcs-admin.xml` ruleset; admin/ lint-clean; second CI step wired |
 | **3** | #325 | Audit purge strategy | ✅ Done 2026-05-04 | New `$admin_audit_purge_strategy` (`inline`/`sampled`/`cron`); `bin/sc-audit-purge.php` CLI for cron path |
 | **4** | PR4 | #321 IPv6 VLSM drawer parity | ✅ Done 2026-05-04 | Inline card → tool-drawer; ui-ux-pro-max pre/post clean |
-| **5** | #328 | Tab-switch focus ergonomics | ⬜ Not started | Smallest JS |
+| **5** | PR6 | #328 Tab-switch focus ergonomics | ✅ Done 2026-05-04 | rAF first-input focus after digit press; overlay help-text updated |
 | **6** | #327 | History capture parity | ⬜ Not started | Markup + JS, cross-cutting |
 | **7** | #322 | Multi-tree diff | ⬜ Not started | Large feature |
 | **8** | #323 | Tree presets / templates | ⬜ Not started | Large feature; depends on #322 infra |
@@ -105,6 +105,77 @@ All must be green before opening a PR.
 ---
 
 ## Session log
+
+### Task 5 — 2026-05-04 — #328 tab-switch keyboard shortcut focuses first input
+**Status:** ✅ Done
+
+Delivered:
+- `Subnet-Calculator/assets/app.js` — in the `(function () { … })()` IIFE
+  that hosts the v3.0.0 keyboard handler, the `TAB_KEY_MAP[e.key]` branch
+  now schedules a `requestAnimationFrame` callback after `btn.click(); btn.focus();`
+  that queries `.panel.active input[type="text"], .panel.active input:not([type]), .panel.active textarea`
+  and focuses the first match. rAF fences against any deferred `.panel.active`
+  toggling inside the tab `click()` handler. The existing `inEditable` early
+  return is preserved, so digit presses while typing in an input on a
+  different tab are still (correctly) ignored. The `/` slash handler is
+  untouched.
+- `Subnet-Calculator/templates/layout.php` — `<dt><kbd>1</kbd> … <kbd>4</kbd></dt>`
+  description rewritten from "Switch to tab (IPv4, IPv6, VLSM, VLSM IPv6)"
+  to "Switch tabs (IPv4, IPv6, VLSM, VLSM IPv6) and focus the first input"
+  to reflect the new behaviour. The `/` row is left intact so users still
+  have a non-tab-switching way to focus the active panel.
+- `testing/scripts/playwright_test.py`:
+  - New `test_kbd_tab_switch_focuses_input` — for each digit 1–4, navigates
+    fresh, blurs any existing focus, presses the digit, then
+    `wait_for_function`s on `document.activeElement.id` matching the
+    expected input id (`ip`, `ipv6`, `vlsm_network`, `vlsm6_network`).
+    Asserts both `tagName === "INPUT"` and the exact id per tab.
+  - Existing `test_kbd_tab_switching_digits` updated: between the two
+    digit presses (`3` then `1`), explicitly blurs the active element and
+    re-clicks body. Without this, the post-#328 behaviour leaves focus on
+    `#vlsm_network` after the first press, and the `inEditable` gate
+    (correctly) swallows the second digit.
+
+UI/UX gate:
+- `ui-ux-pro-max` consulted before AND after. Pre-edit verdict: WAI-ARIA
+  authoring practices for the Tabs pattern document automatic vs manual
+  activation but neither *requires* moving focus into the panel content;
+  custom global shortcuts like the digit keys are distinct from the
+  tablist's own Tab/Arrow navigation, so auto-focusing the first input
+  on intent-bearing digit press is acceptable. Recommended `requestAnimationFrame`
+  over synchronous focus for the digit handler specifically (the `/`
+  handler stays synchronous because it's a different code path with no
+  preceding `.active` toggle). Focus target should be the first text
+  input, not the panel container (which has `tabindex="-1"` for
+  programmatic focus only and conveys no editing affordance). No
+  `:focus-visible` token risk; no new CSS. Post-edit audit: CLEAN across
+  all four tabs — press `1` lands on `#ip`, `2` on `#ipv6`, `3` on
+  `#vlsm_network`, `4` on `#vlsm6_network`. `:focus-visible` ring renders
+  as defined by existing tokens (browser still classifies the focus as
+  keyboard-driven). Overlay help text updated. `/` slash row left intact.
+  No deviations to fix.
+
+Files added/modified:
+- M: `Subnet-Calculator/assets/app.js`
+- M: `Subnet-Calculator/templates/layout.php`
+- M: `testing/scripts/playwright_test.py`
+- M: `docs/superpowers/plans/v3.1.0-living-doc.md`
+
+QA gates:
+- `vendor/bin/phpunit` — 330 tests, 678 assertions, 0 failures.
+- `phpstan analyse --memory-limit=512M` — `[OK] No errors`.
+- `vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/` — clean.
+- `vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/` — clean.
+- `npx @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml` — no errors.
+- `semgrep` on `includes/`, `api/`, `templates/`, `admin/` — 0 findings.
+- `npm run lint` — 5 pre-existing ESLint warnings (no errors), Stylelint clean.
+- **Acceptance test:** `make test-docker` → **871/871** passed (was 863;
+  +8 assertions for the new `test_kbd_tab_switch_focuses_input` group —
+  4 tabs × 2 assertions per tab).
+
+Deviations from plan: None.
+
+New gaps: None.
 
 ### Task 4 — 2026-05-04 — #321 IPv6 VLSM Save Session drawer parity
 **Status:** ✅ Done

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -4595,6 +4595,11 @@ async def test_kbd_tab_switching_digits(page: Page) -> None:
         await page.get_attribute("#tab-vlsm", "aria-selected"),
         "true",
     )
+    # v3.1.0 (#328): digit presses now also focus the first input on the
+    # destination panel, so we must blur before the next digit press —
+    # otherwise the inEditable gate (correctly) swallows it.
+    await page.evaluate("() => document.activeElement && document.activeElement.blur()")
+    await page.locator("body").click()
     await page.keyboard.press("1")
     assert_eq(
         "kbd: '1' selects ipv4 tab",
@@ -4610,6 +4615,34 @@ async def test_kbd_slash_focuses_input(page: Page) -> None:
     await page.keyboard.press("/")
     focused_id = await page.evaluate("() => document.activeElement?.id")
     assert_eq("kbd: '/' focuses #ip on IPv4 tab", focused_id, "ip")
+
+
+async def test_kbd_tab_switch_focuses_input(page: Page) -> None:
+    section("v3.1.0 #328 — tab-switch digits focus the first input on the destination panel")
+    await navigate(page, APP_URL)
+    await page.locator("body").click()
+    expectations = [
+        ("1", "ip"),
+        ("2", "ipv6"),
+        ("3", "vlsm_network"),
+        ("4", "vlsm6_network"),
+    ]
+    for key, expected_id in expectations:
+        # Reload between iterations: each digit press lands on an input, and a
+        # follow-up digit press would otherwise be (correctly) swallowed by the
+        # inEditable gate.
+        await navigate(page, APP_URL)
+        await page.locator("body").click()
+        await page.evaluate("() => document.activeElement && document.activeElement.blur()")
+        await page.keyboard.press(key)
+        await page.wait_for_function(
+            "id => document.activeElement && document.activeElement.id === id",
+            arg=expected_id,
+        )
+        active_tag = await page.evaluate("() => document.activeElement?.tagName")
+        active_id = await page.evaluate("() => document.activeElement?.id")
+        assert_eq(f"kbd: '{key}' focuses INPUT after tab switch", active_tag, "INPUT")
+        assert_eq(f"kbd: '{key}' focuses #{expected_id}", active_id, expected_id)
 
 
 async def test_kbd_help_button_hidden_on_touch(page: Page) -> None:
@@ -5199,6 +5232,8 @@ async def main() -> None:
             await test_kbd_overlay_header_button_opens(page)
             await test_kbd_tab_switching_digits(page)
             await test_kbd_slash_focuses_input(page)
+            # v3.1.0 #328 — tab-switch focus
+            await test_kbd_tab_switch_focuses_input(page)
             await test_kbd_help_button_hidden_on_touch(page)
             await test_history_disabled_by_default(page)
             await test_history_opt_in_records_calculation(page)


### PR DESCRIPTION
## Summary

Closes #328. The v3.0.0 keyboard overlay (#300) maps `1`–`4` to tab switching, but after the digit press focus stayed on the tab button — users who pressed `1` because they wanted to type an IPv4 had to follow up with `/` to focus the input. Two key presses for one intent.

After this change, pressing `1`–`4` switches tabs **and** moves focus to the first text input on the newly-active panel via `requestAnimationFrame`. The existing `inEditable` gate is preserved so digit presses while typing in an input on a different tab are still (correctly) ignored. The `/` slash handler is untouched — it remains the non-tab-switching way to focus the active panel.

- `Subnet-Calculator/assets/app.js` — `TAB_KEY_MAP` branch schedules a rAF callback after `btn.click(); btn.focus();` that queries `.panel.active input[type="text"], .panel.active input:not([type]), .panel.active textarea` and focuses the first match.
- `Subnet-Calculator/templates/layout.php` — overlay help row for `1`–`4` rewritten to "Switch tabs (IPv4, IPv6, VLSM, VLSM IPv6) and focus the first input".
- `testing/scripts/playwright_test.py` — new `test_kbd_tab_switch_focuses_input` (8 assertions: 4 tabs × `tagName === "INPUT"` + exact `id`); existing `test_kbd_tab_switching_digits` updated to blur between presses (post-#328, the `inEditable` gate correctly swallows back-to-back digits without a blur).

## ui-ux-pro-max consultation (verbatim)

### PRE-EDIT verdict

WAI-ARIA Authoring Practices for the Tabs pattern documents two valid focus models: (1) automatic activation — focus stays on the tab button after activation, panel is shown; (2) manual activation — Tab key moves focus into the panel. Neither *requires* moving focus into the panel content, but neither *forbids* it when activation is via a deliberate non-arrow shortcut (here: digit press \`1\`–\`4\`). Because the digit shortcuts are an explicit, intent-bearing app-level command — distinct from the tab-bar's own arrow-key navigation — auto-focusing the first input is acceptable and matches the user's stated intent ("I pressed 1 because I want to type an IPv4"). It does not conflict with the standard tabs pattern because the standard pattern's focus rules govern *Tab/Arrow* navigation within the tablist, not custom global shortcuts. Existing prior art in \`assets/app.js\` (the \`/\` slash handler at ~line 1190) uses **synchronous** \`firstInput.focus()\` on \`.panel.active\`. Use the same selector and matching synchronous pattern for consistency. **However**, for the digit handler specifically, \`btn.click()\` may toggle \`.active\` class via the tab click handler in a way that could run synchronously already — verify, and if so use synchronous focus. If \`.active\` toggling defers (e.g. via a microtask/listener), \`requestAnimationFrame\` is the right fence. **Recommendation: use \`requestAnimationFrame\` for the digit handler** because (a) the tab \`click()\` dispatches a synthetic event that runs all click listeners synchronously, but rAF guarantees a layout pass has settled and \`.panel.active\` reflects the new state regardless of listener ordering; (b) it cannot regress the existing \`/\` handler (separate code path); (c) \`:focus-visible\` token is unaffected — keyboard-driven focus continues to render the visible ring. **Focus target: first text input, not the panel container.** The panel container has \`tabindex="-1"\` for programmatic focus only and conveys no editing affordance; landing focus on it would still require a second key press to begin typing, defeating the fix. **No \`:focus-visible\` token risk.** Update the overlay help text row for \`1\`–\`4\` to reflect the new behaviour ("switch tabs and focus the first input"); leave the \`/\` row intact so users still have a non-tab-switching way to focus.

### POST-EDIT verdict

Audit results across the four tabs after the digit press change in \`Subnet-Calculator/assets/app.js\`:

- Press \`1\` → \`.panel.active\` is \`#panel-ipv4\` → first matching input is \`#ip\` (text). PASS.
- Press \`2\` → \`.panel.active\` is \`#panel-ipv6\` → first matching input is \`#ipv6\` (text). PASS.
- Press \`3\` → \`.panel.active\` is \`#panel-vlsm\` → first matching input is \`#vlsm_network\` (text). PASS.
- Press \`4\` → \`.panel.active\` is \`#panel-vlsm6\` → first matching input is \`#vlsm6_network\` (text). PASS.

\`:focus-visible\` regression: none. Focus is moved programmatically in response to a keyboard event, so the browser still classifies the focused element as keyboard-focused and renders the \`:focus-visible\` ring as defined by existing tokens — no token or selector changes were made. No new CSS introduced. Overlay help text for \`1\`–\`4\` updated to communicate the new behaviour; \`/\` slash row left intact so users still have a non-tab-switching way to focus the active panel. \`inEditable\` gate is preserved (the digit handler runs after the early \`if (inEditable) return;\` check), so users typing in any input on a different tab cannot have their digit-entry hijacked. No mobile-specific code paths added; the keyboard overlay remains desktop-gated by the existing \`@media (hover: none)\` rule. No deviations to fix.

## Test plan

- [x] `vendor/bin/phpunit` — 330/330 (no PHP behaviour change).
- [x] `phpstan analyse --memory-limit=512M` — `[OK] No errors`.
- [x] `vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/` — clean.
- [x] `vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/` — clean.
- [x] `npx @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml` — no errors.
- [x] `semgrep` on `includes/`, `api/`, `templates/`, `admin/` — 0 findings.
- [x] `npm run lint` — 5 pre-existing ESLint warnings (no errors), Stylelint clean.
- [x] `make test-docker` — **871/871** (was 863; +8 assertions for `test_kbd_tab_switch_focuses_input`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)