### PR TITLE
docs: v3.3.0 IPv6 Foundations — design spec + implementation plan

### DIFF
--- a/docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md
+++ b/docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md
@@ -269,7 +269,7 @@ pattern, reused identically.
 
 ### API flow
 
-```
+```text
 client → POST /api/v1/<endpoint>
        → api/v1/index.php router
        → handlers/<endpoint>.php (Basic Auth + rate limit + CORS via helpers.php)
@@ -281,7 +281,7 @@ Identical to every existing endpoint.
 
 ### Shareable URL shape
 
-```
+```text
 ?tab=ipv6&tool=range6&range6_start=2001:db8::&range6_end=2001:db8::ffff
 ?tab=ipv6&tool=supernet6&supernet6_action=summarise&supernet6_input=…
 ?tab=ipv6&tool=zoneid&zoneid_input=fe80::1%25eth0
@@ -400,7 +400,7 @@ release PR.
 - IPv6 tab with each new drawer **closed** (sanity)
 - Each new drawer **open** with a representative result
 - Each new drawer **error state**
-- One full-page IPv6 snapshot with all drawers labelled
+- One full-page IPv6 snapshot with all drawers labeled
 
 ### Static analysis & lint (no new tools)
 

--- a/docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md
+++ b/docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md
@@ -1,0 +1,479 @@
+# v3.3.0 — IPv6 Foundations (Design Spec)
+
+**Date:** 2026-05-06
+**Status:** Approved (brainstorming complete)
+**Milestone position:** First of four IPv6-themed minor releases.
+
+## Milestone context
+
+Subnet Calculator is healthy at v3.2.x and the calculator surface itself
+hasn't changed since v2.11. v4 and v6 features are nearly at parity, but
+the v6 tab is sparser and missing several capabilities the v4 tab has
+already grown — and there's a separate body of IPv6-native capability
+(SLAAC, transition mechanisms, multicast, prefix delegation) that the
+project doesn't currently surface at all.
+
+This spec defines **v3.3.0** only. It's the first of a four-release IPv6
+milestone:
+
+| Release | Theme | Scope |
+|---|---|---|
+| **v3.3.0 (this spec)** | IPv6 Foundations | Parity ports + address derivation + zone-ID parser |
+| v3.4.0 | IPv6 Prefix Planning | Prefix-delegation planner, nibble-boundary helper, RFC 3531 sparse-allocation guidance |
+| v3.5.0 | IPv6 Transition | NAT64 / DNS64 / 6to4 / Teredo / ISATAP / 6rd; embedded-v4 detector |
+| v3.6.0 | IPv6 Multicast | Scope decoder, embedded-RP (RFC 3956), RFC 3306; PMTU helper |
+
+Each release is independently shippable; later releases get their own
+specs at their turn.
+
+## Goal
+
+Bring the IPv6 tab to v4 parity for the two missing capabilities
+(`range→CIDR`, `supernet`/`summarise`) and add three foundational
+IPv6-native capabilities (zone-ID parsing, MAC-derived addresses,
+SLAAC privacy addresses).
+
+## Non-goals
+
+- Transition mechanisms (NAT64, 6to4, Teredo, ISATAP, 6rd, DNS64)
+  → deferred to v3.4–v3.6
+- Multicast tooling (scope, RP, RFC 3306) → v3.6
+- Prefix-delegation planner → v3.4
+- Any new top-level tab. v3.3.0 adds **zero** new tabs.
+- Any new design tokens or CSS custom properties.
+- Any change to authentication, the admin surface, or the API
+  authentication layer.
+
+## Audience
+
+Primary user is "anyone who needs an IPv6 calculator" — equally a
+small-shop admin who needs an EUI-64 derived from a MAC and a senior
+network engineer scripting against the API. Every tool ships with
+strong inline help-bubble explanations (educational layer) AND a clean
+API surface + shareable URL (engineer layer).
+
+## Architecture
+
+### Code organisation
+
+New PHP modules in `Subnet-Calculator/includes/`:
+
+- `functions-range6.php` — `range6_to_cidrs(string $start, string $end): array`
+- `functions-supernet6.php` — `supernet6_find(array $cidrs): array`,
+  `summarise6_cidrs(array $cidrs): array`
+- `functions-derive6.php` — combined home for all derivation helpers
+  (they share GMP / MAC parsing logic, and grouping the three MAC-based
+  outputs in one module reflects how they're rendered in the UI):
+  - `mac_to_eui64(string $mac): string`
+  - `mac_to_link_local(string $mac): string`
+  - `unicast_to_solicited_node(string $ipv6): string`
+  - `slaac_privacy_address(string $prefix, ?string $seed = null): array`
+  - `parse_zone_id(string $input): array`
+
+New API handlers in `Subnet-Calculator/api/v1/handlers/`:
+
+- `range6.php` → `POST /api/v1/range6`
+- `supernet6.php` → `POST /api/v1/supernet6`
+- `zone-id.php` → `POST /api/v1/zone-id`
+- `derive.php` → `POST /api/v1/derive`
+- `slaac-privacy.php` → `POST /api/v1/slaac-privacy`
+
+Each handler is a thin shim that calls a `functions-*.php` helper and
+formats via `json_ok` / `json_err`. Heavy logic stays in the helpers so
+PHPUnit can exercise it without booting the API stack.
+
+### UI placement (decided after live-prod audit)
+
+All five tools land as drawer entries on the **existing IPv6 tab**.
+**Zero new top-level tabs.** This was confirmed by Playwright audit at
+375 / 1280 px against subnetcalculator.app: the IPv4 tab already hosts
+8 drawer entries cleanly (4 × 2 buttons mobile, 1 row of 6 + 1 of 2
+desktop); growing the IPv6 drawer from 4 to 9 entries lands at the same
+density as the IPv4 tab today, with headroom.
+
+| Tool | Drawer entry label | Behaviour |
+|---|---|---|
+| range6→CIDR | `Range→CIDR` | Mirror of v4 Range entry |
+| supernet6 / summarise6 | `Supernet` | Mirror of v4 Supernet entry; action toggle find/summarise |
+| zone-ID parser | `Zone ID` | New utility |
+| derive (combined) | `Derive Address` | One MAC input → three outputs (EUI-64, link-local, solicited-node) |
+| SLAAC privacy | `SLAAC Privacy` | Prefix + optional seed |
+
+The "Derive Address" tool is intentionally combined: a single MAC paste
+yields all three derivations side-by-side with their own copy buttons.
+This is both a usability win (one input, three outputs) and a pedagogy
+win (the relationship between EUI-64, link-local, and solicited-node
+becomes visible at a glance).
+
+### Naming
+
+New symbols use the `6` suffix where the name would otherwise be
+ambiguous between v4 and v6 — matching existing conventions like
+`calculate_subnet6` (vs `calculate_subnet`) and `vlsm6_allocate`.
+Symbols whose names already imply IPv6 unambiguously
+(`mac_to_eui64`, `mac_to_link_local`, `unicast_to_solicited_node`,
+`slaac_privacy_address`, `parse_zone_id`) do not need the suffix —
+this also matches existing precedent like `gmp_to_ipv6`.
+
+## Component contracts
+
+### 1. `range6→CIDR`
+
+```php
+function range6_to_cidrs(string $start, string $end): array;
+// Returns:
+//   ['cidrs' => ['2001:db8::/64', ...],
+//    'count' => 12,
+//    'total_addresses' => '2^65',  // string when overflowing PHP int
+//    'truncated' => false,
+//    'cap' => 256]
+```
+
+- Inputs: any IPv6 form parseable by `inet_pton`; full or compressed.
+- Validation: both ends parse; `$start ≤ $end` (GMP compare); reject
+  v4 input.
+- **Output cap:** maximum 256 CIDRs by default, configurable via
+  `$range_max_cidrs` in `config.php`. The cap is on the count of
+  output CIDRs, not on total addresses (the algorithm's output is
+  bounded by bit-alignment of endpoints, not address count). When the
+  cap is hit, `truncated` is true and the caller sees the partial
+  result with a warning band.
+- **The same cap is applied to v4 `range_to_cidrs`** — it currently has
+  no cap, which is a latent issue this release fixes. Backport flagged
+  in the v3.3.0 changelog under `Changed`, not `Added`, since
+  long-time API consumers requesting fragmented ranges may newly hit
+  truncation.
+
+API: `POST /api/v1/range6 {start, end}` → schema mirrors return shape.
+
+### 2. `supernet6 / summarise6`
+
+```php
+function supernet6_find(array $cidrs): array;
+function summarise6_cidrs(array $cidrs): array;
+// supernet6_find returns:    ['supernet' => '2001:db8::/32', 'count' => 12]
+// summarise6_cidrs returns:  ['summaries' => ['2001:db8::/33', ...]]
+```
+
+- Inputs: array of IPv6 CIDR strings, max 50 (matches v4 cap).
+- Validation: every entry resolves via `resolve_ipv6_input()`; reject
+  mixed v4+v6 (`'All entries must be IPv6.'`).
+- `find` with no common ancestor returns
+  `['supernet' => null, 'count' => 0]` — empty result, not an error.
+
+API: `POST /api/v1/supernet6 {action: 'find'|'summarise', cidrs[]}`.
+
+### 3. `zone-ID parser`
+
+```php
+function parse_zone_id(string $input): array;
+// Returns:
+//   ['address'       => 'fe80::1',
+//    'zone_id'       => 'eth0',
+//    'is_link_local' => true,
+//    'warning'       => null]
+```
+
+- Input: `fe80::1%eth0` form; address with optional `%zone` suffix.
+- Validation: address parses; zone is `[A-Za-z0-9_-]{1,32}` if present.
+- **Zone supplied with non-link-local address** is a warning, not an
+  error — the result still renders, with a yellow `--color-warning`
+  banner explaining that zone IDs are only meaningful on link-local
+  addresses.
+
+API: `POST /api/v1/zone-id {input}`.
+
+### 4. `derive` (combined MAC → IPv6 forms)
+
+```php
+// Single combined function for the API + web flow:
+function derive_from_mac(string $mac): array;
+// Returns:
+//   ['mac_canonical'  => '00:24:b9:7e:ab:cd',
+//    'eui64'          => '0226:b9ff:fe7e:abcd',
+//    'ul_bit_flipped' => true,
+//    'link_local'     => 'fe80::226:b9ff:fe7e:abcd',
+//    'solicited_node' => 'ff02::1:ff7e:abcd']
+
+// Backed by three smaller helpers (also exported for unit testing):
+function mac_to_eui64(string $mac): string;
+function mac_to_link_local(string $mac): string;
+function unicast_to_solicited_node(string $ipv6): string;
+```
+
+- Input: MAC in any common form (`00:24:b9:7e:ab:cd`,
+  `00-24-b9-7e-ab-cd`, `0024.b97e.abcd`, `0024b97eabcd`).
+- Validation: normalize to canonical lowercase colon form; reject
+  length ≠ 6 octets or non-hex chars.
+- Multicast bit set → warning, not error (proceed with derivation).
+- **RFC compliance vectors** in tests: pull MACs from RFC 4291 §2.5.1
+  examples, compare byte-for-byte. Catches U/L bit mistakes that pass
+  naïve testing.
+
+API: `POST /api/v1/derive {mac}`.
+
+### 5. `slaac-privacy`
+
+```php
+function slaac_privacy_address(string $prefix, ?string $seed = null): array;
+// Returns:
+//   ['prefix'             => '2001:db8:1:2::/64',
+//    'address'            => '2001:db8:1:2:a8d3:f4e1:0c52:9837',
+//    'interface_id'       => 'a8d3:f4e1:0c52:9837',
+//    'seed_used'          => '<16-hex>',
+//    'seed_was_provided'  => false]
+```
+
+- Input: prefix (must be `/64` per RFC 4941/8981); optional 16-char
+  hex seed for reproducibility.
+- **Random source:** `random_bytes(8)` (cryptographically secure) when
+  no seed is provided. Per RFC 8981 §3.3.1. Never `mt_rand()`. If
+  `random_bytes()` fails, the API returns 500 — no fallback.
+- **U/L bit:** the universal/local bit (bit 6 of byte 8) is cleared on
+  the generated interface ID. EUI-64 sets it to 1; privacy addresses
+  must clear it to 0. This is the strongest distinguisher and a
+  property-test target.
+- **Seed parameter** is a power-user/testing field. Surfaced in the UI
+  inside an "Advanced" disclosure (collapsed by default) labeled with
+  copy explaining it's for reproducibility and that production use
+  should generally leave it blank.
+
+API: `POST /api/v1/slaac-privacy {prefix, seed?}`.
+
+## Data flow
+
+### Web flow
+
+For each new tool, add a helper in `request.php`:
+
+```php
+function sc_run_range6(array $src): void {
+    // $src is $_POST or $_GET — same code path
+    // 1. read + trim inputs
+    // 2. validate via resolve_ipv6_input()
+    // 3. call range6_to_cidrs()
+    // 4. populate template globals
+}
+```
+
+`request.php` dispatches:
+
+- **POST** when the relevant `*_action` key is set on `$_POST` and
+  `$active_tab === 'ipv6'`
+- **GET** when the relevant key is set on `$_GET` (shareable-URL
+  hydration); GET hydration ignores `$active_tab` because the URL
+  itself sets the tab
+
+Both branches call the same helper. This is the v2.11 lookup/diff
+pattern, reused identically.
+
+### API flow
+
+```
+client → POST /api/v1/<endpoint>
+       → api/v1/index.php router
+       → handlers/<endpoint>.php (Basic Auth + rate limit + CORS via helpers.php)
+       → includes/functions-*.php helper
+       → json_ok() / json_err()
+```
+
+Identical to every existing endpoint.
+
+### Shareable URL shape
+
+```
+?tab=ipv6&tool=range6&range6_start=2001:db8::&range6_end=2001:db8::ffff
+?tab=ipv6&tool=supernet6&supernet6_action=summarise&supernet6_input=…
+?tab=ipv6&tool=zoneid&zoneid_input=fe80::1%25eth0
+?tab=ipv6&tool=derive&derive_mac=00:24:b9:7e:ab:cd
+?tab=ipv6&tool=slaac&slaac_prefix=2001:db8:1:2::/64&slaac_seed=…
+```
+
+`tool=` controls which drawer panel is auto-opened on render — same
+mechanism as the existing `$open_tool_ipv4` / `$open_tool_ipv6`
+template variables.
+
+### JS contract
+
+- Forms submit natively; no fetch / no JSON. Page reloads with
+  server-rendered results. Matches every existing drawer.
+- Reuse the existing `copyToClipboard()` helper.
+- MAC normalisation stays server-side; no client-side mirroring.
+- No new external deps (no npm install, no CDN loads).
+
+## Error handling
+
+Errors fall into four categories. Same handling pattern as existing
+tools — no new infrastructure.
+
+| Tool | Error | Message | HTTP |
+|---|---|---|---|
+| range6 | Either field empty | `Start and end IPv6 addresses are required.` | 400 |
+| range6 | Invalid IPv6 | `Invalid IPv6 address: <input>` | 400 |
+| range6 | start > end | `Start must be less than or equal to end.` | 400 |
+| range6 | Output exceeds cap | (200 with `truncated: true` + warning) | 200 |
+| supernet6 | Empty | `Enter at least one CIDR.` | 400 |
+| supernet6 | > 50 CIDRs | `Maximum 50 CIDRs per request.` | 400 |
+| supernet6 | Mixed v4/v6 | `All entries must be IPv6.` | 400 |
+| supernet6 | Invalid CIDR | `Invalid IPv6 CIDR: <input>` | 400 |
+| supernet6 | find: no common ancestor | (200, empty result) | 200 |
+| zone-id | Empty | `Enter an address (with optional %zone).` | 400 |
+| zone-id | Invalid address | `Invalid IPv6 address: <input>` | 400 |
+| zone-id | Zone with non-link-local | (warning, not error) | 200 |
+| zone-id | Bad zone format | `Zone identifier must be 1–32 alphanumeric characters.` | 400 |
+| derive | Empty MAC | `Enter a MAC address.` | 400 |
+| derive | Wrong length | `MAC must be 6 octets (12 hex chars).` | 400 |
+| derive | Non-hex | `Invalid MAC: <input>` | 400 |
+| derive | Multicast bit set | (warning, proceed) | 200 |
+| slaac-privacy | Empty prefix | `Enter an IPv6 prefix.` | 400 |
+| slaac-privacy | Not /64 | `SLAAC privacy addresses require a /64 prefix.` | 400 |
+| slaac-privacy | Invalid prefix | `Invalid IPv6 prefix: <input>` | 400 |
+| slaac-privacy | Bad seed | `Seed must be 16 hexadecimal characters.` | 400 |
+
+### Display rules
+
+- Web: `<div class="error-msg">` near the form, using `--color-error`.
+  Existing pattern.
+- API: `json_err($message, $http_status)` — standard.
+- Warnings render as a yellow `--color-warning` band above the result;
+  result still renders.
+- Validation order: presence → length → format → semantic. Stop at first
+  failure per field.
+
+### Security defaults
+
+- All inputs go through `htmlspecialchars()` before any echo (existing
+  `e()` helper). No tool exception.
+- API responses never echo input payloads beyond the offending value.
+- `random_bytes()` for SLAAC privacy fails fast — no `mt_rand()`
+  fallback.
+- No new CSRF surface; web reuses existing form-protection
+  (honeypot/Turnstile); API uses Basic Auth + rate limiting per
+  existing handlers.
+- No new logging of user inputs.
+
+## Testing
+
+### PHPUnit (pure-function logic)
+
+| New file | Tests | Notes |
+|---|---|---|
+| `Range6Test.php` | ~20 | Boundary alignments, fragmented ranges, max-output cap, single-CIDR cases |
+| `Supernet6Test.php` | ~16 | `find` ancestor cases, `summarise` merging, mixed-v4 rejection |
+| `Derive6Test.php` | ~25 | EUI-64 RFC 4291 vectors, link-local, solicited-node, MAC normalisation, U/L bit verification |
+| `SlaacPrivacyTest.php` | ~12 | RFC 8981 invariants (length, prefix preserved, U/L=0, distinctness across calls) + seeded determinism |
+| `ZoneIdTest.php` | ~10 | Address+zone parsing, zone-without-link-local warning, malformed zones |
+
+**Total: ~83 new unit tests.** PHPUnit count goes 226 → ~309.
+
+### Playwright (UI + API + shareable URL)
+
+| Tool | Coverage |
+|---|---|
+| range6 | UI submit, error display, copy buttons, shareable URL hydration, API parity |
+| supernet6 | Both `find` and `summarise` actions, multi-line input, 50-CIDR cap, shareable URL |
+| zone-id | Address+zone display, warning rendering for non-link-local zone |
+| derive | MAC paste, all 3 outputs render, copy button per row, shareable URL |
+| slaac-privacy | Generate without seed, generate with seed (deterministic), advanced disclosure expand |
+
+Plus regression checks:
+
+- IPv6 tab drawer count is 9 (4 existing + 5 new)
+- New `data-tool` panels open via `?tool=` hydration
+- Console error monitor: zero JS regressions
+- Light + dark theme passes for each new form
+
+**Estimated: ~25 new test groups, ~120 new assertions.** Playwright
+total goes 135 → ~160 groups, ~1066 → ~1186 assertions.
+
+### OpenAPI / Spectral
+
+Five new endpoints in `Subnet-Calculator/api/openapi.yaml`. Each entry:
+full request/response schemas, ≥ 1 example, `400` error schema. Spectral
+must pass with zero errors; warnings reviewed and triaged in the
+release PR.
+
+### Visual regression
+
+`testing/snapshots/` gets new baselines for:
+
+- IPv6 tab with each new drawer **closed** (sanity)
+- Each new drawer **open** with a representative result
+- Each new drawer **error state**
+- One full-page IPv6 snapshot with all drawers labelled
+
+### Static analysis & lint (no new tools)
+
+- PHPStan L9, `--memory-limit=512M`, across PHP 8.2 / 8.3 / 8.4
+- PHPCS PSR-12 over new files in `includes/` + `api/v1/handlers/`
+- Semgrep over the new files (no DB, no SQL — should be a clean pass)
+- ESLint + Stylelint — only relevant if new JS/CSS lands; the plan
+  keeps JS minimal so likely no new violations
+
+### CI matrix impact
+
+Estimate +10–15% Playwright runtime, +5% PHPUnit. No matrix changes.
+
+### Test ordering during implementation
+
+Per tool:
+
+1. PHP function + PHPUnit tests (TDD-friendly, no UI deps)
+2. API handler + OpenAPI entry; smoke via curl
+3. UI form + drawer panel; manual smoke
+4. Playwright UI + shareable-URL tests
+5. Visual snapshot baseline
+6. Docs page
+
+## Implementation sequencing
+
+Sequential PR fan-out off `release/v3.3.0`, modelled on v3.2.0's
+PR1–PR10 pattern. Each tool is its own PR; all PRs merge into
+`release/v3.3.0`; the final release-cut PR opens
+`release/v3.3.0 → main`.
+
+Order is from most-familiar to most-novel: parity ports of v4 tools
+land first (smallest review surface, well-understood patterns), then
+the new IPv6-native tools.
+
+| PR | Scope | Depends on |
+|---|---|---|
+| 1 | Branch + living-doc + memory bootstrap | — |
+| 2 | `range6→CIDR` (and v4 cap backport) | PR1 |
+| 3 | `supernet6 / summarise6` | PR2 |
+| 4 | `zone-ID parser` | PR3 |
+| 5 | `derive` (combined MAC tool) | PR4 |
+| 6 | `slaac-privacy` | PR5 |
+| 7 | Release cut → tag → publish → deploy | PR6 |
+
+PRs land sequentially. Every PR's CI must be green and CodeRabbit
+findings resolved before the next PR begins.
+
+## Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| v4 `range_to_cidrs` cap backport surprises an existing API consumer | Low | Default cap (256) is generous; configurable; called out under `Changed` in changelog, not `Added` |
+| IPv6 drawer density on mobile becomes uncomfortable | Low | Verified at 375 px against current 8-entry IPv4 drawer; 9 entries fits the same density |
+| Tab-bar "VLSM IPv6" wrap re-emerges with new tool labels | None — preempted | Fixed in v3.2.4 (`white-space: nowrap` on `.tab-btn`); all new drawer entries are short labels regardless |
+| RFC 4291 / RFC 8981 vector mistakes in derivation tests | Medium | Tests use byte-for-byte vectors directly from the RFCs, not synthetic ones |
+| `random_bytes()` unavailable | Negligible | PHP 7.0+ guarantees it; CI matrix is 8.2+. If it fails at runtime, fail fast with 500 — never fall back |
+
+## Out of scope (explicitly deferred)
+
+- Transition mechanisms (NAT64, DNS64, 6to4, Teredo, ISATAP, 6rd) → v3.5
+- Multicast tooling (scope, embedded-RP, RFC 3306) → v3.6
+- Prefix-delegation planner → v3.4
+- Embedded-v4 detector → v3.5
+- PMTU helper → v3.6
+- Any UI redesign of the tab bar or drawer pattern itself
+- Any change to admin / settings / API authentication
+
+## References
+
+- RFC 4291 — IP Version 6 Addressing Architecture
+- RFC 4193 — Unique Local IPv6 Unicast Addresses (already in v2.7.0)
+- RFC 4941 — Privacy Extensions for SLAAC (obsoleted by 8981)
+- RFC 8981 — Temporary Address Extensions for SLAAC in IPv6
+- Existing project conventions: `CLAUDE.md`,
+  `docs/superpowers/specs/2026-04-23-tool-drawer-design.md`

--- a/docs/superpowers/plans/2026-05-06-v3.3.0-release.md
+++ b/docs/superpowers/plans/2026-05-06-v3.3.0-release.md
@@ -1,0 +1,1077 @@
+# v3.3.0 Implementation Plan — IPv6 Foundations
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Mandatory consultations:**
+> - **`ui-ux-pro-max` skill** — invoke before AND after any markup/CSS edit on every UI-bearing task (PR2–PR6 — every tool ships drawer markup + form + result panel, so every PR is UI-bearing). Same design-language gate as v3.2.0.
+> - **`documentation` skill** — invoke for every doc edit (`docs/*.md`, `CHANGELOG.md`, `README.md`, `mkdocs.yml`, the living-doc).
+> - **Memory MCP** — `add_observations` to `project:subnet-calculator:release:v3.3.0` (create the entity on Task 0) at the close of every task. Required fields per CLAUDE.md: factual sentence, files touched, git short hash, test result.
+>
+> **No deferrals without explicit user approval.** Every tool listed below ships in v3.3.0. If a finding cannot be addressed in the current task, surface it before continuing — do not silently push to "later".
+
+**Goal:** Ship v3.3.0 — the first of four IPv6-themed minor releases — adding five new tools (range6→CIDR, supernet6/summarise6, zone-ID parser, MAC-derived address combo, SLAAC privacy generator) plus a v4 `range_to_cidrs` cap backport, all under one unified design language with complete docs, tests, and OpenAPI coverage.
+
+**Architecture:** Sequential PR fan-out off `release/v3.3.0`, modelled on v3.2.0's PR1–PR10 pattern. Each tool is its own PR; all PRs merge into `release/v3.3.0`; the final release-cut PR opens `release/v3.3.0 → main`. Order is most-familiar to most-novel: parity ports first (range6, supernet6 — well-understood patterns), then the IPv6-native foundations (zone-id, derive, slaac-privacy). All five tools land as drawer entries on the existing IPv6 tab — zero new top-level tabs.
+
+**Tech Stack:** PHP 8.2+ (strict types, GMP), SQLite3 (existing), plain JS, mkdocs + spectral, PHPUnit 11, Playwright 1.4x via docker, PHPStan L9, PHPCS PSR-12, Semgrep.
+
+**Spec reference:** [`docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md`](../../internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md)
+
+---
+
+## Sequencing
+
+| PR | Tool | Title | Depends on | Notes |
+|---|---|---|---|---|
+| **1** | — | Branch + living-doc + memory bootstrap | — | Scaffold; opens tracking PR |
+| **2** | range6 | `range6→CIDR` + v4 cap backport | PR1 | Most familiar surface; establishes IPv6 helper test patterns; backports `$range_max_cidrs` cap to v4 |
+| **3** | supernet6 | `supernet6 / summarise6` | PR2 | Direct mirror of v4 Supernet drawer |
+| **4** | zone-id | Zone-ID parser | PR3 | Smallest novel tool; introduces `functions-derive6.php` module |
+| **5** | derive | `derive` (combined MAC tool) | PR4 | Largest novel tool; three outputs in one form; reuses `functions-derive6.php` |
+| **6** | slaac-privacy | SLAAC privacy generator | PR5 | Includes RFC 8981 property tests + Advanced disclosure UI |
+| **7** | — | Release cut → tag → publish → deploy | PR6 | Same shape as v3.2.0's release-cut PR |
+
+PRs land sequentially. Every PR's CI must be green and CodeRabbit findings resolved before the next subagent begins.
+
+---
+
+## Common Definitions
+
+### Memory MCP entity (create once on Task 0)
+
+```
+name: project:subnet-calculator:release:v3.3.0
+type: release
+observations seeded:
+  - "v3.3.0 release branch cut from main 2026-05-06 at <SHA>; bundles range6, supernet6, zone-id, derive, slaac-privacy."
+  - "Plan locked at docs/superpowers/plans/2026-05-06-v3.3.0-release.md."
+  - "Spec at docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md."
+relations:
+  - project:subnet-calculator --has-release--> project:subnet-calculator:release:v3.3.0
+  - project:subnet-calculator:release:v3.2.4 --predecessor-of--> project:subnet-calculator:release:v3.3.0
+  - project:subnet-calculator:release:v3.3.0 --first-of-milestone--> project:subnet-calculator:milestone:ipv6-overhaul
+```
+
+Every task ends with `add_observations` recording: short commit SHA, files touched, test result, gate outcomes. Per-tool entities (`project:subnet-calculator:feature:<slug>`) are created when the task starts and linked to the release with `--part-of-->`.
+
+### QA gates (run on every PR before opening)
+
+```bash
+vendor/bin/phpunit
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten --config p/sql-injection --error \
+    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+npm run lint
+make test-docker
+```
+
+All must be green before pushing the PR. Docker rebuild + fresh containers required when PHP changes.
+
+### CodeRabbit policy
+
+Every PR triggers CR review. Fix every actionable finding (Critical / Major / Minor) before merging — do not dismiss. Nitpicks may be deferred only if explicitly approved.
+
+### UI design-language gate (every UI-bearing task)
+
+Before AND after every markup/CSS edit on every task in v3.3.0:
+
+1. Invoke `ui-ux-pro-max` skill with the changed surface as input.
+2. Confirm parity with the v2.9.0 style guide (`docs/superpowers/plans/2026-04-25-v2.9.0-ui-ux-style-guide.md`):
+   - Teal accent (`--color-accent: #06d6a0`); dark-text on teal buttons.
+   - Tool-drawer pattern for the new IPv6 entries (mirror existing `data-tool="..."` markup in `templates/layout.php`).
+   - `help_bubble()` on every input.
+   - Focus-visible outline (2px accent) on every interactive element.
+   - **No new design tokens.** Consume existing `--color-*` only.
+   - **No new top-level tabs.**
+3. Document the consultation output verbatim in the PR description.
+4. If the consultant flags any deviation, fix in the same task. **Do not defer.**
+
+### Documentation gate
+
+Every doc edit goes through the `documentation` skill before commit. Required reviews:
+
+- Accuracy against current code behaviour.
+- No internal/server config secrets documented.
+- Consistent voice and terminology with `docs/index.md` and `mkdocs.yml`.
+- New tool pages added to `mkdocs.yml` nav under the existing `IPv6` section.
+
+### Test rig
+
+- **PHPUnit unit tests** live in `testing/unit/`. New file per module. Use RFC vectors where they exist (RFC 4291 §2.5.1 for EUI-64; RFC 8981 §3.3 for SLAAC privacy invariants).
+- **Playwright tests** live in `testing/scripts/playwright_test.py`. New test groups per tool. Run via `make test-docker` (no dev server needed; `SKIP_SNAPSHOTS=1` and `SKIP_LINT=1` set automatically).
+- **Visual regression baselines** captured into `testing/snapshots/` with the existing `capture_snapshot` helper. Baselines committed as PNGs.
+- **OpenAPI** updates land in `Subnet-Calculator/api/openapi.yaml`. Spectral lint must pass with zero errors.
+
+### Definition of done (every PR)
+
+A PR is mergeable when **all** of these are true:
+
+- [ ] PHPUnit green (count visibly increased)
+- [ ] PHPStan L9 clean
+- [ ] PHPCS PSR-12 clean (both rulesets)
+- [ ] Spectral OpenAPI clean
+- [ ] Semgrep clean
+- [ ] `npm run lint` clean
+- [ ] `make test-docker` green
+- [ ] Visual snapshots committed where the PR changes UI
+- [ ] CodeRabbit findings (Critical/Major/Minor) addressed
+- [ ] `ui-ux-pro-max` consultation pasted in PR description (UI-bearing PRs)
+- [ ] `documentation` skill review pasted in PR description (doc-bearing PRs)
+- [ ] Memory MCP observation added with commit SHA + test result
+
+---
+
+## File Structure
+
+New files created during v3.3.0 (every PR adds a subset; full inventory here for reference):
+
+```
+Subnet-Calculator/
+├── includes/
+│   ├── functions-range6.php          ← range6_to_cidrs()
+│   ├── functions-supernet6.php       ← supernet6_find(), summarise6_cidrs()
+│   └── functions-derive6.php         ← parse_zone_id(), mac_to_eui64(),
+│                                       mac_to_link_local(),
+│                                       unicast_to_solicited_node(),
+│                                       derive_from_mac(),
+│                                       slaac_privacy_address()
+├── api/v1/handlers/
+│   ├── range6.php
+│   ├── supernet6.php
+│   ├── zone-id.php
+│   ├── derive.php
+│   └── slaac-privacy.php
+└── api/openapi.yaml                  ← MODIFIED: 5 new endpoints
+
+testing/unit/
+├── Range6Test.php
+├── Supernet6Test.php
+├── ZoneIdTest.php
+├── Derive6Test.php
+└── SlaacPrivacyTest.php
+
+testing/snapshots/                    ← MODIFIED: ~10 new baselines
+
+docs/
+├── ipv6-range.md                     ← (or fold into ipv6.md — decide PR2)
+├── ipv6-supernet.md                  ← (or fold into ipv6.md)
+├── ipv6-zone-id.md
+├── ipv6-derive.md
+└── ipv6-slaac-privacy.md
+```
+
+Modified files in every PR:
+- `Subnet-Calculator/includes/request.php` — add `sc_run_*` helper + dispatch
+- `Subnet-Calculator/templates/layout.php` — add drawer trigger button + drawer panel under the IPv6 tab
+- `Subnet-Calculator/api/v1/index.php` — register new route
+- `CHANGELOG.md`, `mkdocs.yml`, `Subnet-Calculator/sw.js` (release-cut only), `Subnet-Calculator/includes/config.php` (release-cut only)
+
+---
+
+## Task 0 / PR 1: Branch + living-doc + memory bootstrap
+
+**Goal:** Cut the release branch, scaffold the living-doc, seed the Memory MCP entity, open the tracking PR.
+
+**Files:**
+- Create: `docs/superpowers/plans/v3.3.0-living-doc.md`
+- Create (worktree): branch `release/v3.3.0` off `main`
+- No code changes.
+
+- [ ] **Step 1: Create release branch.**
+
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b release/v3.3.0
+```
+
+- [ ] **Step 2: Seed Memory MCP entity.**
+
+Use Memory MCP `create_entities` with:
+
+```
+name: project:subnet-calculator:release:v3.3.0
+entityType: release
+observations:
+  - "v3.3.0 release branch cut from main on 2026-05-06 at <SHORT_SHA>; bundles range6, supernet6, zone-id, derive, slaac-privacy."
+  - "Plan: docs/superpowers/plans/2026-05-06-v3.3.0-release.md"
+  - "Spec: docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md"
+```
+
+Then `create_relations`:
+- `project:subnet-calculator --has-release--> project:subnet-calculator:release:v3.3.0`
+- `project:subnet-calculator:release:v3.2.4 --predecessor-of--> project:subnet-calculator:release:v3.3.0`
+
+- [ ] **Step 3: Create living-doc.**
+
+Create `docs/superpowers/plans/v3.3.0-living-doc.md` with the structure used in `v3.2.0-living-doc.md` (Status header, per-PR sections, checklist of QA gates). Document the seeded Memory entity ID and PR sequencing.
+
+- [ ] **Step 4: Commit + push + open tracking PR.**
+
+```bash
+git add docs/superpowers/plans/v3.3.0-living-doc.md
+git commit -m "release: bootstrap v3.3.0 (living-doc + memory seed)"
+git push -u origin release/v3.3.0
+gh pr create --base main --head release/v3.3.0 \
+  --title "release: v3.3.0 — IPv6 Foundations" \
+  --body "Tracking PR. Bundles range6, supernet6, zone-id, derive, slaac-privacy. See docs/superpowers/plans/2026-05-06-v3.3.0-release.md."
+```
+
+The tracking PR stays open through the release; later PRs target `release/v3.3.0` and merge into it; only the final release-cut PR (PR7) merges this branch into `main`.
+
+- [ ] **Step 5: Memory MCP observation.**
+
+`add_observations` to `project:subnet-calculator:release:v3.3.0`:
+> "PR1 scaffold landed at <SHORT_SHA>. Tracking PR #<N> opened. Living-doc + memory entity in place."
+
+---
+
+## Task 1 / PR 2: `range6→CIDR` + v4 cap backport
+
+**Goal:** Ship the IPv6 range→CIDR converter as a drawer entry on the IPv6 tab. Backport the new `$range_max_cidrs` cap to the v4 `range_to_cidrs` helper to address its existing latent issue.
+
+**Files:**
+- Create: `Subnet-Calculator/includes/functions-range6.php`
+- Modify: `Subnet-Calculator/includes/functions-range.php` (add cap)
+- Modify: `Subnet-Calculator/includes/config.php` (add `$range_max_cidrs`)
+- Modify: `Subnet-Calculator/includes/config.php.example`
+- Modify: `Subnet-Calculator/includes/request.php` (add `sc_run_range6`)
+- Modify: `Subnet-Calculator/templates/layout.php` (drawer trigger + panel under IPv6 tab)
+- Create: `Subnet-Calculator/api/v1/handlers/range6.php`
+- Modify: `Subnet-Calculator/api/v1/index.php` (route registration)
+- Modify: `Subnet-Calculator/api/openapi.yaml` (add `/range6` path; update `/range` to document cap)
+- Create: `testing/unit/Range6Test.php`
+- Modify: `testing/unit/RangeTest.php` (add cap tests for v4)
+- Modify: `testing/scripts/playwright_test.py` (new test group)
+- Create: `testing/snapshots/ipv6-range-{closed,open,error}.png` (captured during dev)
+- Create: `docs/ipv6-range.md` (or section appended to existing `docs/ipv6.md` — pick during the docs step)
+- Modify: `mkdocs.yml` (nav entry if new file)
+- Modify: `CHANGELOG.md` (add `## [Unreleased]` section if not present, with `Added` and `Changed` subsections)
+
+- [ ] **Step 1: Cut the feature branch.**
+
+```bash
+git checkout release/v3.3.0
+git pull --ff-only
+git checkout -b feature/v3.3.0-range6
+```
+
+- [ ] **Step 2: Pre-edit `ui-ux-pro-max` consult.**
+
+Invoke the `ui-ux-pro-max` skill with: "Adding a new drawer entry on the IPv6 tab labeled `Range→CIDR`, mirroring the existing v4 Range drawer. Two text inputs (Start / End IPv6 address), Calculate + Reset buttons, result block listing CIDRs with copy buttons. Need design-language confirmation: drawer pattern, help bubbles, focus rings, no new tokens."
+
+Paste the response into the PR description draft.
+
+- [ ] **Step 3: Write failing PHPUnit tests for `range6_to_cidrs`.**
+
+Create `testing/unit/Range6Test.php`. Test cases:
+- Single-CIDR exact range (`2001:db8::/64` start to `2001:db8::ffff:ffff:ffff:ffff` end → `['2001:db8::/64']`).
+- Two-block aligned range.
+- Fragmented range producing multiple CIDRs.
+- Compressed input forms (`2001:db8::1`).
+- Inverted range (`start > end`) → `InvalidArgumentException`.
+- Mixed v4 input → exception.
+- Cap-hit case (range that produces > 256 CIDRs) → `truncated: true`, `count == cap`.
+- `total_addresses` returns `'2^N'` string when overflowing PHP int.
+
+Aim ~20 cases.
+
+- [ ] **Step 4: Run tests; confirm RED.**
+
+```bash
+vendor/bin/phpunit testing/unit/Range6Test.php
+```
+
+Expected: `Class Range6Test not found` or all tests fail with undefined function.
+
+- [ ] **Step 5: Implement `functions-range6.php`.**
+
+Implement `range6_to_cidrs(string $start, string $end): array` per the spec. Must:
+- Use GMP for arithmetic (mirror `functions-range.php` v4 logic translated to GMP).
+- Return shape `['cidrs' => [], 'count' => N, 'total_addresses' => string|int, 'truncated' => bool, 'cap' => int]`.
+- Read `$range_max_cidrs` from config; default 256.
+- Use `inet_pton` for parsing, `gmp_to_ipv6` (existing helper in `functions-ipv6.php`) for output.
+- `declare(strict_types=1);` and full type hints for PHPStan L9.
+
+- [ ] **Step 6: Run tests; confirm GREEN.**
+
+```bash
+vendor/bin/phpunit testing/unit/Range6Test.php
+```
+
+All cases pass.
+
+- [ ] **Step 7: Add cap to v4 `range_to_cidrs`.**
+
+Modify `Subnet-Calculator/includes/functions-range.php`:
+- Read same `$range_max_cidrs` config.
+- Add `truncated` and `cap` fields to return shape.
+- Same cap default (256).
+
+- [ ] **Step 8: Add v4 cap tests.**
+
+Modify `testing/unit/RangeTest.php`:
+- Add a test that an existing fragmented range now reports `truncated: false`, `cap: 256`.
+- Add a test that a deliberately-large fragmented range hits the cap.
+- Add a test that the existing API contract (`cidrs`, `count`, `total_addresses`) is preserved (regression).
+
+- [ ] **Step 9: Run all unit tests.**
+
+```bash
+vendor/bin/phpunit
+```
+
+Expected: green; total count ≈ 226 + new tests for v6 + 3 v4 cap tests.
+
+- [ ] **Step 10: Add config entry.**
+
+Modify `Subnet-Calculator/includes/config.php` to add:
+
+```
+$range_max_cidrs = 256;  // Maximum CIDRs returned by range_to_cidrs / range6_to_cidrs
+```
+
+Mirror the addition in `Subnet-Calculator/includes/config.php.example` with a comment block explaining the cap and its purpose.
+
+- [ ] **Step 11: Implement API handler + register route.**
+
+Create `Subnet-Calculator/api/v1/handlers/range6.php`. Validate `start` + `end` from `api_body()`, call `range6_to_cidrs`, format with `json_ok` / `json_err` per the error catalogue in the spec.
+
+Register the route in `Subnet-Calculator/api/v1/index.php` next to the existing `/range` registration.
+
+- [ ] **Step 12: Add OpenAPI entry.**
+
+Modify `Subnet-Calculator/api/openapi.yaml`:
+- Add `/range6` path with full request/response schema, ≥ 1 example, `400` error schema.
+- Update existing `/range` path to document the new `truncated` + `cap` fields and the cap behavior.
+
+Run Spectral:
+
+```bash
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+
+Expected: zero errors.
+
+- [ ] **Step 13: Smoke-test the API via curl.**
+
+```bash
+php -S localhost:8345 -t Subnet-Calculator/ &
+curl -sX POST http://localhost:8345/api/v1/range6 \
+  -H 'Content-Type: application/json' \
+  -d '{"start":"2001:db8::","end":"2001:db8::ffff"}' | jq .
+kill %1
+```
+
+Expected: JSON with `cidrs`, `count`, `total_addresses`, `truncated`, `cap`.
+
+- [ ] **Step 14: Add `sc_run_range6` to `request.php`.**
+
+Add the helper that handles both POST and GET (shareable URL). Populate template globals `$range6_input_start`, `$range6_input_end`, `$range6_result`, `$range6_error`, `$range6_warning`. Dispatch logic mirrors v2.11 `sc_run_lookup` / `sc_run_diff` patterns.
+
+- [ ] **Step 15: Add UI markup to `templates/layout.php`.**
+
+Inside the IPv6 tab block:
+- Drawer trigger button: `<button type="button" class="tool-trigger" data-tool="range6" aria-expanded="false">Range→CIDR</button>` placed alphabetically (or in mirror order to v4) within the existing trigger row.
+- Drawer panel: `<div class="tool-panel" data-tool="range6">…</div>` containing form, error band, warning band (for `truncated`), result list with copy-per-CIDR + Copy All buttons.
+- Help bubbles via `help_bubble()` on Start, End, and the CIDR list.
+
+Reference: existing v4 Range drawer at `templates/layout.php:350` for markup parity.
+
+- [ ] **Step 16: Post-edit `ui-ux-pro-max` consult.**
+
+Take a screenshot of the new drawer (open + closed states). Re-invoke the skill with the screenshots to confirm parity. Paste output into the PR description.
+
+- [ ] **Step 17: Add Playwright tests.**
+
+In `testing/scripts/playwright_test.py`, add a test group covering:
+- Open the new drawer; submit valid range; result CIDRs render.
+- Submit inverted range; error band shows expected message.
+- Submit range that hits cap; warning band shows; `truncated` reflected.
+- Click Copy on a CIDR; clipboard contains the value (use `add_init_script` clipboard interception per CLAUDE.md).
+- Shareable URL: `/?tab=ipv6&tool=range6&range6_start=...&range6_end=...` auto-opens drawer + hydrates result.
+- API parity: hit `POST /api/v1/range6` and assert JSON shape matches a curated golden vector.
+
+- [ ] **Step 18: Run Playwright suite.**
+
+```bash
+make test-docker
+```
+
+Expected: green; group count increases by 1; assertion count up by ~10.
+
+- [ ] **Step 19: Capture visual snapshots.**
+
+```bash
+SKIP_SNAPSHOTS=0 python3 testing/scripts/playwright_test.py --capture range6
+```
+
+(Per existing `snapshot_utils.py` conventions; if a different invocation is required, follow the v3.2.0 task pattern.)
+
+Commit `testing/snapshots/ipv6-range-closed.png`, `ipv6-range-open.png`, `ipv6-range-error.png`.
+
+- [ ] **Step 20: Write docs.**
+
+Decide: extend `docs/ipv6.md` with a new "Range→CIDR" section, or create `docs/ipv6-range.md` and add to `mkdocs.yml` nav under IPv6.
+
+Cover: what the tool does, when to use it, input/output examples, the cap explained (with `$range_max_cidrs` config knob), API endpoint, shareable URL.
+
+Run the `documentation` skill on the new content. Paste output into PR description.
+
+- [ ] **Step 21: Update CHANGELOG.**
+
+Append to the `## [Unreleased]` section (create the section if not present):
+
+```markdown
+### Added
+- IPv6 range → CIDR converter as new drawer entry on the IPv6 tab. Pure GMP; no overflow on /128-wide ranges. UI + `POST /api/v1/range6` + shareable URL.
+
+### Changed
+- `range_to_cidrs` (v4) now enforces a configurable output-CIDR cap (default 256, set via `$range_max_cidrs`). Pathological fragmented inputs that previously returned thousands of CIDRs now return the first 256 with `truncated: true`. API consumers should check the new `truncated` + `cap` response fields.
+```
+
+- [ ] **Step 22: Run all QA gates.**
+
+```bash
+vendor/bin/phpunit
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten --config p/sql-injection --error \
+    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+npm run lint
+make test-docker
+```
+
+Every command must exit clean.
+
+- [ ] **Step 23: Commit + push + open PR.**
+
+```bash
+git add ...   # specific files only
+git commit -m "feat(v3.3.0): IPv6 range→CIDR + v4 range cap backport"
+git push -u origin feature/v3.3.0-range6
+gh pr create --base release/v3.3.0 --head feature/v3.3.0-range6 \
+  --title "feat(v3.3.0): IPv6 range→CIDR + v4 cap backport" \
+  --body "$(<PR-body.md)"
+```
+
+PR body must include: ui-ux-pro-max consult output, documentation skill output, QA gate results, Playwright group count delta, visual snapshot list.
+
+- [ ] **Step 24: Address CodeRabbit findings.**
+
+Wait for CR. Fix every Critical / Major / Minor finding in additional commits on the same branch. Re-run gates. Push.
+
+- [ ] **Step 25: Memory MCP observation.**
+
+`add_observations` to `project:subnet-calculator:release:v3.3.0`:
+> "PR2 (range6) merged at <SHORT_SHA>. <N> new unit tests, <M> new Playwright assertions. v4 cap backport: 256 default, configurable via `$range_max_cidrs`. CR clean."
+
+Also create `project:subnet-calculator:feature:range6` and relate it `--part-of-->` the release entity.
+
+---
+
+## Task 2 / PR 3: `supernet6 / summarise6`
+
+**Goal:** Ship the IPv6 supernet finder + summariser as a drawer entry mirroring the v4 Supernet drawer.
+
+**Files:**
+- Create: `Subnet-Calculator/includes/functions-supernet6.php`
+- Modify: `Subnet-Calculator/includes/request.php` (add `sc_run_supernet6`)
+- Modify: `Subnet-Calculator/templates/layout.php` (drawer trigger + panel under IPv6 tab)
+- Create: `Subnet-Calculator/api/v1/handlers/supernet6.php`
+- Modify: `Subnet-Calculator/api/v1/index.php`
+- Modify: `Subnet-Calculator/api/openapi.yaml`
+- Create: `testing/unit/Supernet6Test.php`
+- Modify: `testing/scripts/playwright_test.py`
+- Create: snapshots in `testing/snapshots/`
+- Create: `docs/ipv6-supernet.md` (or extend `docs/ipv6.md`)
+- Modify: `mkdocs.yml`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Branch off `release/v3.3.0`.**
+
+```bash
+git checkout release/v3.3.0
+git pull --ff-only
+git checkout -b feature/v3.3.0-supernet6
+```
+
+- [ ] **Step 2: Pre-edit `ui-ux-pro-max` consult.**
+
+Invoke with: "Adding a new drawer entry on the IPv6 tab labeled `Supernet`, mirroring the existing v4 Supernet drawer. Form: action radio (find / summarise), textarea for CIDR list (max 50), Calculate + Reset buttons, result block (single CIDR for find, list for summarise) with copy buttons."
+
+- [ ] **Step 3: Write failing PHPUnit tests for `supernet6_find` + `summarise6_cidrs`.**
+
+Create `testing/unit/Supernet6Test.php`. ~16 cases:
+- `find` with two adjacent /64s → /63 supernet.
+- `find` with disjoint roots → `['supernet' => null, 'count' => 0]` (no error).
+- `find` with single CIDR → returns same CIDR.
+- `summarise` merging adjacent blocks → expected list.
+- `summarise` with already-non-mergeable blocks → unchanged list.
+- Mixed v4/v6 input → error (`'All entries must be IPv6.'`).
+- Empty input → error.
+- > 50 CIDRs → error.
+- Invalid CIDR string → error pointing to the offending input.
+- Compressed forms accepted (`2001:db8::/48`, `2001:DB8::/48` case-insensitive).
+
+- [ ] **Step 4: Run tests; confirm RED.**
+
+- [ ] **Step 5: Implement `functions-supernet6.php`.**
+
+Translate v4 `supernet_find` / `summarise_cidrs` to GMP. Maintain v4-compatible return shapes (`['supernet' => string|null, 'count' => int]`, `['summaries' => string[]]`). 50-CIDR input cap matches v4. `declare(strict_types=1);` + full type hints.
+
+- [ ] **Step 6: Run tests; confirm GREEN.**
+
+- [ ] **Step 7: Implement API handler + register route.**
+
+Create `api/v1/handlers/supernet6.php` mirroring `supernet.php`. Action discriminator `find` | `summarise`. Register in `api/v1/index.php`.
+
+- [ ] **Step 8: Add OpenAPI entry.**
+
+`/supernet6` path with action enum, request/response schemas, examples, 400 error schema. Run Spectral; expect zero errors.
+
+- [ ] **Step 9: Smoke-test via curl.**
+
+```bash
+php -S localhost:8345 -t Subnet-Calculator/ &
+curl -sX POST http://localhost:8345/api/v1/supernet6 \
+  -H 'Content-Type: application/json' \
+  -d '{"action":"find","cidrs":["2001:db8::/64","2001:db8:0:1::/64"]}' | jq .
+kill %1
+```
+
+- [ ] **Step 10: Add `sc_run_supernet6` to `request.php`.**
+
+Mirror the v4 `is_supernet` block. Both `$_POST` and `$_GET` paths. Populate `$supernet6_*` template globals (separate from v4's `$supernet_*` globals).
+
+- [ ] **Step 11: Add UI markup to `templates/layout.php`.**
+
+Drawer trigger + panel under IPv6 tab. Reference: v4 Supernet drawer at `templates/layout.php:295`. Use `help_bubble()` on action radios, textarea, and result list.
+
+- [ ] **Step 12: Post-edit `ui-ux-pro-max` consult.**
+
+- [ ] **Step 13: Add Playwright tests.**
+
+New test group:
+- Find with adjacent /64s → expected supernet rendered.
+- Find with disjoint roots → "No common supernet" rendered (not an error band).
+- Summarise → list rendered, Copy All works.
+- > 50 CIDRs → error band.
+- Mixed v4/v6 → error band.
+- Shareable URL hydration for both actions.
+- API parity check.
+
+- [ ] **Step 14: Run Playwright; capture snapshots.**
+
+- [ ] **Step 15: Write docs.**
+
+`docs/ipv6-supernet.md` (or extend `docs/ipv6.md`). Cover both `find` and `summarise` actions with worked examples. Include API endpoint + shareable URL.
+
+`documentation` skill consult.
+
+- [ ] **Step 16: Update CHANGELOG.**
+
+Add to `[Unreleased]` → `Added`:
+
+```markdown
+- IPv6 supernet finder + summariser as new drawer entry on the IPv6 tab. Mirrors the v4 Supernet drawer. UI + `POST /api/v1/supernet6` + shareable URL.
+```
+
+- [ ] **Step 17: Run all QA gates.**
+
+- [ ] **Step 18: Commit + push + PR.**
+
+- [ ] **Step 19: Address CodeRabbit findings.**
+
+- [ ] **Step 20: Memory MCP observation.**
+
+---
+
+## Task 3 / PR 4: Zone-ID Parser
+
+**Goal:** Ship a small utility that parses `fe80::1%eth0`-style addresses into `{address, zone_id, is_link_local, warning}`. Introduces `functions-derive6.php` (which Tasks 4–5 will extend).
+
+**Files:**
+- Create: `Subnet-Calculator/includes/functions-derive6.php` (with `parse_zone_id` only for now)
+- Modify: `Subnet-Calculator/includes/request.php` (add `sc_run_zoneid`)
+- Modify: `Subnet-Calculator/templates/layout.php`
+- Create: `Subnet-Calculator/api/v1/handlers/zone-id.php`
+- Modify: `Subnet-Calculator/api/v1/index.php`
+- Modify: `Subnet-Calculator/api/openapi.yaml`
+- Create: `testing/unit/ZoneIdTest.php`
+- Modify: `testing/scripts/playwright_test.py`
+- Create: snapshots
+- Create: `docs/ipv6-zone-id.md`
+- Modify: `mkdocs.yml`, `CHANGELOG.md`
+
+- [ ] **Step 1: Branch off `release/v3.3.0`.**
+
+```bash
+git checkout release/v3.3.0
+git pull --ff-only
+git checkout -b feature/v3.3.0-zone-id
+```
+
+- [ ] **Step 2: Pre-edit `ui-ux-pro-max` consult.**
+
+Surface description: "Adding a small drawer entry labeled `Zone ID` to the IPv6 tab. Single text input. Result block shows `address`, `zone_id`, `is_link_local`, and a yellow warning band when zone is supplied with a non-link-local address. Help bubble explains zone-ID semantics."
+
+- [ ] **Step 3: Write failing tests.**
+
+Create `testing/unit/ZoneIdTest.php`. ~10 cases:
+- `fe80::1%eth0` → `{address: 'fe80::1', zone_id: 'eth0', is_link_local: true, warning: null}`.
+- `fe80::1` (no zone) → `{address: 'fe80::1', zone_id: null, is_link_local: true, warning: null}`.
+- `2001:db8::1%eth0` (zone on non-LL) → `is_link_local: false`, warning populated.
+- `fe80::1%` (empty zone after `%`) → error.
+- `fe80::1%eth0!` (invalid char) → error.
+- 33-char zone → error (cap is 32).
+- Invalid address (`zzz`) → error.
+- Empty input → error.
+- Compressed + expanded address forms produce same canonical.
+
+- [ ] **Step 4: Run tests; confirm RED.**
+
+- [ ] **Step 5: Implement `parse_zone_id` in `functions-derive6.php`.**
+
+Create the file with `declare(strict_types=1);` and the function. Split input on `%`, validate the address with `inet_pton`, validate zone with regex `[A-Za-z0-9_-]{1,32}`. Determine `is_link_local` by checking if the address starts with `fe80::/10`. Populate warning when zone is non-empty and address is not link-local.
+
+- [ ] **Step 6: Run tests; confirm GREEN.**
+
+- [ ] **Step 7: API handler + route + OpenAPI + Spectral.**
+
+Create `api/v1/handlers/zone-id.php`. Register `/zone-id`. Add OpenAPI entry. Spectral clean.
+
+- [ ] **Step 8: Smoke-test via curl.**
+
+- [ ] **Step 9: `sc_run_zoneid` in `request.php`.**
+
+POST + GET. Populate `$zoneid_*` template globals.
+
+- [ ] **Step 10: UI markup.**
+
+Drawer trigger + panel. Single input. Result block with three labelled rows + optional warning band.
+
+- [ ] **Step 11: Post-edit `ui-ux-pro-max` consult.**
+
+- [ ] **Step 12: Playwright tests.**
+
+- Open drawer; submit `fe80::1%eth0`; result rows render.
+- Submit `2001:db8::1%eth0`; warning band renders.
+- Submit invalid input; error band.
+- Shareable URL hydration (note: `%` must be URL-encoded as `%25`).
+- API parity check.
+
+- [ ] **Step 13: Run Playwright; snapshots.**
+
+- [ ] **Step 14: Docs.**
+
+`docs/ipv6-zone-id.md`. Cover what zone IDs are, why they exist (link-local addresses are interface-scoped), the warning case, the API.
+
+- [ ] **Step 15: CHANGELOG.**
+
+`Added`: "IPv6 zone-ID parser. Splits `fe80::1%eth0`-style input into address + zone with link-local validation. UI + `POST /api/v1/zone-id` + shareable URL."
+
+- [ ] **Step 16: Run all QA gates.**
+
+- [ ] **Step 17: Commit + push + PR.**
+
+- [ ] **Step 18: Address CR findings.**
+
+- [ ] **Step 19: Memory observation.**
+
+---
+
+## Task 4 / PR 5: `derive` (Combined MAC Tool)
+
+**Goal:** Ship the headline MAC-derivation tool. Single MAC input → three labelled outputs (EUI-64 interface ID, link-local address, solicited-node multicast). Each output has its own copy button.
+
+**Files:**
+- Modify: `Subnet-Calculator/includes/functions-derive6.php` (extend with derivation helpers + combined `derive_from_mac`)
+- Modify: `Subnet-Calculator/includes/request.php`
+- Modify: `Subnet-Calculator/templates/layout.php`
+- Create: `Subnet-Calculator/api/v1/handlers/derive.php`
+- Modify: `Subnet-Calculator/api/v1/index.php`
+- Modify: `Subnet-Calculator/api/openapi.yaml`
+- Create: `testing/unit/Derive6Test.php`
+- Modify: `testing/scripts/playwright_test.py`
+- Create: snapshots
+- Create: `docs/ipv6-derive.md`
+- Modify: `mkdocs.yml`, `CHANGELOG.md`
+
+- [ ] **Step 1: Branch off `release/v3.3.0`.**
+
+- [ ] **Step 2: Pre-edit `ui-ux-pro-max` consult.**
+
+Surface: "Adding `Derive Address` drawer entry on IPv6 tab. Single MAC input (any of `00:24:b9:7e:ab:cd`, `00-24-b9-7e-ab-cd`, `0024.b97e.abcd`, `0024b97eabcd`). Result block shows three rows: `EUI-64 interface ID`, `Link-local address`, `Solicited-node multicast` — each with its own copy button. Help bubble explains the U/L bit flip and last-24-bits derivation for solicited-node."
+
+- [ ] **Step 3: Write failing tests for the four helper fns + combined wrapper.**
+
+Create `testing/unit/Derive6Test.php`. ~25 cases pulling vectors from RFC 4291 §2.5.1:
+
+For `mac_to_eui64`:
+- RFC 4291 §2.5.1 MAC `00:24:b9:7e:ab:cd` → `0226:b9ff:fe7e:abcd` (verify U/L bit flip from 0 to 1).
+- All-zero MAC.
+- All-ones MAC.
+- Lowercase + uppercase + dashed + dotted + bare-hex normalisations all produce the same canonical EUI-64.
+- Length ≠ 6 octets → exception.
+- Non-hex chars → exception.
+
+For `mac_to_link_local`:
+- `fe80::` + EUI-64 from same MACs.
+
+For `unicast_to_solicited_node`:
+- `2001:db8::1` → `ff02::1:ff00:1`.
+- `fe80::226:b9ff:fe7e:abcd` → `ff02::1:ff7e:abcd`.
+
+For `derive_from_mac` (combined):
+- One input, all three outputs in one return.
+- `mac_canonical` field present and lowercased.
+- `ul_bit_flipped: true` when U/L bit was originally 0 (most consumer MACs).
+- Multicast bit set on input → `warning` field populated.
+
+- [ ] **Step 4: Run tests; confirm RED.**
+
+- [ ] **Step 5: Implement the helpers in `functions-derive6.php`.**
+
+Extend the file with:
+- `mac_to_eui64(string $mac): string` — normalize, split into octets, insert `ff:fe` between bytes 3 and 4, flip U/L bit (bit 1 of byte 0 — i.e., `byte0 ^= 0x02`).
+- `mac_to_link_local(string $mac): string` — `fe80::` + `mac_to_eui64`.
+- `unicast_to_solicited_node(string $ipv6): string` — take last 24 bits, prepend `ff02::1:ff`.
+- `derive_from_mac(string $mac): array` — orchestrator returning all three plus `mac_canonical` and `ul_bit_flipped`. Detect multicast bit (LSB of first octet) and populate `warning`.
+
+Add a private MAC-normalization helper used by all three (deduplicated).
+
+- [ ] **Step 6: Run tests; confirm GREEN.**
+
+- [ ] **Step 7: API handler + route + OpenAPI + Spectral.**
+
+`api/v1/handlers/derive.php`. Register `/derive`. OpenAPI entry with response showing all three outputs. Spectral clean.
+
+- [ ] **Step 8: Smoke-test via curl.**
+
+```bash
+curl -sX POST http://localhost:8345/api/v1/derive \
+  -H 'Content-Type: application/json' \
+  -d '{"mac":"00:24:b9:7e:ab:cd"}' | jq .
+```
+
+Expected: all three outputs + `mac_canonical: "00:24:b9:7e:ab:cd"`, `ul_bit_flipped: true`.
+
+- [ ] **Step 9: `sc_run_derive` in `request.php`.**
+
+- [ ] **Step 10: UI markup.**
+
+Drawer trigger + panel. Single MAC input. Result block with three rows: each row has a label, the derived value (monospace), and a copy button. Use `help_bubble()` on input + each output row explaining its derivation.
+
+- [ ] **Step 11: Post-edit `ui-ux-pro-max` consult.**
+
+- [ ] **Step 12: Playwright tests.**
+
+- Paste a MAC; all three outputs render.
+- Click each copy button; clipboard intercept asserts the right value (per CLAUDE.md `add_init_script` clipboard pattern).
+- Submit invalid MAC; error band.
+- Submit MAC with multicast bit set; warning band; outputs still render.
+- Shareable URL `?tab=ipv6&tool=derive&derive_mac=...` auto-hydrates.
+- API parity check using a golden vector.
+
+- [ ] **Step 13: Run Playwright; capture snapshots.**
+
+- [ ] **Step 14: Docs.**
+
+`docs/ipv6-derive.md`. Explain EUI-64 (with U/L bit flip), link-local construction, solicited-node mapping (last 24 bits → `ff02::1:ff__:____`). Include API + shareable URL examples.
+
+- [ ] **Step 15: CHANGELOG.**
+
+`Added`: "MAC-to-IPv6 derivation tool. One MAC input → EUI-64 interface ID + link-local address + solicited-node multicast. Per RFC 4291 §2.5.1 (with U/L bit flip)."
+
+- [ ] **Step 16: Run all QA gates.**
+
+- [ ] **Step 17: Commit + push + PR.**
+
+- [ ] **Step 18: Address CR findings.**
+
+- [ ] **Step 19: Memory observation.**
+
+---
+
+## Task 5 / PR 6: SLAAC Privacy Generator
+
+**Goal:** Ship the SLAAC privacy address generator (RFC 8981). Optional seed for reproducibility, hidden behind an "Advanced" disclosure. Property-based tests verify RFC 8981 invariants on unseeded output.
+
+**Files:**
+- Modify: `Subnet-Calculator/includes/functions-derive6.php` (add `slaac_privacy_address`)
+- Modify: `Subnet-Calculator/includes/request.php`
+- Modify: `Subnet-Calculator/templates/layout.php`
+- Create: `Subnet-Calculator/api/v1/handlers/slaac-privacy.php`
+- Modify: `Subnet-Calculator/api/v1/index.php`
+- Modify: `Subnet-Calculator/api/openapi.yaml`
+- Create: `testing/unit/SlaacPrivacyTest.php`
+- Modify: `testing/scripts/playwright_test.py`
+- Create: snapshots
+- Create: `docs/ipv6-slaac-privacy.md`
+- Modify: `mkdocs.yml`, `CHANGELOG.md`
+
+- [ ] **Step 1: Branch off `release/v3.3.0`.**
+
+- [ ] **Step 2: Pre-edit `ui-ux-pro-max` consult.**
+
+Surface: "Adding `SLAAC Privacy` drawer entry. Inputs: prefix (text, must be /64), seed (16-hex, optional). Seed lives inside an `<details>` collapsed-by-default Advanced disclosure with copy explaining it's for reproducibility/testing and production should leave blank. Result block shows generated address, interface ID, and seed-used. The generate button is the primary action; pressing it without a seed produces a fresh random address."
+
+- [ ] **Step 3: Write failing tests for `slaac_privacy_address`.**
+
+Create `testing/unit/SlaacPrivacyTest.php`. ~12 cases.
+
+Property tests (unseeded):
+- Output address is exactly 128 bits.
+- First 64 bits equal the input prefix's network bits.
+- The U/L bit (bit 6 of byte 8) is `0` (privacy MUST clear it).
+- Last 24 bits are not `fe:XXXX` and bytes 11–12 are not `ff:fe` (i.e. doesn't accidentally look like an EUI-64).
+- Two consecutive calls with no seed produce different addresses (statistical sanity; flake probability `2^-64`).
+
+Seeded determinism tests:
+- Same seed + same prefix → identical address.
+- Different seed → different address.
+- Seed is echoed back in `seed_used` and `seed_was_provided: true`.
+
+Validation tests:
+- Empty prefix → error.
+- Non-/64 prefix → error (`'SLAAC privacy addresses require a /64 prefix.'`).
+- Invalid prefix string → error.
+- 15-char seed → error (`'Seed must be 16 hexadecimal characters.'`).
+- Non-hex seed → error.
+
+- [ ] **Step 4: Run tests; confirm RED.**
+
+- [ ] **Step 5: Implement `slaac_privacy_address` in `functions-derive6.php`.**
+
+```
+function slaac_privacy_address(string $prefix, ?string $seed = null): array
+```
+
+- Validate prefix is /64, parseable, network-canonical.
+- If `$seed` is null: `random_bytes(8)` (cryptographically secure). If `$seed` is provided: validate 16-hex-chars, convert to 8 raw bytes.
+- Clear U/L bit (bit 6 of byte 8): `$bytes[8] = chr(ord($bytes[8]) & ~0x02)`. (Note: bit 6 in network-byte-order = `0x02` mask in PHP byte indexing.) **Verify this bit position against RFC 8981 §3.3 during implementation — getting the wrong bit is the most likely error.**
+- Concatenate prefix bits with the modified 64-bit interface ID.
+- Output via `inet_ntop`.
+- Return shape per spec.
+- If `random_bytes` fails (PHP throws), let it propagate (no `mt_rand` fallback).
+
+- [ ] **Step 6: Run tests; confirm GREEN.**
+
+- [ ] **Step 7: API handler + route + OpenAPI + Spectral.**
+
+`api/v1/handlers/slaac-privacy.php`. Register `/slaac-privacy`. OpenAPI entry. Spectral clean.
+
+- [ ] **Step 8: Smoke-test via curl.**
+
+```bash
+# Unseeded
+curl -sX POST http://localhost:8345/api/v1/slaac-privacy \
+  -H 'Content-Type: application/json' \
+  -d '{"prefix":"2001:db8:1:2::/64"}' | jq .
+# Seeded (reproducible)
+curl -sX POST http://localhost:8345/api/v1/slaac-privacy \
+  -H 'Content-Type: application/json' \
+  -d '{"prefix":"2001:db8:1:2::/64","seed":"a8d3f4e10c529837"}' | jq .
+```
+
+- [ ] **Step 9: `sc_run_slaac` in `request.php`.**
+
+POST + GET. Populate `$slaac_*` template globals.
+
+- [ ] **Step 10: UI markup.**
+
+Drawer trigger + panel. Form:
+- Prefix input (required).
+- `<details>` Advanced disclosure containing the seed input and explanatory copy.
+- Generate + Reset buttons.
+- Result block with three labelled rows (address, interface ID, seed used) + copy buttons.
+
+Help bubbles on prefix, seed, and each output row. Disclosure copy must mention RFC 8981 and that production should leave seed empty.
+
+- [ ] **Step 11: Post-edit `ui-ux-pro-max` consult.**
+
+- [ ] **Step 12: Playwright tests.**
+
+- Submit prefix only; address generates; result fields render.
+- Click Advanced; seed input becomes visible (test `<details>` open semantics).
+- Submit prefix + seed twice; assert addresses match (deterministic).
+- Submit prefix only twice; assert addresses differ (statistical; flake probability `2^-64`, treat any failure as a real bug).
+- Submit non-/64; error band.
+- Submit invalid seed; error band.
+- Shareable URL hydration (with seed).
+- API parity check.
+
+- [ ] **Step 13: Run Playwright; snapshots.**
+
+- [ ] **Step 14: Docs.**
+
+`docs/ipv6-slaac-privacy.md`. Cover:
+- What SLAAC privacy addresses are and why (RFC 4941 / 8981 motivation: no MAC leakage).
+- How they differ from EUI-64 (U/L bit, no derivation from MAC).
+- The seed parameter's testing/reproducibility purpose and warning that production should leave it blank.
+- API + shareable URL examples.
+
+- [ ] **Step 15: CHANGELOG.**
+
+`Added`: "SLAAC privacy address generator (RFC 8981). Optional 16-hex seed for reproducibility (advanced/testing use); unseeded output uses `random_bytes`. UI + `POST /api/v1/slaac-privacy` + shareable URL."
+
+- [ ] **Step 16: Run all QA gates.**
+
+- [ ] **Step 17: Commit + push + PR.**
+
+- [ ] **Step 18: Address CR findings.**
+
+- [ ] **Step 19: Memory observation.**
+
+---
+
+## Task 6 / PR 7: Release cut → tag → publish → deploy
+
+**Goal:** Final release-cut PR. Bumps version, updates docs, builds tarball, opens `release/v3.3.0 → main`.
+
+**Files:**
+- Modify: `Subnet-Calculator/includes/config.php` (`$app_version` 3.2.4 → 3.3.0)
+- Modify: `Subnet-Calculator/sw.js` (`CACHE_NAME` → `sc-v3.3.0`)
+- Modify: `mkdocs.yml` (`version: "3.3.0"`)
+- Modify: `docs/index.md` (tarball filename → `subnet-calculator-3.3.0.tar.gz`)
+- Modify: `README.md` (add v3.3.0 row to downloads table)
+- Modify: `CHANGELOG.md` (rename `[Unreleased]` to `[3.3.0] - YYYY-MM-DD`; add release narrative paragraph at top)
+- Create: `releases/subnet-calculator-3.3.0.tar.gz`
+
+- [ ] **Step 1: Branch off `release/v3.3.0`.**
+
+```bash
+git checkout release/v3.3.0
+git pull --ff-only
+git checkout -b release/v3.3.0-cut
+```
+
+- [ ] **Step 2: Bump `$app_version`.**
+
+Modify `Subnet-Calculator/includes/config.php` line setting `$app_version` to `'3.3.0'`.
+
+- [ ] **Step 3: Bump `CACHE_NAME`.**
+
+Modify `Subnet-Calculator/sw.js` line setting `CACHE_NAME` to `'sc-v3.3.0'`. Per CLAUDE.md release checklist this is mandatory — service worker won't purge old cache otherwise.
+
+- [ ] **Step 4: Bump docs version.**
+
+Modify `mkdocs.yml` `extra.version` to `"3.3.0"`. Modify `docs/index.md` tarball filename to `subnet-calculator-3.3.0.tar.gz`.
+
+- [ ] **Step 5: Finalise CHANGELOG.**
+
+Rename `## [Unreleased]` heading to `## [3.3.0] - YYYY-MM-DD` (today's date). Add a release-narrative paragraph at the top of the section summarising: parity ports, new IPv6-native tools, v4 cap backport. Match the prose style of v3.2.0's CHANGELOG entry.
+
+- [ ] **Step 6: Add README row.**
+
+Modify `README.md` downloads table — add v3.3.0 row at top above the v3.2.4 row. Description summarises the release in one paragraph.
+
+- [ ] **Step 7: Build tarball.**
+
+```bash
+cp CHANGELOG.md Subnet-Calculator/CHANGELOG.md
+tar --exclude='admin/_test-drain.php' \
+    -czf releases/subnet-calculator-3.3.0.tar.gz -C Subnet-Calculator .
+rm Subnet-Calculator/CHANGELOG.md
+shasum -a 256 releases/subnet-calculator-3.3.0.tar.gz
+```
+
+Record the SHA256 — it goes in the changelog/release notes.
+
+- [ ] **Step 8: Run all QA gates one final time.**
+
+```bash
+vendor/bin/phpunit
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten --config p/sql-injection --error \
+    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+npm run lint
+make test-docker
+```
+
+- [ ] **Step 9: Commit + push + open release-cut PR.**
+
+```bash
+git add Subnet-Calculator/includes/config.php Subnet-Calculator/sw.js \
+        mkdocs.yml docs/index.md README.md CHANGELOG.md \
+        releases/subnet-calculator-3.3.0.tar.gz
+git commit -m "release: v3.3.0 — IPv6 Foundations"
+git push -u origin release/v3.3.0-cut
+```
+
+This branch merges into `release/v3.3.0` (closing out the milestone), then `release/v3.3.0` opens the existing tracking PR (PR1's PR) to merge into `main`.
+
+Alternative (matches v3.2.0 pattern): commit the cut directly on `release/v3.3.0` and let the existing tracking PR carry the cut commit. Pick whichever the v3.2.0 release used; do not invent a new pattern.
+
+- [ ] **Step 10: Address CR findings on the cut PR.**
+
+- [ ] **Step 11: Merge → tag → GitHub release.**
+
+After merge into `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+git tag -a v3.3.0 -m "v3.3.0 — IPv6 Foundations"
+git push origin v3.3.0
+gh release create v3.3.0 \
+  --title "v3.3.0 — IPv6 Foundations" \
+  --notes-file <(awk '/## \[3\.3\.0\]/,/## \[3\.2\.4\]/' CHANGELOG.md | head -n -1) \
+  releases/subnet-calculator-3.3.0.tar.gz
+```
+
+- [ ] **Step 12: Deploy to prod.**
+
+Per project convention (use `/deploy-test` first to verify on test instance, then deploy to prod). Confirm post-deploy:
+- App version on `subnetcalculator.app` shows `v3.3.0` in the header pill.
+- Service worker `CACHE_NAME` is `sc-v3.3.0`.
+- All five new drawer entries present on the IPv6 tab.
+- Spot-check one tool in browser.
+
+- [ ] **Step 13: Final Memory MCP observation.**
+
+`add_observations` to `project:subnet-calculator:release:v3.3.0`:
+> "v3.3.0 shipped on YYYY-MM-DD. Tag v3.3.0 at <SHA>. Bundle SHA256 <hash>. Deployed to prod and test. PHPUnit ~309, Playwright ~160 groups."
+
+Add observation to `project:subnet-calculator` summarising the release.
+
+---
+
+## Self-Review
+
+(Run before declaring the plan ready.)
+
+**Spec coverage check.** Map each spec section to a task:
+
+- Architecture / file organisation → Tasks 1–5 (each creates the expected modules and handlers); Task 6 (release cut).
+- UI placement (5 drawer entries on IPv6 tab) → Tasks 1–5 each add one entry; Step 11 in the relevant task adds drawer markup.
+- Component contracts (5 tools) → Each tool gets a dedicated task with PHP function, API handler, OpenAPI entry, UI form.
+- Data flow (`sc_run_*` helpers, shareable URL shape) → Each task has a `sc_run_<tool>` step in `request.php` and a Playwright shareable-URL hydration test.
+- Error handling catalogue → PHPUnit tests in each task assert the documented error messages and HTTP codes; Playwright tests assert the warning-vs-error display split.
+- Testing requirements (~83 unit + ~25 Playwright + 5 OpenAPI + visual regression) → Each tool task has explicit Step N for unit tests, Step N for Playwright, Step N for OpenAPI/Spectral, Step N for snapshots.
+- Implementation sequencing (PR1 scaffold → PR2–6 tools → PR7 release cut) → Tasks 0–6 match exactly.
+- Non-goals (no new tabs, no new tokens, no auth changes) → Reinforced in the UI gate; no task creates a tab or new CSS custom property.
+
+No gaps identified.
+
+**Placeholder scan.** No "TBD", "implement later", or "fill in details". Every step has actionable content. The two judgement calls explicitly flagged for in-task decision (`docs/ipv6.md` extension vs new file; release-cut PR shape vs commit-on-branch) are scoped, with both options described.
+
+**Type / signature consistency.** Function signatures match across tasks:
+- `range6_to_cidrs(string, string): array` — declared in Task 1, referenced in Task 1's API handler step.
+- `supernet6_find(array): array` and `summarise6_cidrs(array): array` — Task 2.
+- `parse_zone_id(string): array` — Task 3.
+- `mac_to_eui64(string): string`, `mac_to_link_local(string): string`, `unicast_to_solicited_node(string): string`, `derive_from_mac(string): array` — Task 4. Each helper is independently exported (per spec), and `derive_from_mac` is the orchestrator.
+- `slaac_privacy_address(string, ?string): array` — Task 5.
+
+Template globals follow `${tool}_*` naming and don't collide with existing v4 globals (`$range6_*` vs `$range_*`; `$supernet6_*` vs `$supernet_*`; etc.).
+
+OpenAPI paths match the spec exactly: `/range6`, `/supernet6`, `/zone-id`, `/derive`, `/slaac-privacy`.
+
+No issues found.


### PR DESCRIPTION
## Summary

Adds the design spec **and** implementation plan for **v3.3.0 — IPv6 Foundations**, the first of four IPv6-themed minor releases (v3.3.0–v3.6.0).

## What's in this PR

- **Spec:** `docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md` — architecture, component contracts, data flow, error catalogue, testing strategy, milestone context.
- **Plan:** `docs/superpowers/plans/2026-05-06-v3.3.0-release.md` — 7-PR sequencing (1 scaffold + 5 tools + 1 release cut), per-task checkbox steps, mandatory consultations, DoD gates. Mirrors the v3.2.0 plan structure.

## Tools shipping in v3.3.0

| PR | Tool | Drawer label | Type | Issue |
|---|---|---|---|---|
| 2 | range6→CIDR + v4 cap backport | `Range→CIDR` | v4 parity port | #364 |
| 3 | supernet6 / summarise6 | `Supernet` | v4 parity port | #365 |
| 4 | zone-ID parser | `Zone ID` | new utility | #366 |
| 5 | derive (combined MAC tool) | `Derive Address` | new (RFC 4291) | #367 |
| 6 | SLAAC privacy generator | `SLAAC Privacy` | new (RFC 8981) | #368 |

All five tools land as drawer entries on the existing IPv6 tab. **Zero new top-level tabs.** Placement validated by Playwright audit at 375/1280 px against `subnetcalculator.app` prod.

Tracking milestone: [v3.3.0](https://github.com/seanmousseau/Subnet-Calculator/milestone/25).

## Audit context

A side-effect of the audit was a v3.2.4 CSS hotfix (`white-space: nowrap` on `.tab-btn`) — see PR #362 — that resolves the "VLSM IPv6" tab-label two-line wrap.

## Test plan

- [ ] Stakeholder review of spec + plan
- [ ] After approval: invoke `superpowers:subagent-driven-development` (or `executing-plans`) to implement task-by-task
- [ ] Each tool PR follows the DoD gates spelled out in the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design specification and implementation planning documentation for the v3.3.0 IPv6 Foundations release, detailing technical requirements and delivery roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->