### PR TITLE
feat(v3.1.0): #323 tree-editor preset library + 6 starter presets

### DIFF
--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -69,6 +69,8 @@ tags:
     description: IP address range to CIDR conversion
   - name: Tree
     description: Subnet allocation tree
+  - name: TreePresets
+    description: Subnet tree-editor preset library (v3.1.0, #323)
   - name: Wildcard
     description: Wildcard mask ↔ CIDR conversion
   - name: Lookup
@@ -1923,6 +1925,152 @@ paths:
           content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
         "404":
           description: Schema not found
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+
+  /tree-presets:
+    get:
+      operationId: listTreePresets
+      tags: [TreePresets]
+      summary: List subnet tree-editor presets
+      description: |
+        Returns the manifest of available presets (v3.1.0, #323). Presets are
+        loaded from `Subnet-Calculator/data/tree-presets/` (or the directory
+        configured via `$tree_presets_dir`). The manifest excludes the
+        `operations` field — use `GET /tree-presets/{id}` for the full preset.
+      responses:
+        "200":
+          description: Preset manifest
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [presets]
+                        properties:
+                          presets:
+                            type: array
+                            items:
+                              type: object
+                              required: [id, name, family, rootPrefix, operationCount]
+                              properties:
+                                id:             { type: string, pattern: "^[a-z0-9-]+$" }
+                                name:           { type: string }
+                                description:    { type: string }
+                                family:         { type: string, enum: [ipv4, ipv6] }
+                                rootPrefix:     { type: integer, minimum: 0, maximum: 128 }
+                                rootCidr:       { type: string }
+                                operationCount: { type: integer, minimum: 0 }
+              example:
+                ok: true
+                data:
+                  presets:
+                    - id: lan-dmz-mgmt-24
+                      name: "LAN / DMZ / Mgmt (/24)"
+                      description: "Classic small-site /24 split."
+                      family: ipv4
+                      rootPrefix: 24
+                      rootCidr: "10.0.0.0/24"
+                      operationCount: 5
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+
+  /tree-presets/{id}:
+    get:
+      operationId: getTreePreset
+      tags: [TreePresets]
+      summary: Load a single tree preset by id
+      description: |
+        Returns a full preset definition including its `operations` list.
+        The `id` parameter must match `^[a-z0-9-]+$` and equal the JSON file's
+        basename without the `.json` extension; any other value returns 404.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9-]+$"
+            maxLength: 64
+          example: lan-dmz-mgmt-24
+      responses:
+        "200":
+          description: Full preset payload
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [preset]
+                        properties:
+                          preset:
+                            type: object
+                            required: [id, name, family, rootPrefix, operations]
+                            properties:
+                              id:          { type: string, pattern: "^[a-z0-9-]+$" }
+                              name:        { type: string }
+                              description: { type: string }
+                              family:      { type: string, enum: [ipv4, ipv6] }
+                              rootPrefix:  { type: integer, minimum: 0, maximum: 128 }
+                              rootCidr:    { type: string }
+                              operations:
+                                type: array
+                                items:
+                                  oneOf:
+                                    - type: object
+                                      required: [op, cidr, into]
+                                      properties:
+                                        op:   { type: string, enum: [split] }
+                                        cidr: { type: string }
+                                        into: { type: integer, enum: [2, 4, 8, 16] }
+                                    - type: object
+                                      required: [op, cidr, name]
+                                      properties:
+                                        op:    { type: string, enum: [rename] }
+                                        cidr:  { type: string }
+                                        name:  { type: string }
+                                        notes: { type: string }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Preset not found
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/schemas/tree-preset.schema.json
+++ b/Subnet-Calculator/api/schemas/tree-preset.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://subnetcalculator.app/api/schemas/tree-preset.schema.json",
+  "title": "Subnet Tree Preset (v3.1.0 #323)",
+  "description": "A reusable subnet-allocation template for the v3.0.0 tree editor. Each preset declares a root CIDR (parameterised by family + prefix length) and an ordered list of operations that mutate the tree via the editor's reducer. Operators may drop additional preset JSON files into the `Subnet-Calculator/data/tree-presets/` directory (or a directory configured via `$tree_presets_dir` in `config.php`); the file's basename without the `.json` extension MUST match the preset's `id` field, and `id` MUST match `^[a-z0-9-]+$` to keep filesystem lookups path-traversal-safe.",
+  "type": "object",
+  "required": ["id", "name", "family", "rootPrefix", "operations"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Slug identifier; must equal the filename without the .json extension."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Human-readable preset title shown in the picker card heading."
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 512,
+      "description": "Short summary shown beneath the name in the picker card."
+    },
+    "family": {
+      "type": "string",
+      "enum": ["ipv4", "ipv6"],
+      "description": "Address family the preset targets. Apply rejects a root CIDR from the wrong family."
+    },
+    "rootPrefix": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 128,
+      "description": "Default prefix length for the root CIDR (e.g. 24 for an IPv4 /24 plan, 48 for an IPv6 /48 plan)."
+    },
+    "rootCidr": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 64,
+      "description": "Default root CIDR used when crafting the preset's operation list. Operators can override this on Apply."
+    },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 256,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["op", "cidr", "into"],
+            "additionalProperties": false,
+            "properties": {
+              "op": { "const": "split" },
+              "cidr": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 64,
+                "description": "CIDR to split. Must already exist in the tree at the time the operation runs."
+              },
+              "into": {
+                "type": "integer",
+                "enum": [2, 4, 8, 16],
+                "description": "Number of equal children to create."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["op", "cidr", "name"],
+            "additionalProperties": false,
+            "properties": {
+              "op": { "const": "rename" },
+              "cidr": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 64
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1024
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "examples": [
+    {
+      "id": "lan-dmz-mgmt-24",
+      "name": "LAN / DMZ / Mgmt (/24)",
+      "description": "Classic small-site /24 split: LAN, DMZ, management, and a reserve segment.",
+      "family": "ipv4",
+      "rootPrefix": 24,
+      "rootCidr": "10.0.0.0/24",
+      "operations": [
+        { "op": "split", "cidr": "10.0.0.0/24", "into": 4 },
+        { "op": "rename", "cidr": "10.0.0.0/26", "name": "LAN" },
+        { "op": "rename", "cidr": "10.0.0.64/26", "name": "DMZ" },
+        { "op": "rename", "cidr": "10.0.0.128/26", "name": "Mgmt" },
+        { "op": "rename", "cidr": "10.0.0.192/26", "name": "Reserve" }
+      ]
+    }
+  ]
+}

--- a/Subnet-Calculator/api/v1/handlers/tree-presets.php
+++ b/Subnet-Calculator/api/v1/handlers/tree-presets.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * GET /api/v1/tree-presets         → manifest list
+ * GET /api/v1/tree-presets/{id}    → full preset (operations included)
+ *
+ * Both routes are read-only; presets are loaded from the configured directory
+ * and validated against the schema in `api/schemas/tree-preset.schema.json`.
+ * `id` is constrained to ^[a-z0-9-]+$ — no user-supplied value reaches the
+ * filesystem unfiltered.
+ */
+
+declare(strict_types=1);
+
+if ($method !== 'GET') {
+    json_err('Method not allowed.', 405);
+}
+
+if (preg_match('#^/tree-presets/([a-z0-9-]+)$#', $uri, $m)) {
+    $preset = tree_preset_load($m[1]);
+    if ($preset === null) {
+        json_err('Preset not found.', 404);
+    }
+    json_ok(['preset' => $preset]);
+}
+
+if ($uri === '/tree-presets') {
+    json_ok(['presets' => tree_presets_list()]);
+}
+
+json_err('Not found.', 404);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -27,6 +27,7 @@ require_once $base . 'functions-resolve.php';
 require $base . 'functions-range.php';
 require $base . 'functions-tree.php';
 require $base . 'functions-tree-diff.php';
+require $base . 'functions-tree-presets.php';
 require $base . 'functions-lookup.php';
 require $base . 'functions-diff.php';
 require $base . 'functions-apikeys.php';
@@ -103,6 +104,8 @@ if ($uri === '/' && $method === 'GET') {
             'GET  /api/v1/sessions/{id}',
             'POST /api/v1/range/ipv4',
             'POST /api/v1/tree',
+            'GET  /api/v1/tree-presets',
+            'GET  /api/v1/tree-presets/{id}',
             'POST /api/v1/wildcard',
             'POST /api/v1/lookup',
             'POST /api/v1/diff',
@@ -134,6 +137,8 @@ if (!empty($api_allowed_endpoints) && $uri !== '/') {
         $ep = 'schemas';
     } elseif (str_starts_with($ep, 'admin/keys')) {
         $ep = 'admin';
+    } elseif (str_starts_with($ep, 'tree-presets')) {
+        $ep = 'tree-presets';
     }
     if (!in_array($ep, $api_allowed_endpoints, true)) {
         json_err('Not found.', 404);
@@ -151,6 +156,11 @@ if ($method === 'GET' && preg_match('#^/sessions/([0-9a-f]{8})$#', $uri, $m)) {
 // Schema export: /schemas/{name}
 if ($method === 'GET' && preg_match('#^/schemas/[a-z0-9\-]+$#', $uri)) {
     require __DIR__ . '/handlers/schemas.php';
+}
+
+// Tree presets (#323): /tree-presets and /tree-presets/{id}
+if ($method === 'GET' && ($uri === '/tree-presets' || preg_match('#^/tree-presets/[a-z0-9\-]+$#', $uri))) {
+    require __DIR__ . '/handlers/tree-presets.php';
 }
 
 // Admin: /admin/keys (POST, GET), /admin/keys/{id} (DELETE),

--- a/Subnet-Calculator/assets/app.css
+++ b/Subnet-Calculator/assets/app.css
@@ -1985,3 +1985,101 @@
     .tree-diff-card { padding: 0.85rem; max-width: 96vw; max-height: 92vh; }
     .tree-diff-inputs { grid-template-columns: 1fr; }
 }
+
+/* ── Tree preset picker (#323, v3.1.0) ───────────────────────────────────── */
+
+.tree-preset-card {
+    max-width: 560px;
+    width: 92vw;
+    max-height: 84vh;
+    overflow-y: auto;
+}
+.tree-preset-error {
+    background: var(--color-error-bg);
+    border: 1px solid var(--color-error-border);
+    color: var(--color-error-text);
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+}
+.tree-preset-error[hidden] { display: none; }
+.tree-preset-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-height: 50vh;
+    overflow-y: auto;
+}
+.tree-preset-list[hidden] { display: none; }
+.tree-preset-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-surface-alt);
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    transition: border-color 200ms, background-color 200ms;
+}
+.tree-preset-item:hover,
+.tree-preset-item:focus,
+.tree-preset-item[aria-selected="true"] {
+    border-color: var(--color-accent);
+    background: var(--color-surface);
+    outline: none;
+}
+.tree-preset-item-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.tree-preset-item-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+.tree-preset-item-family {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.05rem 0.4rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+}
+.tree-preset-item-desc {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+.tree-preset-item-meta {
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.tree-preset-confirm[hidden] { display: none; }
+.tree-preset-confirm {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+.tree-preset-confirm-meta {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+.tree-preset-extend {
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--color-border);
+    padding-top: 0.5rem;
+}
+.tree-preset-extend[hidden] { display: none; }
+
+@media (width <= 480px) {
+    .tree-preset-card { padding: 0.85rem; max-width: 96vw; max-height: 92vh; }
+    .tree-preset-list { max-height: 55vh; }
+}

--- a/Subnet-Calculator/assets/app.js
+++ b/Subnet-Calculator/assets/app.js
@@ -2289,6 +2289,303 @@ if (window.self === window.top && 'serviceWorker' in navigator) {
         }
     });
 
+    // ── Apply Template / preset picker (#323, v3.1.0) ──────────────────────
+    //
+    // Fetches the manifest from GET /api/v1/tree-presets on first open
+    // (cached per-page-load).  Selecting a preset reveals a confirm pane
+    // with an editable Root CIDR.  Apply replays the preset's operations
+    // through dispatch() so undo/redo works normally.
+
+    const presetModal = root.querySelector('[data-role="preset-modal"]');
+    let presetManifest = null;
+    let presetSelectedFull = null; // full preset (with operations)
+    let presetLastFocused = null;  // focus return target on close
+
+    function presetApiBase() {
+        // Match the convention used by saveSession() — relative path so the
+        // app works regardless of install sub-path.
+        return 'api/v1/tree-presets';
+    }
+
+    function presetShowError(msg) {
+        const err = presetModal && presetModal.querySelector('[data-role="preset-error"]');
+        if (!err) { return; }
+        if (!msg) { err.hidden = true; err.textContent = ''; return; }
+        err.hidden = false;
+        err.textContent = msg;
+    }
+
+    function presetSwitchToList() {
+        const list = presetModal.querySelector('[data-role="preset-list"]');
+        const confirm = presetModal.querySelector('[data-role="preset-confirm"]');
+        const footer = presetModal.querySelector('[data-role="preset-list-footer"]');
+        const listActions = presetModal.querySelector('[data-role="preset-list-actions"]');
+        if (list) { list.hidden = false; }
+        if (confirm) { confirm.hidden = true; }
+        if (footer) { footer.hidden = false; }
+        if (listActions) { listActions.hidden = false; }
+        presetShowError('');
+    }
+
+    function presetSwitchToConfirm() {
+        const list = presetModal.querySelector('[data-role="preset-list"]');
+        const confirm = presetModal.querySelector('[data-role="preset-confirm"]');
+        const footer = presetModal.querySelector('[data-role="preset-list-footer"]');
+        const listActions = presetModal.querySelector('[data-role="preset-list-actions"]');
+        if (list) { list.hidden = true; }
+        if (confirm) { confirm.hidden = false; }
+        if (footer) { footer.hidden = true; }
+        if (listActions) { listActions.hidden = true; }
+        presetShowError('');
+    }
+
+    function presetRenderList(manifest) {
+        const list = presetModal.querySelector('[data-role="preset-list"]');
+        if (!list) { return; }
+        list.replaceChildren();
+        if (!manifest || !manifest.length) {
+            const empty = document.createElement('p');
+            empty.className = 'tree-modal-help';
+            empty.textContent = 'No presets available on this server.';
+            list.appendChild(empty);
+            return;
+        }
+        manifest.forEach(function (p, idx) {
+            const item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'tree-preset-item';
+            item.setAttribute('role', 'option');
+            item.setAttribute('data-preset-id', p.id);
+            item.setAttribute('aria-selected', idx === 0 ? 'true' : 'false');
+
+            const head = document.createElement('div');
+            head.className = 'tree-preset-item-head';
+            const name = document.createElement('span');
+            name.className = 'tree-preset-item-name';
+            name.textContent = p.name;
+            head.appendChild(name);
+            const fam = document.createElement('span');
+            fam.className = 'tree-preset-item-family';
+            fam.textContent = p.family === 'ipv6' ? 'v6' : 'v4';
+            head.appendChild(fam);
+            item.appendChild(head);
+
+            if (p.description) {
+                const desc = document.createElement('div');
+                desc.className = 'tree-preset-item-desc';
+                desc.textContent = p.description;
+                item.appendChild(desc);
+            }
+            const meta = document.createElement('div');
+            meta.className = 'tree-preset-item-meta';
+            meta.textContent = 'Root /' + p.rootPrefix + ' · ' + p.operationCount + ' operation' + (p.operationCount === 1 ? '' : 's');
+            item.appendChild(meta);
+
+            list.appendChild(item);
+        });
+    }
+
+    function presetFetchManifest() {
+        if (presetManifest) { return Promise.resolve(presetManifest); }
+        return fetch(presetApiBase(), { headers: { 'Accept': 'application/json' } })
+            .then(function (r) { return r.json(); })
+            .then(function (json) {
+                if (!json || !json.ok || !json.data || !Array.isArray(json.data.presets)) {
+                    throw new Error((json && json.error) || 'Bad manifest response');
+                }
+                presetManifest = json.data.presets;
+                return presetManifest;
+            });
+    }
+
+    function presetFetchOne(id) {
+        return fetch(presetApiBase() + '/' + encodeURIComponent(id), {
+            headers: { 'Accept': 'application/json' }
+        }).then(function (r) { return r.json(); }).then(function (json) {
+            if (!json || !json.ok || !json.data || !json.data.preset) {
+                throw new Error((json && json.error) || 'Preset not found.');
+            }
+            return json.data.preset;
+        });
+    }
+
+    function presetOpen() {
+        presetLastFocused = document.activeElement;
+        openModal(presetModal);
+        presetSwitchToList();
+        const list = presetModal.querySelector('[data-role="preset-list"]');
+        if (list) {
+            list.replaceChildren();
+            const loading = document.createElement('p');
+            loading.className = 'tree-modal-help';
+            loading.textContent = 'Loading templates…';
+            list.appendChild(loading);
+        }
+        presetFetchManifest().then(function (manifest) {
+            presetRenderList(manifest);
+            const first = presetModal.querySelector('.tree-preset-item');
+            if (first) { first.focus(); }
+        }).catch(function (e) {
+            presetShowError('Could not load templates: ' + e.message);
+        });
+    }
+
+    function presetClose() {
+        closeModal(presetModal);
+        presetSelectedFull = null;
+        if (presetLastFocused && typeof presetLastFocused.focus === 'function') {
+            presetLastFocused.focus();
+        }
+    }
+
+    function presetSelectById(id) {
+        if (!presetManifest) { return; }
+        const row = presetManifest.find(function (p) { return p.id === id; });
+        if (!row) { return; }
+        // mark aria-selected
+        presetModal.querySelectorAll('.tree-preset-item').forEach(function (el) {
+            el.setAttribute('aria-selected', el.getAttribute('data-preset-id') === id ? 'true' : 'false');
+        });
+        presetShowError('');
+        presetFetchOne(id).then(function (full) {
+            presetSelectedFull = full;
+            const meta = presetModal.querySelector('[data-role="preset-confirm-meta"]');
+            if (meta) {
+                meta.textContent = full.name
+                    + (full.description ? ' — ' + full.description : '')
+                    + ' (family ' + (full.family === 'ipv6' ? 'IPv6' : 'IPv4')
+                    + ', root /' + full.rootPrefix + ', '
+                    + (full.operations ? full.operations.length : 0) + ' op'
+                    + ((full.operations && full.operations.length === 1) ? '' : 's') + ')';
+            }
+            const inp = presetModal.querySelector('[data-role="preset-root-cidr"]');
+            if (inp) {
+                inp.value = full.rootCidr || '';
+            }
+            presetSwitchToConfirm();
+            if (inp) { inp.focus(); inp.select(); }
+        }).catch(function (e) {
+            presetShowError('Could not load preset: ' + e.message);
+        });
+    }
+
+    function presetRebaseCidr(cidr, family, fromRootCidr) {
+        // Rewrite each operation cidr from the preset's baked-in root to the
+        // user-chosen root.  Both must be the same family + same prefix len.
+        // The operation's prefix delta from the original root is applied to
+        // the new root by adding the same offset.
+        const fromRoot = cidrParts(fromRootCidr);
+        const toRoot = cidrParts(cidr);
+        // Compute offset of the op's network from the *original* root, then
+        // translate by the same offset relative to the *user's* root.
+        return function (opCidr) {
+            const o = cidrParts(opCidr);
+            const fromBase = ipToBig(fromRoot.ip, family);
+            const opNet = ipToBig(o.ip, family);
+            const delta = opNet - fromBase;
+            const newBase = ipToBig(toRoot.ip, family);
+            return bigToIp(newBase + delta, family) + '/' + o.prefix;
+        };
+    }
+
+    function presetApply() {
+        presetShowError('');
+        if (!presetSelectedFull) { presetShowError('No preset selected.'); return; }
+        const inp = presetModal.querySelector('[data-role="preset-root-cidr"]');
+        const raw = inp ? inp.value.trim() : '';
+        if (!raw || raw.indexOf('/') === -1) {
+            presetShowError('CIDR must include a prefix, e.g. 10.0.0.0/24.');
+            return;
+        }
+        const fam = cidrFamily(raw);
+        if (fam !== presetSelectedFull.family) {
+            presetShowError('This preset is ' + (presetSelectedFull.family === 'ipv6' ? 'IPv6' : 'IPv4')
+                + '. Enter a matching root CIDR.');
+            return;
+        }
+        const parts = cidrParts(raw);
+        if (parts.prefix !== presetSelectedFull.rootPrefix) {
+            presetShowError('Root CIDR must use prefix /' + presetSelectedFull.rootPrefix
+                + ' (got /' + parts.prefix + ').');
+            return;
+        }
+        let canon;
+        try { canon = canonicalCidr(raw, fam); }
+        catch (e) { presetShowError('Invalid CIDR: ' + e.message); return; }
+
+        // If the editor isn't started yet, start it on the chosen root first.
+        if (!state) {
+            startEditor(canon);
+            if (!state) { presetShowError('Could not start editor on ' + canon + '.'); return; }
+        } else if (state.root.cidr !== canon) {
+            // Replace the current root with the chosen one (RESET equivalent
+            // to a fresh root). This also clears children — desirable for a
+            // preset apply.
+            state.root = { cidr: canon };
+            state.family = fam;
+            undoStack = [];
+            redoStack = [];
+        }
+
+        const fromRoot = presetSelectedFull.rootCidr || (
+            // Best-effort: derive from first split op's cidr if not set.
+            (presetSelectedFull.operations[0] && presetSelectedFull.operations[0].cidr) || canon
+        );
+        const rebase = presetRebaseCidr(canon, fam, fromRoot);
+
+        // Replay each op via dispatch() so undo lands on a single coherent
+        // pre-apply snapshot — push the snapshot ourselves, then run ops with
+        // history-disabled inserts via direct state edits *only* if dispatch
+        // produces one entry per op.  Simpler: just call dispatch() per op;
+        // each dispatch pushes its own undo frame, which gives operators
+        // step-by-step undo through the preset.  Documented behaviour.
+        try {
+            (presetSelectedFull.operations || []).forEach(function (op) {
+                if (op.op === 'split') {
+                    dispatch({ type: 'SPLIT', cidr: rebase(op.cidr), count: op.into });
+                } else if (op.op === 'rename') {
+                    dispatch({ type: 'RENAME', cidr: rebase(op.cidr), name: op.name, notes: op.notes || '' });
+                }
+            });
+        } catch (e) {
+            presetShowError('Apply failed: ' + e.message);
+            return;
+        }
+
+        setStatus('Applied template "' + presetSelectedFull.name + '". Press Ctrl+Z to undo.');
+        presetClose();
+    }
+
+    if (presetModal) {
+        presetModal.addEventListener('click', function (e) {
+            const item = e.target.closest('.tree-preset-item');
+            if (item) { presetSelectById(item.getAttribute('data-preset-id')); return; }
+            if (e.target.matches('[data-role="preset-cancel"]')) { presetClose(); return; }
+            if (e.target.matches('[data-role="preset-back"]')) { presetSwitchToList(); return; }
+            if (e.target.matches('[data-role="preset-apply"]')) { presetApply(); return; }
+        });
+        // Arrow-key navigation across the listbox.
+        presetModal.addEventListener('keydown', function (e) {
+            const list = presetModal.querySelector('[data-role="preset-list"]');
+            if (list && list.hidden === false && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+                const items = Array.prototype.slice.call(list.querySelectorAll('.tree-preset-item'));
+                if (!items.length) { return; }
+                const cur = document.activeElement;
+                let idx = items.indexOf(cur);
+                if (idx === -1) { idx = 0; }
+                else { idx += (e.key === 'ArrowDown' ? 1 : -1); }
+                if (idx < 0) { idx = items.length - 1; }
+                if (idx >= items.length) { idx = 0; }
+                items[idx].focus();
+                e.preventDefault();
+            }
+            if (e.key === 'Escape') { presetClose(); e.preventDefault(); }
+        });
+    }
+
+    const applyBtn = root.querySelector('.tree-editor-toolbar [data-action="apply-template"]');
+    if (applyBtn) { applyBtn.addEventListener('click', presetOpen); }
+
     // Keyboard: Ctrl/Cmd+Z = undo, +Shift = redo (only when editor is open
     // and focus is inside it, to avoid clobbering page-level shortcuts).
     document.addEventListener('keydown', function (e) {

--- a/Subnet-Calculator/data/tree-presets/flat-equal-split-24.json
+++ b/Subnet-Calculator/data/tree-presets/flat-equal-split-24.json
@@ -1,0 +1,11 @@
+{
+  "id": "flat-equal-split-24",
+  "name": "Flat 4-way split (/24)",
+  "description": "Plain four-way split of a /24 into 4 × /26 with no naming. Useful as a starting building block.",
+  "family": "ipv4",
+  "rootPrefix": 24,
+  "rootCidr": "10.0.0.0/24",
+  "operations": [
+    { "op": "split", "cidr": "10.0.0.0/24", "into": 4 }
+  ]
+}

--- a/Subnet-Calculator/data/tree-presets/hq-branches-16.json
+++ b/Subnet-Calculator/data/tree-presets/hq-branches-16.json
@@ -1,0 +1,15 @@
+{
+  "id": "hq-branches-16",
+  "name": "HQ + 3 Branches (/16)",
+  "description": "Split a /16 into four /18 segments — one HQ and three remote branches (16,384 addresses each).",
+  "family": "ipv4",
+  "rootPrefix": 16,
+  "rootCidr": "10.0.0.0/16",
+  "operations": [
+    { "op": "split", "cidr": "10.0.0.0/16", "into": 4 },
+    { "op": "rename", "cidr": "10.0.0.0/18", "name": "HQ" },
+    { "op": "rename", "cidr": "10.0.64.0/18", "name": "Branch-A" },
+    { "op": "rename", "cidr": "10.0.128.0/18", "name": "Branch-B" },
+    { "op": "rename", "cidr": "10.0.192.0/18", "name": "Branch-C" }
+  ]
+}

--- a/Subnet-Calculator/data/tree-presets/ipv6-site-48.json
+++ b/Subnet-Calculator/data/tree-presets/ipv6-site-48.json
@@ -1,0 +1,19 @@
+{
+  "id": "ipv6-site-48",
+  "name": "IPv6 Sites A–H (/48)",
+  "description": "Split an IPv6 /48 into 8 × /51 site blocks (Site-A through Site-H).",
+  "family": "ipv6",
+  "rootPrefix": 48,
+  "rootCidr": "2001:db8::/48",
+  "operations": [
+    { "op": "split", "cidr": "2001:db8::/48", "into": 8 },
+    { "op": "rename", "cidr": "2001:db8::/51", "name": "Site-A" },
+    { "op": "rename", "cidr": "2001:db8:0:2000::/51", "name": "Site-B" },
+    { "op": "rename", "cidr": "2001:db8:0:4000::/51", "name": "Site-C" },
+    { "op": "rename", "cidr": "2001:db8:0:6000::/51", "name": "Site-D" },
+    { "op": "rename", "cidr": "2001:db8:0:8000::/51", "name": "Site-E" },
+    { "op": "rename", "cidr": "2001:db8:0:a000::/51", "name": "Site-F" },
+    { "op": "rename", "cidr": "2001:db8:0:c000::/51", "name": "Site-G" },
+    { "op": "rename", "cidr": "2001:db8:0:e000::/51", "name": "Site-H" }
+  ]
+}

--- a/Subnet-Calculator/data/tree-presets/ipv6-three-tier-48.json
+++ b/Subnet-Calculator/data/tree-presets/ipv6-three-tier-48.json
@@ -1,0 +1,15 @@
+{
+  "id": "ipv6-three-tier-48",
+  "name": "IPv6 Production / Staging / Dev (/48)",
+  "description": "Three-tier IPv6 environment split of a /48 into 4 × /50 blocks with a reserve.",
+  "family": "ipv6",
+  "rootPrefix": 48,
+  "rootCidr": "2001:db8::/48",
+  "operations": [
+    { "op": "split", "cidr": "2001:db8::/48", "into": 4 },
+    { "op": "rename", "cidr": "2001:db8::/50", "name": "Production" },
+    { "op": "rename", "cidr": "2001:db8:0:4000::/50", "name": "Staging" },
+    { "op": "rename", "cidr": "2001:db8:0:8000::/50", "name": "Dev" },
+    { "op": "rename", "cidr": "2001:db8:0:c000::/50", "name": "Reserve" }
+  ]
+}

--- a/Subnet-Calculator/data/tree-presets/lan-dmz-mgmt-24.json
+++ b/Subnet-Calculator/data/tree-presets/lan-dmz-mgmt-24.json
@@ -1,0 +1,15 @@
+{
+  "id": "lan-dmz-mgmt-24",
+  "name": "LAN / DMZ / Mgmt (/24)",
+  "description": "Classic small-site /24 split: LAN, DMZ, management, and a reserve segment (4 × /26).",
+  "family": "ipv4",
+  "rootPrefix": 24,
+  "rootCidr": "10.0.0.0/24",
+  "operations": [
+    { "op": "split", "cidr": "10.0.0.0/24", "into": 4 },
+    { "op": "rename", "cidr": "10.0.0.0/26", "name": "LAN" },
+    { "op": "rename", "cidr": "10.0.0.64/26", "name": "DMZ" },
+    { "op": "rename", "cidr": "10.0.0.128/26", "name": "Mgmt" },
+    { "op": "rename", "cidr": "10.0.0.192/26", "name": "Reserve" }
+  ]
+}

--- a/Subnet-Calculator/data/tree-presets/three-tier-24.json
+++ b/Subnet-Calculator/data/tree-presets/three-tier-24.json
@@ -1,0 +1,15 @@
+{
+  "id": "three-tier-24",
+  "name": "Production / Staging / Dev (/24)",
+  "description": "Three-tier environment split of a /24 with a reserve block (4 × /26).",
+  "family": "ipv4",
+  "rootPrefix": 24,
+  "rootCidr": "10.0.0.0/24",
+  "operations": [
+    { "op": "split", "cidr": "10.0.0.0/24", "into": 4 },
+    { "op": "rename", "cidr": "10.0.0.0/26", "name": "Production" },
+    { "op": "rename", "cidr": "10.0.0.64/26", "name": "Staging" },
+    { "op": "rename", "cidr": "10.0.0.128/26", "name": "Dev" },
+    { "op": "rename", "cidr": "10.0.0.192/26", "name": "Reserve" }
+  ]
+}

--- a/Subnet-Calculator/includes/config.php
+++ b/Subnet-Calculator/includes/config.php
@@ -71,6 +71,12 @@ $admin_audit_purge_sample_rate = 0.001;
 // Admin TOTP / 2FA (v3.0.0, #313)
 $admin_totp_secret = '';  // base32 RFC 6238 secret; empty = TOTP disabled
 
+// Tree-editor preset library (v3.1.0, #323). Empty = use the bundled
+// `Subnet-Calculator/data/tree-presets/` directory; set to an absolute path to
+// load presets from elsewhere. A non-existent override falls back to the
+// bundled location (with a single error_log warning).
+$tree_presets_dir = '';
+
 // Wizard-written config first (lowest tier); hand-edited config.php overrides.
 // Order matters: PHP resolves the *last* assignment to a variable, so config.php
 // runs second so an operator edit always wins over auto-written values.
@@ -173,3 +179,4 @@ if (!is_numeric($admin_audit_purge_sample_rate ?? null)) {
     $admin_audit_purge_sample_rate = max(0.0, min(1.0, (float)$admin_audit_purge_sample_rate));
 }
 $admin_totp_secret = is_string($admin_totp_secret ?? null) ? trim((string)$admin_totp_secret) : '';
+$tree_presets_dir  = is_string($tree_presets_dir ?? null) ? trim((string)$tree_presets_dir) : '';

--- a/Subnet-Calculator/includes/functions-tree-presets.php
+++ b/Subnet-Calculator/includes/functions-tree-presets.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Subnet tree-editor preset library (#323, v3.1.0).
+ *
+ * Loads JSON preset files from `Subnet-Calculator/data/tree-presets/` (or a
+ * directory configured via `$tree_presets_dir` in `config.php`), validates
+ * each against a small built-in schema mirror of `api/schemas/tree-preset.schema.json`,
+ * and exposes them to the tree-presets API handler.
+ *
+ * Security model:
+ *   - Preset `id` is constrained to `^[a-z0-9-]+$` and the file's basename
+ *     (without the .json extension) MUST equal that id.  No user-supplied
+ *     value is ever joined into a filesystem path.
+ *   - `tree_preset_load($id)` re-validates the id pattern *before* any
+ *     filesystem call, defending against path-traversal probes.
+ *   - Schema-violating presets fail closed (return null + error_log) — the
+ *     manifest skips them rather than surfacing partial data.
+ */
+
+/**
+ * Resolve the directory containing preset JSON files.  Honours an operator
+ * override via the global `$tree_presets_dir` (set in `config.php`); if the
+ * override is empty or points to a non-existent path, falls back to the
+ * bundled directory and logs a warning.
+ */
+function tree_presets_dir(): string
+{
+    $default = dirname(__DIR__) . '/data/tree-presets';
+    $override = isset($GLOBALS['tree_presets_dir']) && is_string($GLOBALS['tree_presets_dir'])
+        ? trim($GLOBALS['tree_presets_dir'])
+        : '';
+    if ($override === '') {
+        return $default;
+    }
+    if (!is_dir($override)) {
+        error_log('sc: $tree_presets_dir "' . $override . '" does not exist — using bundled directory.');
+        return $default;
+    }
+    return $override;
+}
+
+/**
+ * List every valid preset in the configured directory.  Returns a manifest
+ * array (one entry per preset) with the lightweight fields needed by the
+ * picker UI.  The full operations list is loaded on demand via
+ * `tree_preset_load()`.
+ *
+ * @return list<array{id:string,name:string,description:string,family:string,rootPrefix:int,rootCidr:string,operationCount:int}>
+ */
+function tree_presets_list(): array
+{
+    $dir = tree_presets_dir();
+    if (!is_dir($dir)) {
+        return [];
+    }
+
+    $entries = @scandir($dir);
+    if ($entries === false) {
+        return [];
+    }
+
+    $out = [];
+    foreach ($entries as $entry) {
+        if ($entry === '.' || $entry === '..') {
+            continue;
+        }
+        if (!str_ends_with($entry, '.json')) {
+            continue;
+        }
+        $id = substr($entry, 0, -5);
+        if (!tree_preset_id_is_safe($id)) {
+            error_log('sc: tree-preset filename "' . $entry . '" has unsafe id — skipped.');
+            continue;
+        }
+        $preset = tree_preset_load($id);
+        if ($preset === null) {
+            continue;
+        }
+        $pid     = is_string($preset['id'] ?? null)          ? $preset['id']          : '';
+        $pname   = is_string($preset['name'] ?? null)        ? $preset['name']        : '';
+        $pdesc   = is_string($preset['description'] ?? null) ? $preset['description'] : '';
+        $pfam    = is_string($preset['family'] ?? null)      ? $preset['family']      : '';
+        $pprefix = is_int($preset['rootPrefix'] ?? null)     ? $preset['rootPrefix']  : 0;
+        $proot   = is_string($preset['rootCidr'] ?? null)    ? $preset['rootCidr']    : '';
+        $pops    = is_array($preset['operations'] ?? null)   ? $preset['operations']  : [];
+        $out[] = [
+            'id'             => $pid,
+            'name'           => $pname,
+            'description'    => $pdesc,
+            'family'         => $pfam,
+            'rootPrefix'     => $pprefix,
+            'rootCidr'       => $proot,
+            'operationCount' => count($pops),
+        ];
+    }
+
+    usort($out, static function (array $a, array $b): int {
+        return strcmp($a['name'], $b['name']);
+    });
+
+    return $out;
+}
+
+/**
+ * Load a single preset by id.  Returns null when the id fails the safety
+ * pattern, the file is missing, or the JSON fails schema validation.
+ *
+ * @return array<string,mixed>|null
+ */
+function tree_preset_load(string $id): ?array
+{
+    if (!tree_preset_id_is_safe($id)) {
+        return null;
+    }
+
+    $dir = tree_presets_dir();
+    $path = $dir . '/' . $id . '.json';
+    if (!is_file($path)) {
+        return null;
+    }
+
+    $raw = @file_get_contents($path);
+    if ($raw === false) {
+        error_log('sc: tree-preset "' . $id . '" — file_get_contents failed.');
+        return null;
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        error_log('sc: tree-preset "' . $id . '" — JSON parse failed.');
+        return null;
+    }
+
+    /** @var array<string,mixed> $normalised */
+    $normalised = [];
+    foreach ($decoded as $k => $v) {
+        if (is_string($k)) {
+            $normalised[$k] = $v;
+        }
+    }
+
+    $errors = tree_preset_validate($normalised);
+    if (!empty($errors)) {
+        error_log('sc: tree-preset "' . $id . '" — invalid: ' . implode('; ', $errors));
+        return null;
+    }
+
+    // Filename must match the declared id — the safety pattern bounded `id`,
+    // so this also bounds the file we just opened.
+    $declaredId = is_string($normalised['id'] ?? null) ? $normalised['id'] : '';
+    if ($declaredId !== $id) {
+        error_log('sc: tree-preset "' . $id . '" — id field "' . $declaredId
+            . '" does not match filename.');
+        return null;
+    }
+
+    return $normalised;
+}
+
+/**
+ * True when `$id` is safe to use as a path segment.
+ */
+function tree_preset_id_is_safe(string $id): bool
+{
+    return $id !== '' && (bool)preg_match('/^[a-z0-9-]+$/', $id) && strlen($id) <= 64;
+}
+
+/**
+ * Validate a decoded preset against the schema rules in
+ * `api/schemas/tree-preset.schema.json`.  Returns a list of human-readable
+ * error strings (empty array = valid).
+ *
+ * @param array<string,mixed> $preset
+ * @return list<string>
+ */
+function tree_preset_validate(array $preset): array
+{
+    $errors = [];
+
+    if (!isset($preset['id']) || !is_string($preset['id']) || !tree_preset_id_is_safe($preset['id'])) {
+        $errors[] = 'id must match ^[a-z0-9-]+$ (max 64 chars)';
+    }
+    if (
+        !isset($preset['name']) || !is_string($preset['name'])
+        || $preset['name'] === '' || strlen($preset['name']) > 128
+    ) {
+        $errors[] = 'name must be a non-empty string up to 128 chars';
+    }
+    if (
+        isset($preset['description']) && (!is_string($preset['description'])
+        || strlen($preset['description']) > 512)
+    ) {
+        $errors[] = 'description must be a string up to 512 chars';
+    }
+    if (!isset($preset['family']) || !in_array($preset['family'], ['ipv4', 'ipv6'], true)) {
+        $errors[] = 'family must be "ipv4" or "ipv6"';
+    }
+    if (
+        !isset($preset['rootPrefix']) || !is_int($preset['rootPrefix'])
+        || $preset['rootPrefix'] < 0 || $preset['rootPrefix'] > 128
+    ) {
+        $errors[] = 'rootPrefix must be an integer 0–128';
+    }
+    if (
+        isset($preset['rootCidr']) && (!is_string($preset['rootCidr'])
+        || strlen($preset['rootCidr']) < 3 || strlen($preset['rootCidr']) > 64)
+    ) {
+        $errors[] = 'rootCidr must be a string 3–64 chars';
+    }
+    if (
+        !isset($preset['operations']) || !is_array($preset['operations'])
+        || count($preset['operations']) === 0 || count($preset['operations']) > 256
+    ) {
+        $errors[] = 'operations must be a list with 1–256 entries';
+        return $errors;
+    }
+
+    foreach ($preset['operations'] as $i => $op) {
+        if (!is_array($op)) {
+            $errors[] = "operation[$i] must be an object";
+            continue;
+        }
+        $kind = $op['op'] ?? null;
+        if ($kind === 'split') {
+            if (
+                !isset($op['cidr']) || !is_string($op['cidr'])
+                || strlen($op['cidr']) < 3 || strlen($op['cidr']) > 64
+            ) {
+                $errors[] = "operation[$i].cidr must be a string 3–64 chars";
+            }
+            if (!isset($op['into']) || !in_array($op['into'], [2, 4, 8, 16], true)) {
+                $errors[] = "operation[$i].into must be 2, 4, 8, or 16";
+            }
+            $extra = array_diff(array_keys($op), ['op', 'cidr', 'into']);
+            if (!empty($extra)) {
+                $errors[] = "operation[$i] has unknown keys: " . implode(',', $extra);
+            }
+        } elseif ($kind === 'rename') {
+            if (
+                !isset($op['cidr']) || !is_string($op['cidr'])
+                || strlen($op['cidr']) < 3 || strlen($op['cidr']) > 64
+            ) {
+                $errors[] = "operation[$i].cidr must be a string 3–64 chars";
+            }
+            if (
+                !isset($op['name']) || !is_string($op['name'])
+                || $op['name'] === '' || strlen($op['name']) > 128
+            ) {
+                $errors[] = "operation[$i].name must be a non-empty string up to 128 chars";
+            }
+            if (
+                isset($op['notes']) && (!is_string($op['notes'])
+                || strlen($op['notes']) > 1024)
+            ) {
+                $errors[] = "operation[$i].notes must be a string up to 1024 chars";
+            }
+            $extra = array_diff(array_keys($op), ['op', 'cidr', 'name', 'notes']);
+            if (!empty($extra)) {
+                $errors[] = "operation[$i] has unknown keys: " . implode(',', $extra);
+            }
+        } else {
+            $errors[] = "operation[$i].op must be 'split' or 'rename'";
+        }
+    }
+
+    return $errors;
+}

--- a/Subnet-Calculator/templates/_tree_editor.php
+++ b/Subnet-Calculator/templates/_tree_editor.php
@@ -36,6 +36,7 @@
             <button type="button" class="tree-editor-btn" data-action="download-json">JSON</button>
             <button type="button" class="tree-editor-btn" data-action="share-url">Share URL</button>
             <button type="button" class="tree-editor-btn" data-action="diff">Diff</button>
+            <button type="button" class="tree-editor-btn" data-action="apply-template">Apply Template</button>
             <span class="tree-editor-spacer"></span>
             <button type="button" class="tree-editor-btn tree-editor-btn-danger" data-action="reset">Reset</button>
         </div>
@@ -124,6 +125,41 @@
                     <span class="tree-diff-legend-item" data-diff="removed">removed</span>
                     <span class="tree-diff-legend-item" data-diff="changed">changed</span>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Apply Template picker modal (#323, v3.1.0) -->
+    <div class="tree-modal" data-role="preset-modal" role="dialog" aria-modal="true" aria-labelledby="tree-preset-title" hidden>
+        <div class="tree-modal-backdrop" data-role="preset-cancel"></div>
+        <div class="tree-modal-card tree-preset-card">
+            <h3 id="tree-preset-title">Apply Template</h3>
+            <p class="tree-modal-help">Pick a preset, then confirm or customise the root CIDR before it's applied to the editor.</p>
+            <div class="tree-preset-error" data-role="preset-error" role="alert" hidden></div>
+
+            <!-- Step 1: list of presets (role=listbox) -->
+            <div class="tree-preset-list" data-role="preset-list" role="listbox" aria-label="Subnet templates"></div>
+
+            <!-- Step 2: confirm root CIDR -->
+            <div class="tree-preset-confirm" data-role="preset-confirm" hidden>
+                <div class="tree-preset-confirm-meta" data-role="preset-confirm-meta"></div>
+                <label class="tree-modal-label">
+                    Root CIDR
+                    <input type="text" data-role="preset-root-cidr" autocomplete="off" spellcheck="false">
+                </label>
+                <div class="tree-modal-actions">
+                    <button type="button" class="splitter-btn" data-role="preset-apply">Apply</button>
+                    <button type="button" class="tree-editor-btn" data-role="preset-back">&larr; Back</button>
+                    <button type="button" class="tree-modal-cancel" data-role="preset-cancel">Cancel</button>
+                </div>
+            </div>
+
+            <p class="tree-modal-help tree-preset-extend" data-role="preset-list-footer">
+                Drop a JSON file into <code>data/tree-presets/</code> to add your own.
+                <a href="https://docs.subnetcalculator.app/tree/#templates" target="_blank" rel="noopener">Schema reference</a>.
+            </p>
+            <div class="tree-modal-actions" data-role="preset-list-actions">
+                <button type="button" class="tree-modal-cancel" data-role="preset-cancel">Cancel</button>
             </div>
         </div>
     </div>

--- a/docs/superpowers/plans/v3.1.0-living-doc.md
+++ b/docs/superpowers/plans/v3.1.0-living-doc.md
@@ -45,7 +45,7 @@ last). Every session must:
 | **5** | PR6 | #328 Tab-switch focus ergonomics | ✅ Done 2026-05-04 | rAF first-input focus after digit press; overlay help-text updated |
 | **6** | PR7 | #327 History capture parity | ✅ Done 2026-05-04 | `data-history-source` trio on every tool result block; JS predicate extended; 3 new playwright tests |
 | **7** | #322 | Multi-tree diff | ✅ Done 2026-05-04 | `functions-tree-diff.php` + JS mirror; modal w/ paste/URL/draft sources; `--color-warning-fg` amber introduced (one new primitive); 8 PHPUnit + 9 Playwright assertions; 892/892 |
-| **8** | #323 | Tree presets / templates | ⬜ Not started | Large feature; depends on #322 infra |
+| **8** | #323 | Tree presets / templates | ✅ Done 2026-05-04 | JSON-Schema + 6 starter presets; loader + REST GET endpoints; picker modal w/ list→confirm pane; reducer-replay Apply; 6 PHPUnit + 11 Playwright assertions; 903/903 |
 | **9** | — | Release cut + deploy | ⬜ Not started | Same shape as v3.0.0 PR4 |
 
 ---
@@ -105,6 +105,40 @@ All must be green before opening a PR.
 ---
 
 ## Session log
+
+### Task 8 — 2026-05-04 — #323 tree presets / templates
+
+**Status:** ✅ Done
+
+Delivered:
+- `Subnet-Calculator/api/schemas/tree-preset.schema.json` — Draft 2020-12 JSON-Schema for preset files. Defines `id` (`^[a-z0-9-]+$`, ≤64 chars), `name`, `description`, `family` (`ipv4`|`ipv6`), `rootPrefix` (0–128), `rootCidr`, and an `operations` array whose items use `oneOf` to discriminate `split` (with `into ∈ {2, 4, 8, 16}`) vs `rename` (with `name` + optional `notes`). `additionalProperties: false` everywhere; example block at the bottom matches the bundled `lan-dmz-mgmt-24` preset.
+- `Subnet-Calculator/data/tree-presets/*.json` — 6 starter presets: `lan-dmz-mgmt-24`, `three-tier-24`, `hq-branches-16`, `flat-equal-split-24`, `ipv6-site-48`, `ipv6-three-tier-48`. Every starter validates against its own schema and replays into a `tree_validate()`-passing tree (covered by `testStarterPresetExpandsToValidTree`).
+- `Subnet-Calculator/includes/functions-tree-presets.php` — strict-types loader with three public functions: `tree_presets_dir()` (resolves bundled path or `$tree_presets_dir` override; falls back with a single error_log warning if the override is missing), `tree_presets_list()` (walks the directory, filters `.json`, validates each, returns a manifest sorted by name), and `tree_preset_load(string $id)` (re-validates the safety pattern *before* any filesystem call, then loads + validates + verifies the declared `id` matches the filename). Path-traversal probes (`../../../etc/passwd`, `..`, `/etc/passwd`, uppercase, spaces, `;`) all return `null` without touching disk.
+- `Subnet-Calculator/includes/config.php` — adds `$tree_presets_dir = ''` (empty default → bundled directory) plus a string-coercion sanitiser. Documented as the operator override hook.
+- `Subnet-Calculator/api/v1/index.php` — bootstrap `require functions-tree-presets.php`, allowlist mapping for `tree-presets`, and a pre-dispatch `if ($method === 'GET' && /tree-presets…)` route. Meta-endpoint listing also gains the two new endpoints.
+- `Subnet-Calculator/api/v1/handlers/tree-presets.php` — `GET /api/v1/tree-presets` returns the manifest; `GET /api/v1/tree-presets/{id}` returns the full preset including `operations`. The id capture group in the URL pattern enforces `^[a-z0-9-]+$` so unsafe ids never reach `tree_preset_load()`.
+- `Subnet-Calculator/api/openapi.yaml` — new `TreePresets` tag plus full `paths` entries for both endpoints with response schemas (manifest items + full-preset items including the `oneOf` operation discriminator). Spectral-clean.
+- `Subnet-Calculator/templates/_tree_editor.php` — new toolbar button `[data-action="apply-template"]` between Diff and the spacer. New `[data-role="preset-modal"]` modal markup: list pane (`role="listbox"`) + confirm pane (editable Root CIDR + Apply/Back/Cancel) + footer extensibility hint linking to the docs schema reference. Reuses the existing `.tree-modal*` token set; no new colour primitives.
+- `Subnet-Calculator/assets/app.js` — preset-picker IIFE block. Manifest fetched on first open and cached; selecting a preset fetches the full preset payload (with operations) and switches to the confirm pane. Apply validates the user's Root CIDR (family + prefix-length match the preset; canonicalised via existing `canonicalCidr()`), starts the editor if not already started or replaces the root if the user changed it, then replays each preset op through `dispatch({type:'SPLIT',…})` / `dispatch({type:'RENAME',…})` so each step pushes its own undo frame. CIDRs are rebased from the preset's baked-in root via BigInt offset arithmetic so `10.0.0.0/24`-rooted ops correctly translate to a user-chosen `172.16.0.0/24`. Arrow keys navigate the listbox; Esc closes; focus returns to the toolbar button via `presetLastFocused`.
+- `Subnet-Calculator/assets/app.css` — `.tree-preset-card`, `.tree-preset-error`, `.tree-preset-list`, `.tree-preset-item` (+ `:hover`/`:focus`/`[aria-selected="true"]`), `.tree-preset-item-head`, `.tree-preset-item-name`, `.tree-preset-item-family` (chip), `.tree-preset-item-desc`, `.tree-preset-item-meta`, `.tree-preset-confirm`, `.tree-preset-confirm-meta`, `.tree-preset-extend`. All styles reuse existing `--color-border`, `--color-surface*`, `--color-accent`, `--color-text-muted`, `--color-error-*` tokens. Mobile @≤480px: full-bleed card + 55vh list.
+- `testing/unit/TreePresetsTest.php` — 6 PHPUnit cases (81 assertions): manifest lists all six starter ids; valid load returns expected structure; non-existent id returns null; path-traversal ids all return null without filesystem access; every starter replays into a `tree_validate()`-passing tree; the schema file itself is valid JSON with `$schema`/`$id`/`oneOf` operation discriminator. `testing/unit/bootstrap.php` requires the new file.
+- `testing/scripts/playwright_test.py` — `test_tree_editor_apply_preset_then_undo` group (11 assertions): banner `# v3.1.0 #323 — tree presets`. Opens the editor on `10.0.0.0/24`, opens the picker, asserts the manifest renders, clicks `lan-dmz-mgmt-24`, asserts the confirm pane appears with the Root CIDR pre-filled, clicks Apply, asserts 5 nodes total + the four child CIDRs + the four rename labels, then Ctrl+Z and asserts the Reserve rename is dropped (proving op-by-op undo). The existing `test_tree_editor_merge_via_drag` group needed a `scroll_into_view_if_needed()` call to remain stable after the new toolbar button pushed the canvas low enough to expose a latent HTML5 drag-and-drop fragility — fix is documented inline.
+- `docs/tree.md` — appended a "Templates (v3.1.0+)" subsection covering the picker flow, a table of all six bundled starter presets, the user-extensibility hook (drop a JSON into `data/tree-presets/`), a minimal valid-preset JSON example, and links to both the REST endpoints and the published JSON-Schema.
+- `phpstan.neon` paths extended for the new include + handler.
+
+ui-ux-pro-max consult outcomes:
+- **PRE-edit:** Captured a 7-question spec covering presentation (single centered modal, no action-sheet fork — the listbox UX is wrong for a bottom sheet), card layout (vertical stack with name + family chip + description + "Root /N · M ops" meta), input flow (two-pane Step-1/Step-2 inside the same modal, matching the Diff modal's input→result transition), toolbar placement (`Diff | Apply Template | spacer | Reset`), error pattern (`role="alert"` top-of-pane matching `tree-diff-error`), status cue (`setStatus("Applied template … Press Ctrl+Z to undo.")`), keyboard/ARIA (listbox + arrow-key nav + Esc close + focus return), and the in-modal extensibility footer. Verbatim into PR body.
+- **POST-edit:** Delivered markup matches the spec line-for-line. Tokens reused (no new colour primitives). Arrow-key navigation tested manually + via Playwright `keyboard.press`; focus return via `presetLastFocused`; family chip uses neutral border (no new colours). Each preset op pushes its own undo frame — verified by the Playwright test's "undo dropped the Reserve rename" assertion.
+
+QA gates:
+- `vendor/bin/phpunit`: **344 / 344**, **794 assertions** (was 338 / 713; +6 cases, +81 assertions)
+- `phpstan analyse --memory-limit=512M`: No errors (new file under L9)
+- `vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/`: clean
+- `vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/`: clean
+- `npx @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml`: no errors
+- `semgrep ... Subnet-Calculator/{includes,api,templates}/`: 0 findings
+- `npm run lint`: 0 errors (9 pre-existing warnings unchanged)
+- `make test-docker`: **903 / 903** passed (was 892; +11 assertions for the new preset group)
 
 ### Task 7 — 2026-05-04 — #322 multi-tree comparison / diff
 

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -113,3 +113,68 @@ emits a checklist suitable for change-management tickets:
 The diff is computed client-side; the same algorithm is exposed as
 `tree_diff()` in `includes/functions-tree-diff.php` for tests and any future
 batch / API integration.
+
+### Templates (v3.1.0+)
+
+Click **Apply Template** in the toolbar to start from a pre-built subnet plan
+instead of building one click-by-click. The picker lists every preset
+available on the server, each tagged with the address family (`v4` / `v6`),
+its root prefix length, and the number of operations it will perform when
+applied.
+
+Selecting a preset reveals a confirmation pane with an editable **Root CIDR**
+field — pre-filled with the preset's default but freely overridable. The
+chosen CIDR must use the preset's family and prefix length (e.g. a
+`/24` preset rejects a `/23` root). Click **Apply** to replay the preset's
+operations through the same reducer that handles manual edits, so each step
+lands as its own undo frame — `Ctrl+Z` peels back the preset operation by
+operation.
+
+#### Bundled starter presets
+
+| ID | Family | Root | What it does |
+|---|---|---|---|
+| `lan-dmz-mgmt-24`     | IPv4 | `/24` | Splits a `/24` into LAN, DMZ, Mgmt, Reserve (4 × `/26`). |
+| `three-tier-24`       | IPv4 | `/24` | Splits a `/24` into Production, Staging, Dev, Reserve (4 × `/26`). |
+| `hq-branches-16`      | IPv4 | `/16` | Splits a `/16` into HQ + 3 branches (4 × `/18`). |
+| `flat-equal-split-24` | IPv4 | `/24` | Plain four-way split into 4 × `/26`, no naming — useful as a building block. |
+| `ipv6-site-48`        | IPv6 | `/48` | Splits a `/48` into 8 site blocks (8 × `/51`, Site-A through Site-H). |
+| `ipv6-three-tier-48`  | IPv6 | `/48` | Splits a `/48` into Production, Staging, Dev, Reserve (4 × `/50`). |
+
+#### Custom presets
+
+Drop a JSON file into `Subnet-Calculator/data/tree-presets/` (or override the
+location with `$tree_presets_dir` in `config.php`) and it appears in the
+picker on the next page load. The file's basename must match the preset's
+`id` field, and `id` must match `^[a-z0-9-]+$` to keep filesystem lookups
+path-traversal-safe.
+
+A minimal valid preset:
+
+```json
+{
+  "id": "edge-routers-22",
+  "name": "Edge router pair (/22)",
+  "description": "Split a /22 into two /23 edge router blocks.",
+  "family": "ipv4",
+  "rootPrefix": 22,
+  "rootCidr": "10.10.0.0/22",
+  "operations": [
+    { "op": "split",  "cidr": "10.10.0.0/22", "into": 2 },
+    { "op": "rename", "cidr": "10.10.0.0/23", "name": "Edge-A" },
+    { "op": "rename", "cidr": "10.10.2.0/23", "name": "Edge-B" }
+  ]
+}
+```
+
+Each operation is either `split` (with `cidr` + `into ∈ {2, 4, 8, 16}`) or
+`rename` (with `cidr` + `name` + optional `notes`). Operations run in order;
+each one references a CIDR that must already exist in the tree at that step.
+
+Presets are also exposed via REST:
+
+- `GET /api/v1/tree-presets` — manifest list (no `operations` field).
+- `GET /api/v1/tree-presets/{id}` — full preset including operations.
+
+The published JSON-Schema for preset files lives at
+[`api/schemas/tree-preset.schema.json`](https://github.com/seanmousseau/Subnet-Calculator/blob/main/Subnet-Calculator/api/schemas/tree-preset.schema.json).

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,6 +18,7 @@ parameters:
         - Subnet-Calculator/includes/functions-range.php
         - Subnet-Calculator/includes/functions-tree.php
         - Subnet-Calculator/includes/functions-tree-diff.php
+        - Subnet-Calculator/includes/functions-tree-presets.php
         - Subnet-Calculator/includes/functions-apikeys.php
         - Subnet-Calculator/includes/functions-admin-auth.php
         - Subnet-Calculator/includes/functions-admin-totp.php
@@ -41,6 +42,7 @@ parameters:
         - Subnet-Calculator/api/v1/handlers/sessions.php
         - Subnet-Calculator/api/v1/handlers/range.php
         - Subnet-Calculator/api/v1/handlers/tree.php
+        - Subnet-Calculator/api/v1/handlers/tree-presets.php
         - Subnet-Calculator/api/v1/handlers/changelog.php
         - Subnet-Calculator/api/v1/handlers/schemas.php
         - Subnet-Calculator/api/v1/handlers/admin_keys.php

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -4906,6 +4906,11 @@ async def test_tree_editor_merge_via_drag(page: Page) -> None:
     assert_true("split occurred before merge", initial == 3)
     # Drag first child onto second.
     children = page.locator(".tree-editor-children .tree-editor-card")
+    # Scroll children into view so HTML5 drag-and-drop's drop event fires —
+    # Chromium silently drops when source/destination are below the painted
+    # viewport region (#323 added a toolbar button that pushed the canvas
+    # low enough to expose this latent fragility).
+    await children.nth(1).scroll_into_view_if_needed()
     src = await children.nth(0).bounding_box()
     dst = await children.nth(1).bounding_box()
     if src and dst:
@@ -5135,6 +5140,60 @@ async def test_tree_editor_diff_two_sessions(page: Page) -> None:
     assert_true("markdown contains removed marker", "− 10.0.0.128/25" in md)
     assert_true("markdown contains prefix marker",  "Δ 10.0.0.0/25 → 10.0.0.0/26" in md)
     assert_true("markdown contains rename marker",  '~ 10.0.0.0/24: name "DMZ" → "Edge"' in md)
+
+
+# v3.1.0 #323 — tree presets
+async def test_tree_editor_apply_preset_then_undo(page: Page) -> None:
+    section("v3.1.0 #323 tree editor — apply LAN/DMZ/Mgmt preset, then undo")
+    await _open_tree_editor(page, "10.0.0.0/24")
+
+    # Open the preset picker.
+    await page.click(".tree-editor-toolbar [data-action='apply-template']")
+    await page.wait_for_selector("[data-role='preset-modal']:not([hidden])")
+    # Wait until the manifest loads and the picker renders preset items.
+    await page.wait_for_selector(".tree-preset-item[data-preset-id='lan-dmz-mgmt-24']")
+
+    # Click the lan-dmz-mgmt-24 preset.
+    await page.click(".tree-preset-item[data-preset-id='lan-dmz-mgmt-24']")
+    # Confirm pane appears with the editable Root CIDR.
+    await page.wait_for_selector("[data-role='preset-confirm']:not([hidden])")
+    root_value = await page.locator("[data-role='preset-root-cidr']").input_value()
+    assert_true(
+        "root CIDR pre-filled from preset (10.0.0.0/24)",
+        root_value.strip() == "10.0.0.0/24",
+        f"got: {root_value!r}",
+    )
+
+    # Apply.
+    await page.click("[data-role='preset-apply']")
+    # Picker should close; tree editor should now show the split children.
+    await page.wait_for_selector(".tree-editor-children .tree-editor-card")
+
+    # Tree should now have the root + 4 children = 5 nodes total.
+    cidrs = await page.evaluate(
+        "() => Array.from(document.querySelectorAll('.tree-editor-cidr')).map(e=>e.textContent)"
+    )
+    assert_eq("after apply → 5 nodes", str(len(cidrs)), "5")
+    assert_true("LAN child cidr present", "10.0.0.0/26" in cidrs)
+    assert_true("DMZ child cidr present", "10.0.0.64/26" in cidrs)
+    assert_true("Mgmt child cidr present", "10.0.0.128/26" in cidrs)
+    assert_true("Reserve child cidr present", "10.0.0.192/26" in cidrs)
+
+    # The rename ops should have applied — the names render on the cards.
+    names = await page.evaluate(
+        "() => Array.from(document.querySelectorAll('.tree-editor-name')).map(e=>e.textContent)"
+    )
+    for expected in ("LAN", "DMZ", "Mgmt", "Reserve"):
+        assert_true(f"name {expected} rendered", expected in names)
+
+    # Each preset op pushes its own undo frame — undo should peel back the
+    # last rename first (Reserve), not collapse the whole tree.
+    await page.locator(".tree-editor-canvas").click()  # focus inside editor
+    await page.keyboard.press("Control+z")
+    after_names = await page.evaluate(
+        "() => Array.from(document.querySelectorAll('.tree-editor-name')).map(e=>e.textContent)"
+    )
+    assert_true("undo dropped the Reserve rename", "Reserve" not in after_names)
 
 
 async def test_v290_typography(page: Page) -> None:
@@ -5419,6 +5478,8 @@ async def main() -> None:
             await test_tree_editor_share_too_large_fallback(page)
             # v3.1.0 #322 — multi-tree diff
             await test_tree_editor_diff_two_sessions(page)
+            # v3.1.0 #323 — tree presets
+            await test_tree_editor_apply_preset_then_undo(page)
             await test_v290_typography(page)
         finally:
             await context.close()

--- a/testing/unit/TreePresetsTest.php
+++ b/testing/unit/TreePresetsTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validates the tree-preset library (#323, v3.1.0).
+ *
+ * Covers: manifest listing, single-preset load, path-traversal rejection,
+ * schema-shape validation, end-to-end "apply preset → tree_validate()" replay.
+ */
+class TreePresetsTest extends TestCase
+{
+    /**
+     * @return list<string>
+     */
+    private function expectedStarterIds(): array
+    {
+        return [
+            'flat-equal-split-24',
+            'hq-branches-16',
+            'ipv6-site-48',
+            'ipv6-three-tier-48',
+            'lan-dmz-mgmt-24',
+            'three-tier-24',
+        ];
+    }
+
+    public function testListReturnsAllSixStarterPresets(): void
+    {
+        $manifest = tree_presets_list();
+        $ids = array_map(static fn(array $p): string => (string)$p['id'], $manifest);
+        sort($ids);
+        $this->assertSame($this->expectedStarterIds(), $ids);
+
+        // Each manifest entry has the lightweight summary fields the picker
+        // expects — and *not* the heavy `operations` list.
+        foreach ($manifest as $entry) {
+            $this->assertArrayHasKey('name', $entry);
+            $this->assertArrayHasKey('family', $entry);
+            $this->assertArrayHasKey('rootPrefix', $entry);
+            $this->assertArrayHasKey('operationCount', $entry);
+            $this->assertArrayNotHasKey('operations', $entry);
+            $this->assertContains($entry['family'], ['ipv4', 'ipv6']);
+        }
+    }
+
+    public function testLoadValidPreset(): void
+    {
+        $preset = tree_preset_load('lan-dmz-mgmt-24');
+        $this->assertIsArray($preset);
+        $this->assertSame('lan-dmz-mgmt-24', $preset['id']);
+        $this->assertSame('ipv4', $preset['family']);
+        $this->assertSame(24, $preset['rootPrefix']);
+        $this->assertIsArray($preset['operations']);
+        $this->assertGreaterThanOrEqual(1, count($preset['operations']));
+        // First op should be a split.
+        $first = $preset['operations'][0];
+        $this->assertSame('split', $first['op']);
+        $this->assertSame(4, $first['into']);
+    }
+
+    public function testLoadInvalidIdReturnsNull(): void
+    {
+        $this->assertNull(tree_preset_load('does-not-exist'));
+    }
+
+    public function testIdValidationRejectsPathTraversal(): void
+    {
+        // Each of these would escape the presets directory if not guarded.
+        $this->assertNull(tree_preset_load('../../../etc/passwd'));
+        $this->assertNull(tree_preset_load('..'));
+        $this->assertNull(tree_preset_load('/etc/passwd'));
+        $this->assertNull(tree_preset_load(''));
+        $this->assertNull(tree_preset_load('UPPERCASE'));
+        $this->assertNull(tree_preset_load('with spaces'));
+        $this->assertNull(tree_preset_load('semi;colon'));
+    }
+
+    /**
+     * Replay each starter preset's operations starting from the bundled root
+     * CIDR, then assert the resulting tree validates via tree_validate().
+     */
+    public function testStarterPresetExpandsToValidTree(): void
+    {
+        foreach ($this->expectedStarterIds() as $id) {
+            $preset = tree_preset_load($id);
+            $this->assertIsArray($preset, "load failed for $id");
+            $this->assertArrayHasKey('rootCidr', $preset, "no rootCidr on $id");
+            $rootCidr = (string)$preset['rootCidr'];
+
+            $tree = ['cidr' => $rootCidr];
+            foreach ($preset['operations'] as $op) {
+                $tree = $this->applyOp($tree, (array)$op, (string)$preset['family']);
+            }
+
+            try {
+                tree_validate(['type' => 'tree', 'root' => $tree]);
+            } catch (\InvalidArgumentException $e) {
+                $this->fail("Preset $id produced invalid tree: " . $e->getMessage());
+            }
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    public function testSchemaIsValidJsonSchema(): void
+    {
+        $path = dirname(__DIR__, 2) . '/Subnet-Calculator/api/schemas/tree-preset.schema.json';
+        $this->assertFileExists($path);
+        $raw = file_get_contents($path);
+        $this->assertIsString($raw);
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('$schema', $decoded);
+        $this->assertArrayHasKey('$id', $decoded);
+        $this->assertSame('object', $decoded['type'] ?? null);
+        $this->assertArrayHasKey('properties', $decoded);
+        $this->assertArrayHasKey('operations', $decoded['properties']);
+        // operations.items uses oneOf to discriminate split vs rename.
+        $this->assertArrayHasKey('oneOf', $decoded['properties']['operations']['items']);
+    }
+
+    /**
+     * Apply a single operation to the tree.  Mirrors the JS reducer's SPLIT /
+     * RENAME branches closely enough to validate the data shape; this is
+     * test-only — production replay happens in app.js dispatch().
+     *
+     * @param array<string,mixed> $node
+     * @param array<string,mixed> $op
+     * @return array<string,mixed>
+     */
+    private function applyOp(array $node, array $op, string $family): array
+    {
+        $kind = $op['op'] ?? '';
+        $targetCidr = (string)($op['cidr'] ?? '');
+
+        if ($kind === 'split') {
+            $into = (int)$op['into'];
+            return $this->mutateNode($node, $targetCidr, function (array $n) use ($into, $family): array {
+                $children = $this->splitInto((string)$n['cidr'], $into, $family);
+                $n['children'] = array_map(static fn(string $c): array => ['cidr' => $c], $children);
+                return $n;
+            });
+        }
+        if ($kind === 'rename') {
+            $name = (string)$op['name'];
+            $notes = isset($op['notes']) ? (string)$op['notes'] : null;
+            return $this->mutateNode($node, $targetCidr, function (array $n) use ($name, $notes): array {
+                $n['name'] = $name;
+                if ($notes !== null && $notes !== '') {
+                    $n['notes'] = $notes;
+                }
+                return $n;
+            });
+        }
+        return $node;
+    }
+
+    /**
+     * Walk the tree and apply $fn to the node whose cidr matches.
+     *
+     * @param array<string,mixed> $node
+     * @param callable(array<string,mixed>):array<string,mixed> $fn
+     * @return array<string,mixed>
+     */
+    private function mutateNode(array $node, string $cidr, callable $fn): array
+    {
+        if (($node['cidr'] ?? '') === $cidr) {
+            return $fn($node);
+        }
+        if (isset($node['children']) && is_array($node['children'])) {
+            $kids = [];
+            foreach ($node['children'] as $child) {
+                if (is_array($child)) {
+                    $kids[] = $this->mutateNode($child, $cidr, $fn);
+                }
+            }
+            $node['children'] = $kids;
+        }
+        return $node;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitInto(string $cidr, int $count, string $family): array
+    {
+        $parts = explode('/', $cidr, 2);
+        $ip = $parts[0];
+        $px = (int)$parts[1];
+        $bits = (int)log($count, 2);
+        $newPx = $px + $bits;
+        $totalBits = $family === 'ipv6' ? 128 : 32;
+        $shift = $totalBits - $newPx;
+
+        $out = [];
+        if ($family === 'ipv4') {
+            $start = ip2long($ip) & 0xFFFFFFFF;
+            $stride = $shift >= 32 ? 0 : (1 << $shift);
+            for ($i = 0; $i < $count; $i++) {
+                $addr = ($start + $i * $stride) & 0xFFFFFFFF;
+                $ipStr = long2ip((int)$addr);
+                $out[] = $ipStr . '/' . $newPx;
+            }
+            return $out;
+        }
+        // IPv6 via GMP.
+        $bin = inet_pton($ip);
+        if ($bin === false) {
+            return [];
+        }
+        $g = gmp_init(bin2hex($bin), 16);
+        $stride = gmp_pow(2, $shift);
+        for ($i = 0; $i < $count; $i++) {
+            $cur = gmp_add($g, gmp_mul($stride, $i));
+            $hex = str_pad(gmp_strval($cur, 16), 32, '0', STR_PAD_LEFT);
+            $packed = hex2bin($hex);
+            if ($packed === false) {
+                continue;
+            }
+            $ipStr = inet_ntop($packed);
+            if ($ipStr === false) {
+                continue;
+            }
+            $out[] = $ipStr . '/' . $newPx;
+        }
+        return $out;
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -18,3 +18,4 @@ require $base . 'functions-resolve.php';
 require $base . 'functions-range.php';
 require $base . 'functions-tree.php';
 require $base . 'functions-tree-diff.php';
+require $base . 'functions-tree-presets.php';


### PR DESCRIPTION
## Summary

Issue: #323. Closes the v3.0.0 tree-editor's biggest UX gap: every tree had to be built click-by-click. This PR adds an **Apply Template** picker plus six bundled starter presets, with operator extensibility via `data/tree-presets/`.

- **JSON-Schema** at `api/schemas/tree-preset.schema.json` (Draft 2020-12). Each preset declares `id` (`^[a-z0-9-]+$`), `name`, `family` (`ipv4`|`ipv6`), `rootPrefix`, optional `rootCidr`, and an `operations` array (`split` w/ `into ∈ {2,4,8,16}` or `rename` w/ name+notes).
- **Six starters:** `lan-dmz-mgmt-24`, `three-tier-24`, `hq-branches-16`, `flat-equal-split-24`, `ipv6-site-48`, `ipv6-three-tier-48`.
- **Loader** (`includes/functions-tree-presets.php`) + **REST endpoints** `GET /api/v1/tree-presets` and `GET /api/v1/tree-presets/{id}`. Path-traversal hardened (id pattern re-validated before any filesystem call).
- **Picker modal** (toolbar `Diff | Apply Template | spacer | Reset`). Two-pane list→confirm flow matching the Diff modal pattern, no new colour primitives.
- **Apply replays each operation through `dispatch()`** so each step pushes its own undo frame and CIDRs rebase from the preset's baked-in root to the user-chosen root via BigInt offsets.

## ui-ux-pro-max consults (verbatim)

### PRE-edit

> 1. **Presentation:** Single centered `.tree-modal` for both desktop and touch. Reuse existing `.tree-modal-card`. Do NOT fork into `.tree-action-sheet` — the picker requires a list-with-details affordance that the bottom sheet (single-action vertical buttons) is wrong for. The existing Diff modal already establishes the modal-on-touch precedent for list-of-options UX. Cards stack vertically (single column) inside a `max-height: 60vh; overflow-y: auto` scroll region. Each card shows: preset name (bold), family chip (`v4` / `v6` — reuse `.tree-diff-legend-item` styling, no new primitives), short description, and a muted line `Root: <rootPrefix> · <op-count> operations`. No icons (avoids "AI emoji" smell per skill guidance).
> 2. **Input flow:** Two-pane Step-1/Step-2 inside the same modal (matches Diff modal's input→result transition). Step 1: pick a preset card (click selects, Enter/Space activates, arrow keys navigate). Step 2 (replaces the picker pane): editable `Root CIDR` input pre-filled with the preset's default (e.g. `10.0.0.0/24`); a `← Back` button; primary `Apply` and secondary `Cancel`. Reusing the existing Root CIDR field (option C) was rejected: it would force a context switch out of the modal and lose the preset's metadata.
> 3. **Toolbar placement:** Right of `Diff`, before the spacer (i.e. read-mostly + tree-mutating actions on the right of the spacer; this is a tree-mutating action that's also discovery-focused). Final order: `… Share URL | Diff | Apply Template | spacer | Reset`. Label text: `Apply Template` (verb-first matches `Save Session`, `Copy CIDR`, etc.).
> 4. **Error handling:** Top-of-modal alert pattern matching Diff: a `[data-role="preset-error"]` div with `role="alert"`, hidden by default. Errors: invalid CIDR syntax, family mismatch (v6 preset with v4 input), prefix length mismatch (preset expects /24, user enters /23), fetch failure, or schema validation failure on Apply. Inline-under-card was rejected — errors apply to Step 2, not Step 1, so a top-of-pane location is correct.
> 5. **Status cue:** Yes — surface via existing `setStatus()`: `Applied template "{name}". Press Ctrl+Z to undo.` after successful Apply. This matches the existing `Saved as session …` and `Share URL copied.` patterns. No toast — the status bar is sufficient and respects `prefers-reduced-motion`.
> 6. **Keyboard / ARIA:**
>    - Dialog: `role="dialog" aria-modal="true" aria-labelledby="tree-preset-title"`.
>    - Step 1: preset list rendered as `role="listbox"`, each card `role="option" tabindex="0"`. Arrow keys move selection (matches the existing diff-tab `[role="tab"]` keyboard pattern). Enter/Space advances to Step 2.
>    - Step 2 tab order: Root CIDR input → Apply → Cancel → Back. Initial focus on Root CIDR input.
>    - Esc closes the modal at any pane (matches Diff modal's existing handler).
>    - Focus returns to the `Apply Template` toolbar button on close.
> 7. **User-extensibility hint:** Keep a one-line footer inside the Step-1 pane: `Drop a JSON into data/tree-presets/ to add your own. <a>Schema reference</a>` linking to `docs/tree.md#templates`. Style as `.tree-modal-help` (existing token).
>
> **Tokens (no new primitives):** `.tree-modal`, `.tree-modal-card`, `.tree-modal-help`, `.tree-modal-actions`, `.tree-modal-cancel`, `.splitter-btn` (Apply), `.tree-editor-btn` (Back / Cancel), `.tree-modal-label` (Root CIDR field), `.tree-diff-legend-item` (family chip).

### POST-edit verdict

Design implementation matches the pre-edit spec verbatim:
- Single centered `.tree-modal` reused (unified for desktop + touch via `[hidden]`).
- Cards stacked vertically inside `max-height: 50vh; overflow-y: auto`, with name + family chip (`v4`/`v6`) + description + "Root /N · M operations" meta line.
- No new colour primitives — reused `--color-border`, `--color-surface-alt`, `--color-accent`, `--color-text-muted`, `--color-error-*`.
- Two-pane Step-1/Step-2 transition matching Diff modal's input→result pattern; pre-fills the preset's `rootCidr` and supports edit-in-place override.
- Toolbar placement: `Diff | Apply Template | spacer | Reset`.
- Errors via top-of-card `[data-role="preset-error"][role="alert"]` matching `tree-diff-error`.
- `setStatus()` post-apply: `Applied template "{name}". Press Ctrl+Z to undo.`
- ARIA: `role="dialog" aria-modal="true" aria-labelledby="tree-preset-title"`. List `role="listbox"`; cards `role="option"` with `aria-selected`. Arrow keys navigate; Esc closes; focus returns to toolbar via `presetLastFocused`.
- Footer extensibility hint kept inside Step-1 pane with link to docs.
- Each preset op pushes its own undo frame so Ctrl+Z peels back stepwise — verified by the Playwright test (`undo dropped the Reserve rename`).

## QA gates

- `vendor/bin/phpunit`: **344 / 344**, **794 assertions** (was 338 / 713; +6 cases, +81 assertions)
- `phpstan analyse --memory-limit=512M`: clean
- `vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/`: clean
- `vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/`: clean
- `npx @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml`: 0 errors
- `semgrep ... Subnet-Calculator/{includes,api,templates}/`: 0 findings
- `npm run lint`: 0 errors (9 pre-existing warnings unchanged)
- `make test-docker`: **903 / 903** passed (was 892; +11 assertions for the new preset group)

## Test plan

- [ ] Open IPv4 tab → Tools drawer → Tree Editor → enter `10.0.0.0/24` → click **Apply Template**.
- [ ] Picker modal opens; six starter cards render with family chip + meta line.
- [ ] Click `lan-dmz-mgmt-24` → confirm pane shows pre-filled `10.0.0.0/24` Root CIDR.
- [ ] Click **Apply** → editor renders root + four named children (LAN, DMZ, Mgmt, Reserve).
- [ ] Press `Ctrl+Z` four times — each press peels off one rename; further Ctrl+Z removes the split.
- [ ] Drop a custom JSON into `Subnet-Calculator/data/tree-presets/` and reload — verify it appears in the picker.
- [ ] Hit `GET /api/v1/tree-presets` and `GET /api/v1/tree-presets/lan-dmz-mgmt-24` directly to confirm the API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)