### PR TITLE
docs: fix broken ../CLAUDE.md link in admin.md (mkdocs strict mode)

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -247,7 +247,7 @@ The token is generated per-run by `make test-docker` and passed to both
 the `webapp` and `playwright-tests` containers via docker-compose env. It
 is never baked into the image and never committed to source.
 
-The release-tarball build step in [CLAUDE.md](../CLAUDE.md) excludes
+The release-tarball build step (see `CLAUDE.md` in the [repository root](https://github.com/seanmousseau/Subnet-Calculator/blob/main/CLAUDE.md)) excludes
 `admin/_test-drain.php` so the file never ships to operators. If you copy
 the file to a production host by accident, it stays inert because the
 production environment does not set `PHPUNIT_TEST_DRAIN_TOKEN`.


### PR DESCRIPTION
Hot-fix for the failed v3.1.0 docs deploy. `docs/admin.md` linked `../CLAUDE.md` from the v3.1.0 #324 work, but CLAUDE.md is not part of the mkdocs site and the strict-mode build aborts on the missing-target warning. Replaced with an absolute repo URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated admin documentation to clarify behavior and safety measures around test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->