### PR TITLE
feat(v3.1.0): #327 history capture parity via data-history-source

### DIFF
--- a/Subnet-Calculator/assets/app.js
+++ b/Subnet-Calculator/assets/app.js
@@ -1139,11 +1139,22 @@ if (window.self === window.top && 'serviceWorker' in navigator) {
 
     function captureCurrentPage() {
         if (!historyEnabled()) return;
-        const hasResult = document.querySelector('.results, .vlsm-results, .overlap-result, .split-list');
-        if (!hasResult) return;
+        // v3.1.0 (#327): prefer the new attribute pattern when present — it
+        // covers tool-drawer-only outcomes (Lookup, Diff, Tree, Wildcard,
+        // Range, Supernet/Summarise, ULA) and carries a per-tool label.
+        // Fall back to the v3.0.0 four-container selectors for back-compat.
         const url = window.location.pathname + window.location.search;
         const tabId = activeTabId();
         const tab = tabId ? tabId.replace(/^tab-/, '') : '';
+        const sourceEl = document.querySelector('[data-history-source][data-history-active="1"]');
+        if (sourceEl) {
+            const attrLabel = sourceEl.getAttribute('data-history-label');
+            const label = (attrLabel && attrLabel.trim()) || url;
+            pushHistory({ url, tab, label, ts: Date.now() });
+            return;
+        }
+        const hasResult = document.querySelector('.results, .vlsm-results, .overlap-result, .split-list');
+        if (!hasResult) return;
         const labelInput = document.querySelector('.panel.active input[type="text"], .panel.active textarea');
         const label = (labelInput && labelInput.value.trim()) || url;
         pushHistory({ url, tab, label, ts: Date.now() });

--- a/Subnet-Calculator/templates/_diff_result.php
+++ b/Subnet-Calculator/templates/_diff_result.php
@@ -15,8 +15,20 @@ $_diff_removed   = $diff_result['removed']   ?? [];
 $_diff_unchanged = $diff_result['unchanged'] ?? [];
 $_diff_changed   = $diff_result['changed']   ?? [];
 $_diff_total     = count($_diff_added) + count($_diff_removed) + count($_diff_unchanged) + count($_diff_changed);
+// v3.1.0 (#327) — history-source attributes for the recent-calculations pane.
+// Caller may pre-set $_diff_history_source (defaults to "diff").
+$_diff_history_source = $_diff_history_source ?? 'diff';
+$_diff_history_label  = sprintf(
+    'Diff: +%d −%d ~%d',
+    count($_diff_added),
+    count($_diff_removed),
+    count($_diff_changed)
+);
 ?>
-<div class="diff-results">
+<div class="diff-results"
+     data-history-source="<?= htmlspecialchars($_diff_history_source) ?>"
+     data-history-active="1"
+     data-history-label="<?= htmlspecialchars($_diff_history_label) ?>">
     <div class="diff-summary">
         <span class="diff-summary-pill diff-summary-pill--added"><?= count($_diff_added) ?> added</span>
         <span class="diff-summary-pill diff-summary-pill--removed"><?= count($_diff_removed) ?> removed</span>

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -323,12 +323,27 @@ if ($i < 3) {
                     <?php if ($supernet_error) : ?>
                         <div class="error"><?= htmlspecialchars($supernet_error) ?></div>
                     <?php elseif ($supernet_result !== null) : ?>
+                        <?php
+                        $_supernet_inputs = count(array_filter(array_map('trim', explode("\n", $supernet_input))));
+                        if ($supernet_action === 'find') {
+                            $_supernet_label = 'Supernet: ' . $_supernet_inputs . ' CIDR' . ($_supernet_inputs !== 1 ? 's' : '');
+                        } else {
+                            $_supernet_outs  = count($supernet_result['summaries'] ?? []);
+                            $_supernet_label = 'Summarise: ' . $_supernet_inputs . ' → ' . $_supernet_outs;
+                        }
+                        ?>
                         <?php if ($supernet_action === 'find') : ?>
-                            <div class="overlap-result overlap-contains">
+                            <div class="overlap-result overlap-contains"
+                                 data-history-source="supernet"
+                                 data-history-active="1"
+                                 data-history-label="<?= htmlspecialchars($_supernet_label) ?>">
                                 <?= htmlspecialchars($supernet_result['supernet'] ?? '') ?>
                             </div>
                         <?php else : ?>
-                            <div class="split-list split-list--mt">
+                            <div class="split-list split-list--mt"
+                                 data-history-source="supernet"
+                                 data-history-active="1"
+                                 data-history-label="<?= htmlspecialchars($_supernet_label) ?>">
                                 <button type="button" class="copy-all-btn" data-target="supernet">Copy All</button>
                                 <?php foreach ($supernet_result['summaries'] ?? [] as $s) : ?>
                                     <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($s) ?>">
@@ -370,7 +385,11 @@ if ($i < 3) {
                     <?php if ($range_error) : ?>
                         <div class="error"><?= htmlspecialchars($range_error) ?></div>
                     <?php elseif ($range_result !== null) : ?>
-                        <div class="split-list split-list--mt">
+                        <?php $_range_label = 'Range: ' . $range_start . ' → ' . $range_end; ?>
+                        <div class="split-list split-list--mt"
+                             data-history-source="range"
+                             data-history-active="1"
+                             data-history-label="<?= htmlspecialchars($_range_label) ?>">
                             <button type="button" class="copy-all-btn" data-target="range">Copy All</button>
                             <?php foreach ($range_result as $r_cidr) : ?>
                                 <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($r_cidr) ?>">
@@ -407,7 +426,11 @@ if ($i < 3) {
                     <?php if ($tree_error) : ?>
                         <div class="error"><?= htmlspecialchars($tree_error) ?></div>
                     <?php elseif ($tree_result !== null) : ?>
-                        <div class="tree-view">
+                        <?php $_tree_label = 'Tree: ' . (string)($tree_result['cidr'] ?? $tree_parent); ?>
+                        <div class="tree-view"
+                             data-history-source="tree"
+                             data-history-active="1"
+                             data-history-label="<?= htmlspecialchars($_tree_label) ?>">
                             <?php
                             /**
                              * @param array<string, mixed> $node
@@ -466,7 +489,11 @@ if ($i < 3) {
                     <?php if ($wildcard_error) : ?>
                         <div class="error wildcard-error"><?= htmlspecialchars($wildcard_error) ?></div>
                     <?php elseif ($wildcard_result !== null) : ?>
-                        <div class="split-list split-list--mt">
+                        <?php $_wildcard_label = 'Wildcard: ' . $wildcard_input; ?>
+                        <div class="split-list split-list--mt"
+                             data-history-source="wildcard"
+                             data-history-active="1"
+                             data-history-label="<?= htmlspecialchars($_wildcard_label) ?>">
                             <div class="split-item" tabindex="0" role="button"
                                  data-copy="<?= htmlspecialchars($wildcard_result['cidr']) ?>">
                                 <span class="split-subnet-text" id="wildcard-result-cidr">CIDR: <?= htmlspecialchars($wildcard_result['cidr']) ?></span>
@@ -512,7 +539,21 @@ if ($i < 3) {
                     <?php if ($active_tab === 'ipv4' && $lookup_error) : ?>
                         <div class="error"><?= htmlspecialchars($lookup_error) ?></div>
                     <?php elseif ($active_tab === 'ipv4' && $lookup_result !== null) : ?>
-                        <div class="lookup-results">
+                        <?php
+                        $_lookup_ips_count   = count(array_filter(array_map('trim', explode("\n", $lookup_ips_input))));
+                        $_lookup_cidrs_count = count(array_filter(array_map('trim', explode("\n", $lookup_cidrs_input))));
+                        $_lookup_label = sprintf(
+                            'Lookup: %d IP%s in %d CIDR%s',
+                            $_lookup_ips_count,
+                            $_lookup_ips_count !== 1 ? 's' : '',
+                            $_lookup_cidrs_count,
+                            $_lookup_cidrs_count !== 1 ? 's' : ''
+                        );
+                        ?>
+                        <div class="lookup-results"
+                             data-history-source="lookup"
+                             data-history-active="1"
+                             data-history-label="<?= htmlspecialchars($_lookup_label) ?>">
                             <button type="button" class="copy-all-btn" data-target="lookup">Copy All</button>
                             <div class="lookup-table-wrap">
                                 <table class="lookup-table" aria-label="IP lookup results">
@@ -816,7 +857,11 @@ if ($i < 3) {
                     <?php if ($ula_error) : ?>
                         <div class="error"><?= htmlspecialchars($ula_error) ?></div>
                     <?php elseif ($ula_result !== null) : ?>
-                        <div class="ula-result">
+                        <?php $_ula_label = 'ULA: ' . (string)($ula_result['prefix'] ?? ''); ?>
+                        <div class="ula-result"
+                             data-history-source="ula"
+                             data-history-active="1"
+                             data-history-label="<?= htmlspecialchars($_ula_label) ?>">
                             <div class="overlap-result overlap-contains"><?= htmlspecialchars($ula_result['prefix'] ?? '') ?></div>
                             <div class="ula-meta">
                                 <span>Global ID: <code><?= htmlspecialchars($ula_result['global_id'] ?? '') ?></code></span>
@@ -862,7 +907,21 @@ if ($i < 3) {
                     <?php if ($active_tab === 'ipv6' && $lookup_error) : ?>
                         <div class="error"><?= htmlspecialchars($lookup_error) ?></div>
                     <?php elseif ($active_tab === 'ipv6' && $lookup_result !== null) : ?>
-                        <div class="lookup-results">
+                        <?php
+                        $_lookup_ips_count6   = count(array_filter(array_map('trim', explode("\n", $lookup_ips_input))));
+                        $_lookup_cidrs_count6 = count(array_filter(array_map('trim', explode("\n", $lookup_cidrs_input))));
+                        $_lookup_label6 = sprintf(
+                            'Lookup: %d IP%s in %d CIDR%s',
+                            $_lookup_ips_count6,
+                            $_lookup_ips_count6 !== 1 ? 's' : '',
+                            $_lookup_cidrs_count6,
+                            $_lookup_cidrs_count6 !== 1 ? 's' : ''
+                        );
+                        ?>
+                        <div class="lookup-results"
+                             data-history-source="lookup"
+                             data-history-active="1"
+                             data-history-label="<?= htmlspecialchars($_lookup_label6) ?>">
                             <button type="button" class="copy-all-btn" data-target="lookup">Copy All</button>
                             <div class="lookup-table-wrap">
                                 <table class="lookup-table" aria-label="IP lookup results">

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -76,3 +76,24 @@ The tree form is the persistence path for the [interactive Tree Editor](tree.md#
 Server-side validation (`tree_validate()`) enforces canonical CIDR form (host bits zeroed; IPv6 lower-case compressed), containment (children fall inside their parent), non-overlap (siblings may have gaps but cannot overlap), `name` ≤128 / `notes` ≤1024 chars, tree depth ≤16, and total nodes ≤1024. Trees are single-family (all-IPv4 or all-IPv6).
 
 See [REST API](api.md#post-apiv1sessions) for curl examples.
+
+## Recent calculations history (v3.0.0+)
+
+The header shows a **Recent calculations** button that opens an opt-in history pane. When enabled (toggle inside the pane), every successful calculation is recorded as you navigate the app. Click any entry to re-run that calculation; entries are capped at 50 and stored in `localStorage` (`sc.history.enabled`, `sc.history.entries`).
+
+### What gets captured
+
+The history pane records URLs from the four core result containers (`.results`, `.vlsm-results`, `.overlap-result`, `.split-list`) and — as of **v3.1.0 (#327)** — also from tool-drawer-only outcomes via the `data-history-source` attribute pattern. Each annotated source produces a per-tool label so the entry list is self-describing:
+
+| Source | Label format |
+|--------|--------------|
+| Lookup (IPv4 / IPv6) | `Lookup: <N> IPs in <M> CIDRs` |
+| Subnet Diff (IPv4 / IPv6) | `Diff: +<added> −<removed> ~<changed>` |
+| Subnet Allocation Tree | `Tree: <parent_cidr>` |
+| Wildcard ↔ CIDR | `Wildcard: <input>` |
+| IP Range → CIDR | `Range: <start> → <end>` |
+| Supernet | `Supernet: <N> CIDRs` |
+| Summarise | `Summarise: <N> → <M>` |
+| ULA generator | `ULA: <prefix>` |
+
+Result blocks that surface a calculation expose `data-history-source="<tool>" data-history-active="1" data-history-label="<phrasing>"`; the front-end picks up the new attribute path before falling back to the legacy four-container selectors. No server-side changes are needed to extend coverage to a new tool — annotate the result block with the trio and the entry will appear automatically.

--- a/docs/superpowers/plans/v3.1.0-living-doc.md
+++ b/docs/superpowers/plans/v3.1.0-living-doc.md
@@ -43,7 +43,7 @@ last). Every session must:
 | **3** | #325 | Audit purge strategy | ✅ Done 2026-05-04 | New `$admin_audit_purge_strategy` (`inline`/`sampled`/`cron`); `bin/sc-audit-purge.php` CLI for cron path |
 | **4** | PR4 | #321 IPv6 VLSM drawer parity | ✅ Done 2026-05-04 | Inline card → tool-drawer; ui-ux-pro-max pre/post clean |
 | **5** | PR6 | #328 Tab-switch focus ergonomics | ✅ Done 2026-05-04 | rAF first-input focus after digit press; overlay help-text updated |
-| **6** | #327 | History capture parity | ⬜ Not started | Markup + JS, cross-cutting |
+| **6** | PR7 | #327 History capture parity | ✅ Done 2026-05-04 | `data-history-source` trio on every tool result block; JS predicate extended; 3 new playwright tests |
 | **7** | #322 | Multi-tree diff | ⬜ Not started | Large feature |
 | **8** | #323 | Tree presets / templates | ⬜ Not started | Large feature; depends on #322 infra |
 | **9** | — | Release cut + deploy | ⬜ Not started | Same shape as v3.0.0 PR4 |
@@ -105,6 +105,31 @@ All must be green before opening a PR.
 ---
 
 ## Session log
+
+### Task 6 — 2026-05-04 — #327 history capture parity (data-history-source)
+
+**Status:** ✅ Done
+
+Delivered:
+- `Subnet-Calculator/templates/layout.php` — every tool result block now carries the trio `data-history-source="<tool>" data-history-active="1" data-history-label="<phrasing>"`. Coverage: Lookup (IPv4 + IPv6), Tree, Wildcard, Range, Supernet (find), Summarise, ULA. Each label is built in PHP next to the result render with proper pluralization and Unicode arrows (`→`, `−`).
+- `Subnet-Calculator/templates/_diff_result.php` — shared partial annotates the wrapping `.diff-results` div for both IPv4 and IPv6 Subnet Diff via `$_diff_history_source` (defaults to `"diff"`); label form is `Diff: +<added> −<removed> ~<changed>`.
+- `Subnet-Calculator/assets/app.js` — `captureCurrentPage()` now prefers `[data-history-source][data-history-active="1"]` before falling back to the v3.0.0 four-container selectors (`.results, .vlsm-results, .overlap-result, .split-list`). When the new attribute is present, `data-history-label` is used verbatim as the entry label. The 50-entry FIFO cap and consecutive-duplicate dedupe are unchanged.
+- `testing/scripts/playwright_test.py` — three new test groups under `# v3.1.0 #327 — data-history-source extension`: `test_history_captures_lookup_result`, `test_history_captures_diff_result`, `test_history_captures_wildcard_result`. Each enables history, runs the tool (lookup/diff via shareable GET URL, wildcard via POST form submit through the tool-drawer trigger), asserts the new attributes are present with the expected label format, then closes the auto-opened tool drawer (`.tool-drawer-close`) before opening the history pane and asserting the entry label starts with the per-tool prefix.
+- `docs/sessions.md` — appended a "Recent calculations history (v3.0.0+)" section documenting the opt-in pane plus a per-source label table for the v3.1.0 (#327) extension.
+
+ui-ux-pro-max consult outcomes:
+- **PRE-edit:** Confirmed the trio attribute pattern (separate attributes beat a JSON blob — DevTools inspectable, no parse cost, no XSS surface). Confirmed label voice `Tool: <detail>` with proper Unicode glyphs and pluralization. Confirmed legacy four-container selectors stay for back-compat.
+- **POST-edit:** Audited each tool's result block; verified consistent voice across all 7 tools; verified JS fall-through preserves the legacy capture path; verified zero CSS/token additions; verified no regression in existing `test_history_opt_in_records_calculation`.
+
+QA gates:
+- `vendor/bin/phpunit`: 330 / 330, 678 assertions
+- `phpstan analyse --memory-limit=512M`: No errors
+- `vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/`: clean
+- `vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/`: clean
+- `npx @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml`: no errors
+- `semgrep ... Subnet-Calculator/{includes,api,templates,admin}/`: 0 findings
+- `npm run lint`: 0 errors (5 pre-existing warnings)
+- `make test-docker`: **883/883** (was 871; +12 assertions across 3 new test groups)
 
 ### Task 5 — 2026-05-04 — #328 tab-switch keyboard shortcut focuses first input
 **Status:** ✅ Done

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -4742,6 +4742,99 @@ async def test_history_h_key_opens(page: Page) -> None:
     )
 
 
+async def _enable_history(page: Page) -> None:
+    """Helper: enable the history opt-in via the overlay UI."""
+    await page.evaluate("() => localStorage.clear()")
+    await page.click("#history-toggle")
+    await page.locator("#history-enabled-toggle").check()
+    await page.locator("#history-overlay .modal-close").click()
+
+
+# v3.1.0 #327 — data-history-source extension
+async def test_history_captures_lookup_result(page: Page) -> None:
+    section("v3.1.0 #327 history — IP Lookup result captured via data-history-source")
+    await navigate(page, APP_URL)
+    await _enable_history(page)
+    # Run a lookup via shareable GET URL — history-capture fires on next page load.
+    await navigate(
+        page,
+        APP_URL + "?tab=ipv4&lookup_cidrs=10.0.0.0%2F8%0A192.168.0.0%2F16&lookup_ips=10.1.2.3%0A192.168.5.5%0A8.8.8.8",
+    )
+    # Verify the result block carries the new trio of attributes.
+    block = page.locator('[data-history-source="lookup"][data-history-active="1"]').first
+    assert_true("history #327: lookup result has data-history-source", await block.count() >= 1)
+    label = await block.get_attribute("data-history-label")
+    assert_true(
+        "history #327: lookup label uses 'Lookup:' prefix with counts",
+        bool(label) and label.startswith("Lookup:") and "IP" in (label or "") and "CIDR" in (label or ""),
+    )
+    # Close the auto-opened tool drawer so the history toggle is clickable.
+    await page.locator(".panel.active .tool-drawer.open .tool-drawer-close").first.click()
+    await page.click("#history-toggle")
+    items = page.locator("#history-list .history-item")
+    assert_true("history #327: lookup entry recorded", await items.count() >= 1)
+    first_label = await items.first.locator(".history-link").text_content()
+    assert_true(
+        "history #327: lookup history label starts with 'Lookup:'",
+        bool(first_label) and (first_label or "").startswith("Lookup:"),
+    )
+
+
+async def test_history_captures_diff_result(page: Page) -> None:
+    section("v3.1.0 #327 history — Subnet Diff result captured via data-history-source")
+    await navigate(page, APP_URL)
+    await _enable_history(page)
+    await navigate(
+        page,
+        APP_URL + "?tab=ipv4&diff_before=10.0.0.0%2F24%0A10.0.1.0%2F24&diff_after=10.0.0.0%2F23%0A10.0.2.0%2F24",
+    )
+    block = page.locator('[data-history-source="diff"][data-history-active="1"]').first
+    assert_true("history #327: diff result has data-history-source", await block.count() >= 1)
+    label = await block.get_attribute("data-history-label")
+    assert_true(
+        "history #327: diff label uses 'Diff:' prefix",
+        bool(label) and (label or "").startswith("Diff:"),
+    )
+    await page.locator(".panel.active .tool-drawer.open .tool-drawer-close").first.click()
+    await page.click("#history-toggle")
+    items = page.locator("#history-list .history-item")
+    assert_true("history #327: diff entry recorded", await items.count() >= 1)
+    first_label = await items.first.locator(".history-link").text_content()
+    assert_true(
+        "history #327: diff history label starts with 'Diff:'",
+        bool(first_label) and (first_label or "").startswith("Diff:"),
+    )
+
+
+async def test_history_captures_wildcard_result(page: Page) -> None:
+    section("v3.1.0 #327 history — Wildcard result captured via data-history-source")
+    await navigate(page, APP_URL)
+    await _enable_history(page)
+    # Wildcard is POST-only; submit via the tool drawer form.
+    await navigate(page, APP_URL + "?tab=ipv4")
+    # Open the wildcard tool drawer.
+    await page.locator('.tool-trigger[data-tool="wildcard"]').first.click()
+    await page.locator("#wildcard_input").fill("/24")
+    await page.locator('.tool-panel[data-tool="wildcard"] form button[type="submit"]').click()
+    # After POST submit, the page reloads with the result rendered.
+    block = page.locator('[data-history-source="wildcard"][data-history-active="1"]').first
+    assert_true("history #327: wildcard result has data-history-source", await block.count() >= 1)
+    label = await block.get_attribute("data-history-label")
+    assert_true(
+        "history #327: wildcard label uses 'Wildcard:' prefix with input",
+        bool(label) and (label or "").startswith("Wildcard:") and "/24" in (label or ""),
+    )
+    await page.locator(".panel.active .tool-drawer.open .tool-drawer-close").first.click()
+    await page.click("#history-toggle")
+    items = page.locator("#history-list .history-item")
+    assert_true("history #327: wildcard entry recorded", await items.count() >= 1)
+    first_label = await items.first.locator(".history-link").text_content()
+    assert_true(
+        "history #327: wildcard history label starts with 'Wildcard:'",
+        bool(first_label) and (first_label or "").startswith("Wildcard:"),
+    )
+
+
 async def test_vlsm_keyboard_delete(page: Page) -> None:
     section("VLSM — keyboard Delete on remove button")
     await navigate(page, APP_URL)
@@ -5239,6 +5332,10 @@ async def main() -> None:
             await test_history_opt_in_records_calculation(page)
             await test_history_clear_removes_entries(page)
             await test_history_h_key_opens(page)
+            # v3.1.0 #327 — data-history-source extension
+            await test_history_captures_lookup_result(page)
+            await test_history_captures_diff_result(page)
+            await test_history_captures_wildcard_result(page)
             # v3.0.0 PR3b — interactive subnet tree editor (#302)
             await test_tree_editor_split(page)
             await test_tree_editor_merge_via_drag(page)


### PR DESCRIPTION
## Summary

Closes #327. Extends the v3.0.0 recent-calculations history pane (#301) to capture tool-drawer-only outcomes (Lookup, Diff, Tree, Wildcard, Range, Supernet/Summarise, ULA) that don't render one of the legacy four containers (`.results, .vlsm-results, .overlap-result, .split-list`).

Every tool result block now carries the canonical attribute trio:

```
data-history-source="<tool>"
data-history-active="1"
data-history-label="<phrasing>"
```

`captureCurrentPage()` in `app.js` prefers the new attribute path and falls back to the legacy four-container selectors for back-compat. 50-entry FIFO cap and consecutive-duplicate dedupe unchanged.

## Files changed

- `Subnet-Calculator/templates/layout.php` — annotate every tool result block (Lookup v4+v6, Tree, Wildcard, Range, Supernet, Summarise, ULA)
- `Subnet-Calculator/templates/_diff_result.php` — annotate the shared diff result wrapper for v4 + v6 Subnet Diff
- `Subnet-Calculator/assets/app.js` — extend `captureCurrentPage()` predicate
- `testing/scripts/playwright_test.py` — 3 new test groups (lookup, diff, wildcard)
- `docs/sessions.md` — add "Recent calculations history (v3.0.0+)" section with per-source label table
- `docs/superpowers/plans/v3.1.0-living-doc.md` — Session 6 entry, Session map row

## Per-tool label phrasing

| Tool | Label |
|------|-------|
| Lookup | `Lookup: <N> IPs in <M> CIDRs` |
| Diff | `Diff: +<added> −<removed> ~<changed>` |
| Tree | `Tree: <parent_cidr>` |
| Wildcard | `Wildcard: <input>` |
| Range | `Range: <start> → <end>` |
| Supernet | `Supernet: <N> CIDRs` |
| Summarise | `Summarise: <N> → <M>` |
| ULA | `ULA: <prefix>` |

All labels follow the `Tool: <detail>` convention so the history list is scannable as a left-aligned column.

## ui-ux-pro-max consultation

**PRE-edit verdict (verbatim):**

> 1. Attribute pattern: APPROVED. The trio `data-history-source` + `data-history-active="1"` + `data-history-label` is correct. Three separate attributes beat a single JSON blob — easier to inspect in DevTools, no parse cost in the JS hot path, no XSS surface from `JSON.parse`. The `data-history-active="1"` boolean is necessary because `data-history-source` alone could match an empty/error placeholder; the `="1"` form is the standard HTML data-attribute boolean idiom (avoid bare presence-only attributes for clarity).
> 2. Label phrasing: APPROVED with refinements. All start with `Tool:` — consistent voice, scannable in the list, mirrors how browser history / command palettes read. Final spec uses proper Unicode `−` (U+2212) and `→` (U+2192) glyphs; pluralize Lookup correctly (`1 IP in 1 CIDR` vs `3 IPs in 2 CIDRs`); omit "CIDRs" on Summarise to keep the line short.
> 3. Back-compat: RETAIN legacy selectors. Confirmed. The four `.results, .vlsm-results, .overlap-result, .split-list` selectors stay for back-compat. JS predicate becomes a union: new attribute path takes precedence (richer label), legacy path falls back. No regression risk.
> 4. Voice: `Tool: <detail>` is correct. Sentence case ("Looked up 3 IPs…") would diverge from the existing legacy entries which echo the input value verbatim. The colon prefix doubles as a visual sort key.

**POST-edit verdict (verbatim):**

> Audited the changes. Per-tool labels are consistent in voice — all start with `Tool: <detail>`. No regression on the legacy four-container path — `app.js` still falls back when no `[data-history-source][data-history-active="1"]` element is present; existing `test_history_opt_in_records_calculation` still passes. Every result block annotated: Lookup (IPv4 + IPv6), Diff (IPv4 + IPv6 via shared partial), Tree, Wildcard, Range, Supernet (find + summarise), ULA. Tool drawers without a result don't trigger capture (gated on `_result !== null`). No new CSS added — markup attributes only, zero design impact, zero token changes. Voice consistency confirmed: colon prefix establishes a left-aligned visual sort key in the history list.

## Test plan

- [x] `vendor/bin/phpunit`: 330/330, 678 assertions
- [x] `phpstan analyse --memory-limit=512M`: no errors
- [x] `vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/`: clean
- [x] `vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/`: clean
- [x] Spectral OpenAPI lint: no errors
- [x] semgrep (rules.yml + p/php + p/owasp-top-ten + p/sql-injection): 0 findings
- [x] `npm run lint`: 0 errors (5 pre-existing warnings)
- [x] `make test-docker`: **883/883** (was 871; +12 assertions across 3 new test groups)
- [x] No regression on the existing four-container capture path (`test_history_opt_in_records_calculation` still passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)