### PR TITLE
fix(v3.4.0): cleanup batch — doc typo + RangeTest DI + ul_bit_flipped docblock

### DIFF
--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -1162,12 +1162,14 @@ paths:
         EUI-64 interface identifier per RFC 4291 §2.5.1 (with the U/L bit
         flipped), the IPv6 link-local address (`fe80::` + EUI-64), and the
         solicited-node multicast address (`ff02::1:ff` + low 24 bits) per
-        RFC 4291 §2.7.1. `ul_bit_flipped` reports whether the U/L flip went
-        0 → 1 (the standard case) — false when the input MAC already had
-        U/L set. `warning` is populated when the multicast bit (LSB of the
-        first octet) is set on input, indicating the source MAC is not a
-        valid unicast hardware address; outputs are still computed.
-        Added in v3.3.0.
+        RFC 4291 §2.7.1. `ul_bit_flipped` is True if the U/L bit was originally
+        0 in the input MAC and was therefore flipped to 1 to form the EUI-64
+        modified-IID. False if the U/L bit was already 1 in the input. The
+        flip operation always runs unconditionally; this field reports whether
+        the flip changed the value. `warning` is populated when the multicast
+        bit (LSB of the first octet) is set on input, indicating the source
+        MAC is not a valid unicast hardware address; outputs are still
+        computed. Added in v3.3.0.
       requestBody:
         required: true
         content:
@@ -1193,7 +1195,15 @@ paths:
                         properties:
                           mac_canonical:  { type: string,  example: "00:24:b9:7e:ab:cd" }
                           eui64:          { type: string,  example: "0224:b9ff:fe7e:abcd" }
-                          ul_bit_flipped: { type: boolean, example: true }
+                          ul_bit_flipped:
+                            type: boolean
+                            example: true
+                            description: |
+                              True if the U/L bit was originally 0 in the input MAC and was
+                              therefore flipped to 1 to form the EUI-64 modified-IID. False
+                              if the U/L bit was already 1 in the input. The flip operation
+                              always runs unconditionally; this field reports whether the
+                              flip changed the value.
                           link_local:     { type: string,  example: "fe80::224:b9ff:fe7e:abcd" }
                           solicited_node: { type: string,  example: "ff02::1:ff7e:abcd" }
                           warning:        { type: [string, "null"], example: null }

--- a/Subnet-Calculator/includes/functions-derive6.php
+++ b/Subnet-Calculator/includes/functions-derive6.php
@@ -195,6 +195,11 @@ function unicast_to_solicited_node(string $ipv6): string
  * address, the U/L flip outcome, and an optional warning when the input
  * appears to be a multicast MAC (LSB of first octet set).
  *
+ * `ul_bit_flipped` is True if the U/L bit was originally 0 in the input MAC
+ * and was therefore flipped to 1 to form the EUI-64 modified-IID. False if
+ * the U/L bit was already 1 in the input. The flip operation always runs
+ * unconditionally; this field reports whether the flip changed the value.
+ *
  * @return array{
  *     mac_canonical: string,
  *     eui64: string,
@@ -214,9 +219,11 @@ function derive_from_mac(string $mac): array
         . substr($hex, 8, 2) . ':' . substr($hex, 10, 2);
 
     $byte0 = hexdec(substr($hex, 0, 2));
-    // ul_bit_flipped reports whether the operation toggled the bit from
-    // 0 → 1 (the standard case). When the input already has U/L = 1 the
-    // flip goes 1 → 0, so we report false.
+    // ul_bit_flipped: True if the U/L bit was originally 0 in the input MAC
+    // and was therefore flipped to 1 to form the EUI-64 modified-IID. False
+    // if the U/L bit was already 1 in the input. The flip operation always
+    // runs unconditionally; this field reports whether the flip changed the
+    // value.
     $ul_bit_flipped = (($byte0 & 0x02) === 0);
 
     $eui64           = mac_to_eui64($canonical);

--- a/Subnet-Calculator/includes/functions-range.php
+++ b/Subnet-Calculator/includes/functions-range.php
@@ -12,10 +12,15 @@ declare(strict_types=1);
  * its own size, and (c) does not extend past $end; emit that block as a CIDR,
  * advance the pointer, and repeat until the range is exhausted.
  *
- * v3.3.0: output cap added. Reads the global $range_max_cidrs (default 256) —
- * the same knob that caps range6_to_cidrs(). When the cap is reached the
- * partial result is returned with truncated=true; existing keys are preserved
- * so callers that don't check `truncated` still get a usable list.
+ * v3.3.0: output cap added — same knob that caps range6_to_cidrs(). When the
+ * cap is reached the partial result is returned with truncated=true; existing
+ * keys are preserved so callers that don't check `truncated` still get a
+ * usable list.
+ *
+ * v3.4.0: $cap is now an optional third parameter (DI-friendly). When omitted,
+ * the function falls back to $GLOBALS['range_max_cidrs'] (configured in
+ * config.php) and finally to the built-in default of 256. Callers (and tests)
+ * may pass an explicit cap to override per-call without mutating globals.
  *
  * @return array{
  *     cidrs?: list<string>,
@@ -26,7 +31,7 @@ declare(strict_types=1);
  *     error?: string,
  * }
  */
-function range_to_cidrs(string $start, string $end, ?int $max_cidrs = null): array
+function range_to_cidrs(string $start, string $end, ?int $cap = null): array
 {
     $start_long = ip2long($start);
     $end_long   = ip2long($end);
@@ -46,15 +51,15 @@ function range_to_cidrs(string $start, string $end, ?int $max_cidrs = null): arr
         return ['error' => 'Start address must be less than or equal to end address.'];
     }
 
-    // v3.3.0 — output cap. Explicit $max_cidrs argument wins (used by tests
-    // and any caller that wants to override per-call); otherwise fall back to
-    // the configured global $range_max_cidrs (default 256).
-    if ($max_cidrs !== null) {
-        $cap = max(1, min($max_cidrs, 100000));
-    } else {
-        global $range_max_cidrs;
-        $cap = isset($range_max_cidrs) ? max(1, min((int)$range_max_cidrs, 100000)) : 256;
+    // v3.4.0 — explicit $cap argument wins (DI-friendly); otherwise fall back
+    // to the configured global $range_max_cidrs (set in config.php), and
+    // finally to the built-in default of 256 if even that is unset (e.g. in
+    // unit tests where bootstrap loads config.php into a non-global scope).
+    if ($cap === null) {
+        $configured = $GLOBALS['range_max_cidrs'] ?? 256;
+        $cap = is_numeric($configured) ? (int)$configured : 256;
     }
+    $cap = max(1, min($cap, 100000));
 
     $cidrs = [];
     $cur   = $start_long;

--- a/docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md
+++ b/docs/internal/specs/2026-05-06-v3.3.0-ipv6-foundations-design.md
@@ -190,9 +190,9 @@ API: `POST /api/v1/zone-id {input}`.
 function derive_from_mac(string $mac): array;
 // Returns:
 //   ['mac_canonical'  => '00:24:b9:7e:ab:cd',
-//    'eui64'          => '0226:b9ff:fe7e:abcd',
+//    'eui64'          => '0224:b9ff:fe7e:abcd',
 //    'ul_bit_flipped' => true,
-//    'link_local'     => 'fe80::226:b9ff:fe7e:abcd',
+//    'link_local'     => 'fe80::224:b9ff:fe7e:abcd',
 //    'solicited_node' => 'ff02::1:ff7e:abcd']
 
 // Backed by three smaller helpers (also exported for unit testing):

--- a/docs/superpowers/plans/2026-05-06-v3.3.0-release.md
+++ b/docs/superpowers/plans/2026-05-06-v3.3.0-release.md
@@ -713,7 +713,7 @@ Surface: "Adding `Derive Address` drawer entry on IPv6 tab. Single MAC input (an
 Create `testing/unit/Derive6Test.php`. ~25 cases pulling vectors from RFC 4291 §2.5.1:
 
 For `mac_to_eui64`:
-- RFC 4291 §2.5.1 MAC `00:24:b9:7e:ab:cd` → `0226:b9ff:fe7e:abcd` (verify U/L bit flip from 0 to 1).
+- RFC 4291 §2.5.1 MAC `00:24:b9:7e:ab:cd` → `0224:b9ff:fe7e:abcd` (verify U/L bit flip from 0 to 1).
 - All-zero MAC.
 - All-ones MAC.
 - Lowercase + uppercase + dashed + dotted + bare-hex normalisations all produce the same canonical EUI-64.
@@ -725,7 +725,7 @@ For `mac_to_link_local`:
 
 For `unicast_to_solicited_node`:
 - `2001:db8::1` → `ff02::1:ff00:1`.
-- `fe80::226:b9ff:fe7e:abcd` → `ff02::1:ff7e:abcd`.
+- `fe80::224:b9ff:fe7e:abcd` → `ff02::1:ff7e:abcd`.
 
 For `derive_from_mac` (combined):
 - One input, all three outputs in one return.

--- a/docs/superpowers/plans/v3.4.0-living-doc.md
+++ b/docs/superpowers/plans/v3.4.0-living-doc.md
@@ -32,7 +32,7 @@ its PR opens.
 | PR | Task | Title | Status | SHA(s) | Blockers |
 |---|---|---|---|---|---|
 | 1 | T1 | Branch + living-doc + memory bootstrap | merged | `cf22a7b` | — |
-| 2 | T2 | Cleanup batch — doc typo + RangeTest DI + ul_bit_flipped docblock | pending | — | T1 |
+| 2 | T2 | Cleanup batch — doc typo + RangeTest DI + ul_bit_flipped docblock | in-review (PR #376) | `d153c81` | T1 |
 | 3 | T3 | Extract `copy_button()` helper | pending | — | T2 |
 | 4 | T4 | Split `functions-derive6.php` → zone6/derive6/slaac6 | pending | — | T3 |
 | 5 | T5 | `request.php` flat globals → per-tool arrays | pending | — | T4 |

--- a/testing/unit/RangeTest.php
+++ b/testing/unit/RangeTest.php
@@ -119,12 +119,24 @@ class RangeTest extends TestCase
     {
         // 10.0.0.1 – 10.0.0.255 yields 8 CIDRs with no cap; with cap=4 it
         // truncates to 4 blocks. The explicit third argument keeps the test
-        // free of $GLOBALS mutation (CR feedback PR #369).
+        // DI-friendly and free of any global-state mutation.
         $r = range_to_cidrs('10.0.0.1', '10.0.0.255', 4);
         $this->assertTrue($r['truncated']);
         $this->assertSame(4, $r['count']);
         $this->assertSame(4, $r['cap']);
         $this->assertCount(4, $r['cidrs']);
+    }
+
+    public function testRangeToCidrsAcceptsCapAsParameter(): void
+    {
+        // v3.4.0: explicit cap parameter, no $GLOBALS mutation required.
+        // 10.0.0.0/24 produces a single /24 with no cap; with cap=4 we still
+        // get one CIDR (cap is a list-length cap, not a coverage cap).
+        // Use an asymmetric start to force fragmentation: 10.0.0.1 – 10.0.0.15
+        // produces 4 CIDRs naturally (/32, /31, /30, /29) under cap=4.
+        $r = range_to_cidrs('10.0.0.1', '10.0.0.15', 4);
+        $this->assertCount(4, $r['cidrs'], 'cap parameter limits result list');
+        $this->assertSame(4, $r['cap']);
     }
 
     public function testRange_FragmentedRange_NotTruncatedAtDefaultCap(): void


### PR DESCRIPTION
## Summary

Three small, unrelated fixes carried forward from v3.3.0 — backend/docs only, no UI surface.

- **#4** Doc typo: corrected EUI-64 example `0226:b9ff:fe7e:abcd` → `0224:b9ff:fe7e:abcd` in v3.3.0 plan + spec (and the corresponding `fe80::226:b9ff` link-local form).
- **#5** RangeTest DI: `range_to_cidrs(string $start, string $end, ?int $cap = null): array` — explicit cap parameter; RangeTest no longer mutates `$GLOBALS`. Added a TDD-style smoke test (`testRangeToCidrsAcceptsCapAsParameter`).
- **#6** `ul_bit_flipped` clarification: docblock + OpenAPI description now state explicitly that the U/L flip operation always runs unconditionally; the field reports whether the flip *changed* the bit value (i.e., bit was originally 0).

## Test plan

- [x] PHPUnit: 471 tests / 1107 assertions, 14 skipped (GMP-dependent), all green
- [x] PHPStan level 9 (--memory-limit=512M): 0 errors
- [x] PHPCS PSR-12: clean
- [x] Spectral OpenAPI lint: 0 errors
- [x] Semgrep (`p/php`, `p/owasp-top-ten`, `p/sql-injection`, custom): 0 findings
- [x] ESLint + Stylelint: 0 errors (11 pre-existing warnings, unrelated)
- [x] `make test-docker` Playwright: 1228/1228 passed

Closes v3.3.0 carry-forward items #4, #5, #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)