### PR TITLE
refactor(v3.4.0): request.php flat globals → per-tool arrays

### DIFF
--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -368,16 +368,14 @@ $vlsm6_requirements = [];
 
 $supernet_input  = '';
 $supernet_action = '';
-/** @var array{supernet?: string, summaries?: string[]}|null $supernet_result */
-$supernet_result = null;
-$supernet_error  = null;
+/** @var array{result?: array{supernet?: string, summaries?: string[]}, error?: string} */
+$supernet = [];
 
 // v3.3.0 — IPv6 supernet / summarise (supernet6)
 $supernet6_input  = '';
 $supernet6_action = '';
-/** @var array{supernet?: string, summaries?: string[]}|null $supernet6_result */
-$supernet6_result = null;
-$supernet6_error  = null;
+/** @var array{result?: array{supernet?: string, summaries?: string[]}, error?: string} */
+$supernet6 = [];
 
 // v3.3.0 — IPv6 zone-ID parser
 $zoneid_input = '';
@@ -396,19 +394,17 @@ $slaac_seed_input   = '';
 $slaac = [];
 
 $ula_global_id_input = '';
-/** @var array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}|null $ula_result */
-$ula_result = null;
-$ula_error  = null;
+/** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
+$ula = [];
 
 $session_save_id  = '';
 $session_load_id  = '';
 $session_error    = null;
 
-$range_start  = '';
-$range_end    = '';
-/** @var list<string>|null $range_result */
-$range_result = null;
-$range_error  = null;
+$range_start = '';
+$range_end   = '';
+/** @var array{result?: list<string>, error?: string} */
+$range = [];
 
 // v3.3.0 — IPv6 range → CIDR (range6)
 $range6_start = '';
@@ -808,15 +804,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $supernet_input  = trim((string)($_POST['supernet_input'] ?? ''));
         $lines = array_values(array_filter(array_map('trim', explode("\n", $supernet_input))));
         if (count($lines) < 1) {
-            $supernet_error = 'Enter at least one CIDR.';
+            $supernet = ['error' => 'Enter at least one CIDR.'];
         } elseif (count($lines) > 50) {
-            $supernet_error = 'Maximum 50 CIDRs per check.';
+            $supernet = ['error' => 'Maximum 50 CIDRs per check.'];
         } else {
             $sr = $supernet_action === 'find' ? supernet_find($lines) : summarise_cidrs($lines);
             if (isset($sr['error'])) {
-                $supernet_error = $sr['error'];
+                $supernet = ['error' => $sr['error']];
             } else {
-                $supernet_result = $sr;
+                $supernet = ['result' => $sr];
             }
         }
     }
@@ -829,15 +825,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $supernet6_input  = trim((string)($_POST['supernet6_input'] ?? ''));
         $lines6 = array_values(array_filter(array_map('trim', explode("\n", $supernet6_input))));
         if (count($lines6) < 1) {
-            $supernet6_error = 'Enter at least one CIDR.';
+            $supernet6 = ['error' => 'Enter at least one CIDR.'];
         } elseif (count($lines6) > 50) {
-            $supernet6_error = 'Maximum 50 CIDRs per check.';
+            $supernet6 = ['error' => 'Maximum 50 CIDRs per check.'];
         } else {
             $sr6 = $supernet6_action === 'find' ? supernet6_find($lines6) : summarise6_cidrs($lines6);
             if (isset($sr6['error'])) {
-                $supernet6_error = $sr6['error'];
+                $supernet6 = ['error' => $sr6['error']];
             } else {
-                $supernet6_result = $sr6;
+                $supernet6 = ['result' => $sr6];
             }
         }
     }
@@ -865,9 +861,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $ula_global_id_input = trim((string)($_POST['ula_global_id'] ?? ''));
         $ur = generate_ula_prefix($ula_global_id_input);
         if (isset($ur['error'])) {
-            $ula_error = $ur['error'];
+            $ula = ['error' => $ur['error']];
         } else {
-            $ula_result = $ur;
+            $ula = ['result' => $ur];
         }
     }
 
@@ -1000,13 +996,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $range_start = trim((string)($_POST['range_start'] ?? ''));
         $range_end   = trim((string)($_POST['range_end']   ?? ''));
         if ($range_start === '' || $range_end === '') {
-            $range_error = 'Both start and end IP addresses are required.';
+            $range = ['error' => 'Both start and end IP addresses are required.'];
         } else {
             $rr = range_to_cidrs($range_start, $range_end);
             if (isset($rr['error'])) {
-                $range_error = $rr['error'];
+                $range = ['error' => $rr['error']];
             } else {
-                $range_result = $rr['cidrs'] ?? [];
+                $range = ['result' => $rr['cidrs'] ?? []];
             }
         }
     }
@@ -1231,9 +1227,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (count($lines) >= 1 && count($lines) <= 50) {
             $sr = $supernet_action === 'find' ? supernet_find($lines) : summarise_cidrs($lines);
             if (isset($sr['error'])) {
-                $supernet_error = $sr['error'];
+                $supernet = ['error' => $sr['error']];
             } else {
-                $supernet_result = $sr;
+                $supernet = ['result' => $sr];
             }
         }
     }
@@ -1267,9 +1263,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (count($lines6) >= 1 && count($lines6) <= 50) {
             $sr6 = $supernet6_action === 'find' ? supernet6_find($lines6) : summarise6_cidrs($lines6);
             if (isset($sr6['error'])) {
-                $supernet6_error = $sr6['error'];
+                $supernet6 = ['error' => $sr6['error']];
             } else {
-                $supernet6_result = $sr6;
+                $supernet6 = ['result' => $sr6];
             }
         }
     }

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -224,31 +224,31 @@ function sc_run_zoneid(string $input): array
  * into the by-reference outputs. Used by both the POST handler and the GET
  * shareable-URL hydration path. (v3.3.0 Task 4)
  */
-function sc_run_derive(
-    string $mac,
-    ?string &$mac_canonical_out,
-    ?string &$eui64_out,
-    ?bool &$ul_bit_flipped_out,
-    ?string &$link_local_out,
-    ?string &$solicited_node_out,
-    ?string &$warning_out,
-    ?string &$error_out
-): void {
+/**
+ * Run derive_from_mac() and return an associative array with keys:
+ * mac_canonical, eui64, ul_bit_flipped, link_local, solicited_node,
+ * warning, error. Empty input returns []. (v3.4.0 — flat → array)
+ *
+ * @return array{mac_canonical?: string, eui64?: string, ul_bit_flipped?: bool, link_local?: string, solicited_node?: string, warning?: ?string, error?: string}
+ */
+function sc_run_derive(string $mac): array
+{
     if ($mac === '') {
-        return;
+        return [];
     }
     try {
         $r = derive_from_mac($mac);
     } catch (\InvalidArgumentException $e) {
-        $error_out = $e->getMessage();
-        return;
+        return ['error' => $e->getMessage()];
     }
-    $mac_canonical_out  = $r['mac_canonical'];
-    $eui64_out          = $r['eui64'];
-    $ul_bit_flipped_out = $r['ul_bit_flipped'];
-    $link_local_out     = $r['link_local'];
-    $solicited_node_out = $r['solicited_node'];
-    $warning_out        = $r['warning'];
+    return [
+        'mac_canonical'  => $r['mac_canonical'],
+        'eui64'          => $r['eui64'],
+        'ul_bit_flipped' => $r['ul_bit_flipped'],
+        'link_local'     => $r['link_local'],
+        'solicited_node' => $r['solicited_node'],
+        'warning'        => $r['warning'],
+    ];
 }
 
 // ─── SLAAC privacy helper (shared by POST handler and GET shareable URL) ────
@@ -261,35 +261,34 @@ function sc_run_derive(
  * Empty seed strings are treated as "unseeded" so a shareable URL with an
  * empty `slaac_seed=` parameter still produces a fresh address.
  */
-function sc_run_slaac(
-    string $prefix,
-    string $seed,
-    ?string &$prefix_out,
-    ?string &$address_out,
-    ?string &$interface_id_out,
-    ?string &$seed_used_out,
-    bool &$seed_was_provided_out,
-    ?string &$warning_out,
-    ?string &$error_out
-): void {
+/**
+ * Run slaac_privacy_address() and return an associative array with keys:
+ * prefix, address, interface_id, seed_used, seed_was_provided, warning,
+ * error. Empty prefix returns []. (v3.4.0 — flat → array)
+ *
+ * @return array{prefix?: string, address?: string, interface_id?: string, seed_used?: ?string, seed_was_provided?: bool, warning?: ?string, error?: string}
+ */
+function sc_run_slaac(string $prefix, string $seed): array
+{
     if ($prefix === '') {
-        return;
+        return [];
     }
     $seed_arg = ($seed === '') ? null : $seed;
     try {
         $r = slaac_privacy_address($prefix, $seed_arg);
     } catch (\InvalidArgumentException $e) {
-        $error_out = $e->getMessage();
-        return;
+        return ['error' => $e->getMessage()];
     }
-    $prefix_out            = $r['prefix'];
-    $address_out           = $r['address'];
-    $interface_id_out      = $r['interface_id'];
-    $seed_used_out         = $r['seed_used'];
-    $seed_was_provided_out = $r['seed_was_provided'];
-    // $warning_out reserved for future use (e.g. callers may surface "seed is
-    // a documentation/example value" hints). Currently always null.
-    $warning_out           = null;
+    return [
+        'prefix'            => $r['prefix'],
+        'address'           => $r['address'],
+        'interface_id'      => $r['interface_id'],
+        'seed_used'         => $r['seed_used'],
+        'seed_was_provided' => $r['seed_was_provided'],
+        // 'warning' reserved for future use (callers may surface "seed is a
+        // documentation/example value" hints). Currently always null.
+        'warning'           => null,
+    ];
 }
 
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
@@ -385,25 +384,15 @@ $zoneid_input = '';
 $zoneid = [];
 
 // v3.3.0 — MAC → IPv6 derivation tool (derive)
-$derive_input          = '';
-$derive_mac_canonical  = null;
-$derive_eui64          = null;
-$derive_ul_bit_flipped = null;
-$derive_link_local     = null;
-$derive_solicited_node = null;
-$derive_warning        = null;
-$derive_error          = null;
+$derive_input = '';
+/** @var array{mac_canonical?: string, eui64?: string, ul_bit_flipped?: bool, link_local?: string, solicited_node?: string, warning?: ?string, error?: string} */
+$derive = [];
 
 // v3.3.0 — SLAAC privacy address generator (RFC 8981)
-$slaac_prefix_input      = '';
-$slaac_seed_input        = '';
-$slaac_prefix            = null;
-$slaac_address           = null;
-$slaac_interface_id      = null;
-$slaac_seed_used         = null;
-$slaac_seed_was_provided = false;
-$slaac_warning           = null;
-$slaac_error             = null;
+$slaac_prefix_input = '';
+$slaac_seed_input   = '';
+/** @var array{prefix?: string, address?: string, interface_id?: string, seed_used?: ?string, seed_was_provided?: bool, warning?: ?string, error?: string} */
+$slaac = [];
 
 $ula_global_id_input = '';
 /** @var array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}|null $ula_result */
@@ -867,33 +856,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($is_derive && !$form_blocked) {
         $active_tab = 'ipv6';
         $derive_input = trim((string)($_POST['derive_mac'] ?? ''));
-        sc_run_derive(
-            $derive_input,
-            $derive_mac_canonical,
-            $derive_eui64,
-            $derive_ul_bit_flipped,
-            $derive_link_local,
-            $derive_solicited_node,
-            $derive_warning,
-            $derive_error
-        );
+        $derive = sc_run_derive($derive_input);
     }
 
     if ($is_slaac && !$form_blocked) {
         $active_tab = 'ipv6';
         $slaac_prefix_input = trim((string)($_POST['slaac_prefix'] ?? ''));
         $slaac_seed_input   = trim((string)($_POST['slaac_seed']   ?? ''));
-        sc_run_slaac(
-            $slaac_prefix_input,
-            $slaac_seed_input,
-            $slaac_prefix,
-            $slaac_address,
-            $slaac_interface_id,
-            $slaac_seed_used,
-            $slaac_seed_was_provided,
-            $slaac_warning,
-            $slaac_error
-        );
+        $slaac = sc_run_slaac($slaac_prefix_input, $slaac_seed_input);
     }
 
     if ($is_ula && !$form_blocked) {
@@ -1298,33 +1268,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // MAC-derivation tool shareable GET URL (v3.3.0 Task 4)
     if ($active_tab === 'ipv6' && isset($_GET['derive_mac'])) {
         $derive_input = trim((string)($_GET['derive_mac'] ?? ''));
-        sc_run_derive(
-            $derive_input,
-            $derive_mac_canonical,
-            $derive_eui64,
-            $derive_ul_bit_flipped,
-            $derive_link_local,
-            $derive_solicited_node,
-            $derive_warning,
-            $derive_error
-        );
+        $derive = sc_run_derive($derive_input);
     }
 
     // SLAAC privacy address shareable GET URL (v3.3.0 Task 5)
     if ($active_tab === 'ipv6' && isset($_GET['slaac_prefix'])) {
         $slaac_prefix_input = trim((string)($_GET['slaac_prefix'] ?? ''));
         $slaac_seed_input   = trim((string)($_GET['slaac_seed']   ?? ''));
-        sc_run_slaac(
-            $slaac_prefix_input,
-            $slaac_seed_input,
-            $slaac_prefix,
-            $slaac_address,
-            $slaac_interface_id,
-            $slaac_seed_used,
-            $slaac_seed_was_provided,
-            $slaac_warning,
-            $slaac_error
-        );
+        $slaac = sc_run_slaac($slaac_prefix_input, $slaac_seed_input);
     }
 
     // Supernet6 / summarise6 shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -102,14 +102,19 @@ function recaptcha_enterprise_verify(
  *
  * @param list<array{ip: string, matches: list<string>, deepest: string|null}>|null $result_out
  */
+/**
+ * Run lookup_ips() against the given raw textarea inputs and return an
+ * associative array with keys: result, error. Empty-input early-returns
+ * with [] so empty-state defaults apply. (v3.4.0 — flat → array)
+ *
+ * @return array{result?: list<array{ip: string, matches: list<string>, deepest: string|null}>, error?: string}
+ */
 function sc_run_lookup(
     string $cidrs_input,
     string $ips_input,
-    ?array &$result_out,
-    ?string &$error_out,
     int $max_cidrs = 100,
     int $max_ips = 1000
-): void {
+): array {
     // Enforce absolute safety ceilings (hard caps documented in OpenAPI spec).
     $max_cidrs = max(1, min($max_cidrs, 1000));
     $max_ips   = max(1, min($max_ips, 10000));
@@ -117,25 +122,21 @@ function sc_run_lookup(
     $cidr_lines = array_values(array_filter(array_map('trim', explode("\n", $cidrs_input))));
     $ip_lines   = array_values(array_filter(array_map('trim', explode("\n", $ips_input))));
     if ($cidr_lines === []) {
-        $error_out = 'At least one CIDR is required.';
-        return;
+        return ['error' => 'At least one CIDR is required.'];
     }
     if ($ip_lines === []) {
-        $error_out = 'At least one IP is required.';
-        return;
+        return ['error' => 'At least one IP is required.'];
     }
     if (count($cidr_lines) > $max_cidrs) {
-        $error_out = 'Too many CIDRs (max ' . $max_cidrs . ').';
-        return;
+        return ['error' => 'Too many CIDRs (max ' . $max_cidrs . ').'];
     }
     if (count($ip_lines) > $max_ips) {
-        $error_out = 'Too many IPs (max ' . $max_ips . ').';
-        return;
+        return ['error' => 'Too many IPs (max ' . $max_ips . ').'];
     }
     try {
-        $result_out = lookup_ips($cidr_lines, $ip_lines);
+        return ['result' => lookup_ips($cidr_lines, $ip_lines)];
     } catch (\InvalidArgumentException $e) {
-        $error_out = $e->getMessage();
+        return ['error' => $e->getMessage()];
     }
 }
 
@@ -299,34 +300,28 @@ function sc_run_slaac(string $prefix, string $seed): array
  * into $result_out / $error_out by reference. Used by both the POST handler
  * and the GET shareable-URL hydration path.
  *
- * @param array{added: list<string>, removed: list<string>, unchanged: list<string>,
- *               changed: list<array{from: string, to: string, reason: string}>}|null $result_out
+ * @return array{result?: array{added: list<string>, removed: list<string>, unchanged: list<string>, changed: list<array{from: string, to: string, reason: string}>}, error?: string}
  */
 function sc_run_diff(
     string $before_input,
     string $after_input,
-    ?array &$result_out,
-    ?string &$error_out,
     int $max_entries = 1000
-): void {
+): array {
     $before_lines = array_values(array_filter(array_map('trim', explode("\n", $before_input))));
     $after_lines  = array_values(array_filter(array_map('trim', explode("\n", $after_input))));
     if ($before_lines === [] && $after_lines === []) {
-        $error_out = 'At least one CIDR is required in either Before or After.';
-        return;
+        return ['error' => 'At least one CIDR is required in either Before or After.'];
     }
     if (count($before_lines) > $max_entries) {
-        $error_out = 'Too many CIDRs in Before (max ' . $max_entries . ').';
-        return;
+        return ['error' => 'Too many CIDRs in Before (max ' . $max_entries . ').'];
     }
     if (count($after_lines) > $max_entries) {
-        $error_out = 'Too many CIDRs in After (max ' . $max_entries . ').';
-        return;
+        return ['error' => 'Too many CIDRs in After (max ' . $max_entries . ').'];
     }
     try {
-        $result_out = subnet_diff($before_lines, $after_lines);
+        return ['result' => subnet_diff($before_lines, $after_lines)];
     } catch (\InvalidArgumentException $e) {
-        $error_out = $e->getMessage();
+        return ['error' => $e->getMessage()];
     }
 }
 
@@ -346,13 +341,13 @@ $split_result6 = $split_error6 = null;
 $input_split_prefix  = '';
 $input_split_prefix6 = '';
 
-$overlap_result = $overlap_error = null;
 $overlap_cidr_a = $overlap_cidr_b = '';
+/** @var array{result?: string, error?: string} */
+$overlap = [];
 
-$multi_overlap_input  = '';
-/** @var array<array{a: string, b: string, relation: string}>|null $multi_overlap_result */
-$multi_overlap_result = null;
-$multi_overlap_error  = null;
+$multi_overlap_input = '';
+/** @var array{result?: array<array{a: string, b: string, relation: string}>, error?: string} */
+$multi_overlap = [];
 
 $vlsm_result = $vlsm_error = null;
 $vlsm_network = $vlsm_cidr_input = '';
@@ -414,26 +409,22 @@ $range6 = [];
 
 $tree_parent   = '';
 $tree_children = '';
-/** @var array<string, mixed>|null $tree_result */
-$tree_result = null;
-$tree_error  = null;
+/** @var array{result?: array<string, mixed>, error?: string} */
+$tree = [];
 
-$wildcard_input  = '';
-/** @var array{cidr: string, wildcard: string}|null $wildcard_result */
-$wildcard_result = null;
-$wildcard_error  = null;
+$wildcard_input = '';
+/** @var array{result?: array{cidr: string, wildcard: string}, error?: string} */
+$wildcard = [];
 
 $lookup_cidrs_input = '';
 $lookup_ips_input   = '';
-/** @var list<array{ip: string, matches: list<string>, deepest: string|null}>|null $lookup_result */
-$lookup_result = null;
-$lookup_error  = null;
+/** @var array{result?: list<array{ip: string, matches: list<string>, deepest: string|null}>, error?: string} */
+$lookup = [];
 
 $diff_before_input = '';
 $diff_after_input  = '';
-/** @var array{added: list<string>, removed: list<string>, unchanged: list<string>, changed: list<array{from: string, to: string, reason: string}>}|null $diff_result */
-$diff_result = null;
-$diff_error  = null;
+/** @var array{result?: array{added: list<string>, removed: list<string>, unchanged: list<string>, changed: list<array{from: string, to: string, reason: string}>}, error?: string} */
+$diff = [];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $post_tab   = $_POST['tab'] ?? $default_tab;
@@ -595,10 +586,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $a_is_v6 = strpos($overlap_cidr_a, ':') !== false;
         $b_is_v6 = strpos($overlap_cidr_b, ':') !== false;
         if ($a_is_v6 !== $b_is_v6) {
-            $overlap_error = 'Cannot compare IPv4 and IPv6 addresses.';
+            $overlap = ['error' => 'Cannot compare IPv4 and IPv6 addresses.'];
         } elseif ($a_is_v6) {
             if (!extension_loaded('gmp')) {
-                $overlap_error = 'IPv6 overlap check requires the PHP GMP extension.';
+                $overlap = ['error' => 'IPv6 overlap check requires the PHP GMP extension.'];
             } else {
                 [$a_ip, $a_pfx] = array_pad(explode('/', $overlap_cidr_a, 2), 2, '');
                 [$b_ip, $b_pfx] = array_pad(explode('/', $overlap_cidr_b, 2), 2, '');
@@ -607,17 +598,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $b_ip  = trim($b_ip);
                 $b_pfx = trim($b_pfx);
                 if (!is_valid_ipv6($a_ip) || !ctype_digit($a_pfx) || (int)$a_pfx > 128) {
-                    $overlap_error = 'First subnet: Invalid IPv6 CIDR.';
+                    $overlap = ['error' => 'First subnet: Invalid IPv6 CIDR.'];
                 } elseif (!is_valid_ipv6($b_ip) || !ctype_digit($b_pfx) || (int)$b_pfx > 128) {
-                    $overlap_error = 'Second subnet: Invalid IPv6 CIDR.';
+                    $overlap = ['error' => 'Second subnet: Invalid IPv6 CIDR.'];
                 } else {
                     try {
                         $r6a = calculate_subnet6($a_ip, (int)$a_pfx);
                         $r6b = calculate_subnet6($b_ip, (int)$b_pfx);
-                        $overlap_result = cidrs_overlap6($r6a['network_cidr'], $r6b['network_cidr']);
+                        $overlap = ['result' => cidrs_overlap6($r6a['network_cidr'], $r6b['network_cidr'])];
                     } catch (\Exception $e) {
                         error_log('sc IPv6 overlap error: ' . $e->getMessage());
-                        $overlap_error = 'An error occurred during calculation. Please check your input.';
+                        $overlap = ['error' => 'An error occurred during calculation. Please check your input.'];
                     }
                 }
             }
@@ -625,11 +616,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $ra = resolve_ipv4_input($overlap_cidr_a, '');
             $rb = resolve_ipv4_input($overlap_cidr_b, '');
             if (!$ra['result']) {
-                $overlap_error = 'First subnet: ' . ($ra['error'] ?? 'Invalid CIDR.');
+                $overlap = ['error' => 'First subnet: ' . ($ra['error'] ?? 'Invalid CIDR.')];
             } elseif (!$rb['result']) {
-                $overlap_error = 'Second subnet: ' . ($rb['error'] ?? 'Invalid CIDR.');
+                $overlap = ['error' => 'Second subnet: ' . ($rb['error'] ?? 'Invalid CIDR.')];
             } else {
-                $overlap_result = cidrs_overlap($ra['result']['network_cidr'], $rb['result']['network_cidr']);
+                $overlap = ['result' => cidrs_overlap($ra['result']['network_cidr'], $rb['result']['network_cidr'])];
             }
         }
     }
@@ -639,9 +630,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $raw_lines = array_filter(array_map('trim', explode("\n", $multi_overlap_input)));
         $lines = array_values($raw_lines);
         if (count($lines) < 2) {
-            $multi_overlap_error = 'Enter at least two CIDRs (one per line).';
+            $multi_overlap = ['error' => 'Enter at least two CIDRs (one per line).'];
         } elseif (count($lines) > 50) {
-            $multi_overlap_error = 'Maximum 50 CIDRs per check.';
+            $multi_overlap = ['error' => 'Maximum 50 CIDRs per check.'];
         } else {
             $normalised = [];
             $multi_err  = null;
@@ -676,7 +667,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
             if ($multi_err !== null) {
-                $multi_overlap_error = $multi_err;
+                $multi_overlap = ['error' => $multi_err];
             } else {
                 $has_v4 = false;
                 $has_v6 = false;
@@ -688,7 +679,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     }
                 }
                 if ($has_v4 && $has_v6) {
-                    $multi_overlap_error = 'Cannot mix IPv4 and IPv6 CIDRs.';
+                    $multi_overlap = ['error' => 'Cannot mix IPv4 and IPv6 CIDRs.'];
                 } else {
                     $conflicts = [];
                     $n_count = count($normalised);
@@ -706,7 +697,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             }
                         }
                     }
-                    $multi_overlap_result = $conflicts;
+                    $multi_overlap = ['result' => $conflicts];
                 }
             }
         }
@@ -1017,22 +1008,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($is_wildcard && !$form_blocked) {
         $wildcard_input = trim((string)($_POST['wildcard_input'] ?? ''));
         if ($wildcard_input === '') {
-            $wildcard_error = 'A CIDR prefix or wildcard mask is required.';
+            $wildcard = ['error' => 'A CIDR prefix or wildcard mask is required.'];
         } else {
             try {
                 if (str_contains($wildcard_input, '.')) {
-                    $wildcard_result = [
+                    $wildcard = ['result' => [
                         'cidr'     => wildcard_to_cidr($wildcard_input),
                         'wildcard' => $wildcard_input,
-                    ];
+                    ]];
                 } else {
-                    $wildcard_result = [
+                    $wildcard = ['result' => [
                         'cidr'     => '/' . ltrim($wildcard_input, '/'),
                         'wildcard' => cidr_to_wildcard($wildcard_input),
-                    ];
+                    ]];
                 }
             } catch (\InvalidArgumentException $e) {
-                $wildcard_error = $e->getMessage();
+                $wildcard = ['error' => $e->getMessage()];
             }
         }
     }
@@ -1040,11 +1031,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($is_lookup && !$form_blocked) {
         $lookup_cidrs_input = (string)($_POST['lookup_cidrs'] ?? '');
         $lookup_ips_input   = (string)($_POST['lookup_ips']   ?? '');
-        sc_run_lookup(
+        $lookup = sc_run_lookup(
             $lookup_cidrs_input,
             $lookup_ips_input,
-            $lookup_result,
-            $lookup_error,
             isset($lookup_max_cidrs) ? (int)$lookup_max_cidrs : 100,
             isset($lookup_max_ips)   ? (int)$lookup_max_ips   : 1000,
         );
@@ -1053,12 +1042,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($is_diff && !$form_blocked) {
         $diff_before_input = (string)($_POST['diff_before'] ?? '');
         $diff_after_input  = (string)($_POST['diff_after']  ?? '');
-        sc_run_diff(
-            $diff_before_input,
-            $diff_after_input,
-            $diff_result,
-            $diff_error,
-        );
+        $diff = sc_run_diff($diff_before_input, $diff_after_input);
     }
 
     if ($is_tree && !$form_blocked) {
@@ -1066,15 +1050,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $tree_children = trim((string)($_POST['tree_children'] ?? ''));
         $child_lines   = array_values(array_filter(array_map('trim', explode("\n", $tree_children))));
         if ($tree_parent === '') {
-            $tree_error = 'Parent CIDR is required.';
+            $tree = ['error' => 'Parent CIDR is required.'];
         } elseif (count($child_lines) > 100) {
-            $tree_error = 'Maximum 100 child CIDRs per request.';
+            $tree = ['error' => 'Maximum 100 child CIDRs per request.'];
         } else {
             $tr = build_subnet_tree($tree_parent, $child_lines);
             if (isset($tr['error'])) {
-                $tree_error = $tr['error'];
+                $tree = ['error' => $tr['error']];
             } else {
-                $tree_result = $tr['tree'] ?? [];
+                $tree = ['result' => $tr['tree'] ?? []];
             }
         }
     }
@@ -1185,11 +1169,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ) {
         $lookup_cidrs_input = (string)($_GET['lookup_cidrs'] ?? '');
         $lookup_ips_input   = (string)($_GET['lookup_ips']   ?? '');
-        sc_run_lookup(
+        $lookup = sc_run_lookup(
             $lookup_cidrs_input,
             $lookup_ips_input,
-            $lookup_result,
-            $lookup_error,
             isset($lookup_max_cidrs) ? (int)$lookup_max_cidrs : 100,
             isset($lookup_max_ips)   ? (int)$lookup_max_ips   : 1000,
         );
@@ -1202,12 +1184,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ) {
         $diff_before_input = (string)($_GET['diff_before'] ?? '');
         $diff_after_input  = (string)($_GET['diff_after']  ?? '');
-        sc_run_diff(
-            $diff_before_input,
-            $diff_after_input,
-            $diff_result,
-            $diff_error,
-        );
+        $diff = sc_run_diff($diff_before_input, $diff_after_input);
     }
 
     // IPv6 range → CIDR shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -192,27 +192,29 @@ function sc_run_range6(
  * pattern: ONE helper for both methods, populates the same template globals
  * regardless of entry point.
  */
-function sc_run_zoneid(
-    string $input,
-    ?string &$address_out,
-    ?string &$zone_id_out,
-    ?bool &$is_link_local_out,
-    ?string &$warning_out,
-    ?string &$error_out
-): void {
+/**
+ * Run parse_zone_id() against the given input and return an associative array
+ * with keys: address, zone_id, is_link_local, warning, error. Empty input
+ * returns an empty array. (v3.4.0 — flat globals → per-tool array)
+ *
+ * @return array{address?: string, zone_id?: ?string, is_link_local?: bool, warning?: ?string, error?: string}
+ */
+function sc_run_zoneid(string $input): array
+{
     if ($input === '') {
-        return;
+        return [];
     }
     try {
         $r = parse_zone_id($input);
     } catch (\InvalidArgumentException $e) {
-        $error_out = $e->getMessage();
-        return;
+        return ['error' => $e->getMessage()];
     }
-    $address_out       = $r['address'];
-    $zone_id_out       = $r['zone_id'];
-    $is_link_local_out = $r['is_link_local'];
-    $warning_out       = $r['warning'];
+    return [
+        'address'       => $r['address'],
+        'zone_id'       => $r['zone_id'],
+        'is_link_local' => $r['is_link_local'],
+        'warning'       => $r['warning'],
+    ];
 }
 
 // ─── Derive helper (shared by POST handler and GET shareable URL) ───────────
@@ -378,12 +380,9 @@ $supernet6_result = null;
 $supernet6_error  = null;
 
 // v3.3.0 — IPv6 zone-ID parser
-$zoneid_input         = '';
-$zoneid_address       = null;
-$zoneid_zone_id       = null;
-$zoneid_is_link_local = null;
-$zoneid_warning       = null;
-$zoneid_error         = null;
+$zoneid_input = '';
+/** @var array{address?: string, zone_id?: ?string, is_link_local?: bool, warning?: ?string, error?: string} */
+$zoneid = [];
 
 // v3.3.0 — MAC → IPv6 derivation tool (derive)
 $derive_input          = '';
@@ -862,14 +861,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($is_zoneid && !$form_blocked) {
         $active_tab = 'ipv6';
         $zoneid_input = trim((string)($_POST['zoneid_input'] ?? ''));
-        sc_run_zoneid(
-            $zoneid_input,
-            $zoneid_address,
-            $zoneid_zone_id,
-            $zoneid_is_link_local,
-            $zoneid_warning,
-            $zoneid_error
-        );
+        $zoneid = sc_run_zoneid($zoneid_input);
     }
 
     if ($is_derive && !$form_blocked) {
@@ -1300,14 +1292,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Zone-ID parser shareable GET URL (v3.3.0)
     if ($active_tab === 'ipv6' && isset($_GET['zoneid_input'])) {
         $zoneid_input = trim((string)($_GET['zoneid_input'] ?? ''));
-        sc_run_zoneid(
-            $zoneid_input,
-            $zoneid_address,
-            $zoneid_zone_id,
-            $zoneid_is_link_local,
-            $zoneid_warning,
-            $zoneid_error
-        );
+        $zoneid = sc_run_zoneid($zoneid_input);
     }
 
     // MAC-derivation tool shareable GET URL (v3.3.0 Task 4)

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -231,7 +231,10 @@ function sc_run_zoneid(string $input): array
  * mac_canonical, eui64, ul_bit_flipped, link_local, solicited_node,
  * warning, error. Empty input returns []. (v3.4.0 — flat → array)
  *
- * @return array{mac_canonical?: string, eui64?: string, ul_bit_flipped?: bool, link_local?: string, solicited_node?: string, warning?: ?string, error?: string}
+ * @return array{
+ *     mac_canonical?: string, eui64?: string, ul_bit_flipped?: bool,
+ *     link_local?: string, solicited_node?: string, warning?: ?string, error?: string
+ * }
  */
 function sc_run_derive(string $mac): array
 {
@@ -268,7 +271,10 @@ function sc_run_derive(string $mac): array
  * prefix, address, interface_id, seed_used, seed_was_provided, warning,
  * error. Empty prefix returns []. (v3.4.0 — flat → array)
  *
- * @return array{prefix?: string, address?: string, interface_id?: string, seed_used?: ?string, seed_was_provided?: bool, warning?: ?string, error?: string}
+ * @return array{
+ *     prefix?: string, address?: string, interface_id?: string,
+ *     seed_used?: ?string, seed_was_provided?: bool, warning?: ?string, error?: string
+ * }
  */
 function sc_run_slaac(string $prefix, string $seed): array
 {
@@ -300,7 +306,13 @@ function sc_run_slaac(string $prefix, string $seed): array
  * into $result_out / $error_out by reference. Used by both the POST handler
  * and the GET shareable-URL hydration path.
  *
- * @return array{result?: array{added: list<string>, removed: list<string>, unchanged: list<string>, changed: list<array{from: string, to: string, reason: string}>}, error?: string}
+ * @return array{
+ *     result?: array{
+ *         added: list<string>, removed: list<string>, unchanged: list<string>,
+ *         changed: list<array{from: string, to: string, reason: string}>
+ *     },
+ *     error?: string
+ * }
  */
 function sc_run_diff(
     string $before_input,
@@ -576,7 +588,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($new_pfx6 <= $current_pfx6) {
                     $splitter6 = ['error' => 'New prefix must be larger than /' . $current_pfx6 . '.'];
                 } else {
-                    $splitter6 = ['result' => split_subnet6($network_ipv6, $current_pfx6, $new_pfx6, $split_max_subnets)];
+                    $splitter6 = [
+                        'result' => split_subnet6($network_ipv6, $current_pfx6, $new_pfx6, $split_max_subnets),
+                    ];
                 }
             }
         }

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -151,34 +151,35 @@ function sc_run_lookup(
  *
  * @param list<string>|null $result_out
  */
-function sc_run_range6(
-    string $start,
-    string $end,
-    ?array &$result_out,
-    ?string &$error_out,
-    ?string &$warning_out,
-    ?int &$count_out,
-    int|string|null &$total_out
-): void {
+/**
+ * Run range6_to_cidrs() and return an associative array with keys: result
+ * (cidrs list), error, warning, count, total. Empty inputs return [].
+ * (v3.4.0 — flat → array)
+ *
+ * @return array{result?: list<string>, error?: string, warning?: string, count?: ?int, total?: int|string|null}
+ */
+function sc_run_range6(string $start, string $end): array
+{
     if ($start === '' && $end === '') {
-        return;
+        return [];
     }
     if ($start === '' || $end === '') {
-        $error_out = 'Start and end IPv6 addresses are required.';
-        return;
+        return ['error' => 'Start and end IPv6 addresses are required.'];
     }
     $r = range6_to_cidrs($start, $end);
     if (isset($r['error'])) {
-        $error_out = $r['error'];
-        return;
+        return ['error' => $r['error']];
     }
-    $result_out = $r['cidrs'] ?? [];
-    $count_out  = $r['count'] ?? null;
-    $total_out  = $r['total_addresses'] ?? null;
+    $out = [
+        'result' => $r['cidrs'] ?? [],
+        'count'  => $r['count'] ?? null,
+        'total'  => $r['total_addresses'] ?? null,
+    ];
     if (!empty($r['truncated'])) {
         $cap = (int)($r['cap'] ?? 256);
-        $warning_out = 'Result truncated at ' . $cap . ' CIDRs (configure via $range_max_cidrs).';
+        $out['warning'] = 'Result truncated at ' . $cap . ' CIDRs (configure via $range_max_cidrs).';
     }
+    return $out;
 }
 
 // ─── Zone-ID helper (shared by POST handler and GET shareable URL) ──────────
@@ -410,16 +411,10 @@ $range_result = null;
 $range_error  = null;
 
 // v3.3.0 — IPv6 range → CIDR (range6)
-$range6_start  = '';
-$range6_end    = '';
-/** @var list<string>|null $range6_result */
-$range6_result   = null;
-$range6_error    = null;
-$range6_warning  = null;
-/** @var int|null $range6_count */
-$range6_count    = null;
-/** @var int|string|null $range6_total */
-$range6_total    = null;
+$range6_start = '';
+$range6_end   = '';
+/** @var array{result?: list<string>, error?: string, warning?: string, count?: ?int, total?: int|string|null} */
+$range6 = [];
 
 $tree_parent   = '';
 $tree_children = '';
@@ -1020,15 +1015,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $active_tab   = 'ipv6';
         $range6_start = trim((string)($_POST['range6_start'] ?? ''));
         $range6_end   = trim((string)($_POST['range6_end']   ?? ''));
-        sc_run_range6(
-            $range6_start,
-            $range6_end,
-            $range6_result,
-            $range6_error,
-            $range6_warning,
-            $range6_count,
-            $range6_total,
-        );
+        $range6 = sc_run_range6($range6_start, $range6_end);
     }
 
     if ($is_wildcard && !$form_blocked) {
@@ -1231,15 +1218,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($active_tab === 'ipv6' && (isset($_GET['range6_start']) || isset($_GET['range6_end']))) {
         $range6_start = trim((string)($_GET['range6_start'] ?? ''));
         $range6_end   = trim((string)($_GET['range6_end']   ?? ''));
-        sc_run_range6(
-            $range6_start,
-            $range6_end,
-            $range6_result,
-            $range6_error,
-            $range6_warning,
-            $range6_count,
-            $range6_total,
-        );
+        $range6 = sc_run_range6($range6_start, $range6_end);
     }
 
     // Supernet / summarise shareable GET URL

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -336,10 +336,12 @@ $input_ip = $input_mask = '';
 $result6 = $error6 = null;
 $input_ipv6 = $input_prefix = '';
 
-$split_result  = $split_error  = null;
-$split_result6 = $split_error6 = null;
 $input_split_prefix  = '';
 $input_split_prefix6 = '';
+/** @var array{result?: list<string>, error?: string} */
+$splitter = [];
+/** @var array{result?: list<string>, error?: string} */
+$splitter6 = [];
 
 $overlap_cidr_a = $overlap_cidr_b = '';
 /** @var array{result?: string, error?: string} */
@@ -349,17 +351,17 @@ $multi_overlap_input = '';
 /** @var array{result?: array<array{a: string, b: string, relation: string}>, error?: string} */
 $multi_overlap = [];
 
-$vlsm_result = $vlsm_error = null;
 $vlsm_network = $vlsm_cidr_input = '';
 /** @var array<array{name: string, hosts: int}> $vlsm_requirements */
 $vlsm_requirements = [];
+/** @var array{result?: list<array{name: string, hosts_needed: int, subnet: string, usable: int}>, error?: string} */
+$vlsm = [];
 
-/** @var list<array{name: string, hosts_needed: int|string, subnet: string, usable: int|string}>|null $vlsm6_result */
-$vlsm6_result = null;
-$vlsm6_error  = null;
 $vlsm6_network = $vlsm6_cidr_input = '';
 /** @var array<array{name: string, hosts: int|string}> $vlsm6_requirements */
 $vlsm6_requirements = [];
+/** @var array{result?: list<array{name: string, hosts_needed: int|string, subnet: string, usable: int|string}>, error?: string} */
+$vlsm6 = [];
 
 $supernet_input  = '';
 $supernet_action = '';
@@ -540,15 +542,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $input_split_prefix = trim((string)$_POST['split_prefix']);
             $sp = ltrim($input_split_prefix, '/');
             if (!ctype_digit($sp) || (int)$sp < 1 || (int)$sp > 32) {
-                $split_error = 'New prefix must be between 1 and 32.';
+                $splitter = ['error' => 'New prefix must be between 1 and 32.'];
             } else {
                 $new_pfx      = (int)$sp;
                 $current_cidr = (int)ltrim($result['netmask_cidr'], '/');
                 $network_ip   = explode('/', $result['network_cidr'])[0];
                 if ($new_pfx <= $current_cidr) {
-                    $split_error = 'New prefix must be larger than /' . $current_cidr . '.';
+                    $splitter = ['error' => 'New prefix must be larger than /' . $current_cidr . '.'];
                 } else {
-                    $split_result = split_subnet($network_ip, $current_cidr, $new_pfx, $split_max_subnets);
+                    $splitter = ['result' => split_subnet($network_ip, $current_cidr, $new_pfx, $split_max_subnets)];
                 }
             }
         }
@@ -566,15 +568,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $input_split_prefix6 = trim((string)$_POST['split_prefix6']);
             $sp6 = ltrim($input_split_prefix6, '/');
             if (!ctype_digit($sp6) || (int)$sp6 < 1 || (int)$sp6 > 128) {
-                $split_error6 = 'New prefix must be between 1 and 128.';
+                $splitter6 = ['error' => 'New prefix must be between 1 and 128.'];
             } else {
                 $new_pfx6     = (int)$sp6;
                 $current_pfx6 = (int)ltrim($result6['prefix'], '/');
                 $network_ipv6 = explode('/', $result6['network_cidr'])[0];
                 if ($new_pfx6 <= $current_pfx6) {
-                    $split_error6 = 'New prefix must be larger than /' . $current_pfx6 . '.';
+                    $splitter6 = ['error' => 'New prefix must be larger than /' . $current_pfx6 . '.'];
                 } else {
-                    $split_result6 = split_subnet6($network_ipv6, $current_pfx6, $new_pfx6, $split_max_subnets);
+                    $splitter6 = ['result' => split_subnet6($network_ipv6, $current_pfx6, $new_pfx6, $split_max_subnets)];
                 }
             }
         }
@@ -708,12 +710,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $vlsm_cidr_input = trim((string)($_POST['vlsm_cidr']   ?? ''));
         $rv = resolve_ipv4_input($vlsm_network, $vlsm_cidr_input);
         if (!$rv['result']) {
-            $vlsm_error = 'Parent network: ' . ($rv['error'] ?? 'Invalid input.');
+            $vlsm['error'] = 'Parent network: ' . ($rv['error'] ?? 'Invalid input.');
         } else {
             $names  = $_POST['vlsm_name']  ?? [];
             $hosts  = $_POST['vlsm_hosts'] ?? [];
             if (!is_array($names) || !is_array($hosts) || count($names) === 0) {
-                $vlsm_error = 'Add at least one requirement.';
+                $vlsm['error'] = 'Add at least one requirement.';
             } else {
                 $reqs = [];
                 foreach ($names as $i => $name) {
@@ -725,16 +727,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $reqs[] = ['name' => $name, 'hosts' => (int)$hval];
                 }
                 if ($reqs === []) {
-                    $vlsm_error = 'Add at least one valid requirement.';
+                    $vlsm['error'] = 'Add at least one valid requirement.';
                 } else {
                     $vlsm_cidr_int   = (int)ltrim($rv['result']['netmask_cidr'], '/');
                     $vlsm_network_ip = explode('/', $rv['result']['network_cidr'])[0];
                     $vlsm_requirements = $reqs;
                     $vr = vlsm_allocate($vlsm_network_ip, $vlsm_cidr_int, $reqs);
                     if (isset($vr['error'])) {
-                        $vlsm_error = $vr['error'];
+                        $vlsm['error'] = $vr['error'];
                     } else {
-                        $vlsm_result = $vr['allocations'] ?? [];
+                        $vlsm['result'] = $vr['allocations'] ?? [];
                     }
                 }
             }
@@ -745,12 +747,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $vlsm6_cidr_input = trim((string)($_POST['vlsm6_cidr']    ?? ''));
         $rv6 = resolve_ipv6_input($vlsm6_network, $vlsm6_cidr_input);
         if (!$rv6['result6']) {
-            $vlsm6_error = 'Parent network: ' . ($rv6['error6'] ?? 'Invalid input.');
+            $vlsm6['error'] = 'Parent network: ' . ($rv6['error6'] ?? 'Invalid input.');
         } else {
             $names6 = $_POST['vlsm6_name']  ?? [];
             $hosts6 = $_POST['vlsm6_hosts'] ?? [];
             if (!is_array($names6) || !is_array($hosts6) || count($names6) === 0) {
-                $vlsm6_error = 'Add at least one requirement.';
+                $vlsm6['error'] = 'Add at least one requirement.';
             } else {
                 $reqs6 = [];
                 $name6_too_long = false;
@@ -770,18 +772,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $reqs6[] = ['name' => $name6, 'hosts' => $hval6];
                 }
                 if ($name6_too_long) {
-                    $vlsm6_error = 'Each requirement name must be 100 characters or fewer.';
+                    $vlsm6['error'] = 'Each requirement name must be 100 characters or fewer.';
                 } elseif ($reqs6 === []) {
-                    $vlsm6_error = 'Add at least one valid requirement.';
+                    $vlsm6['error'] = 'Add at least one valid requirement.';
                 } else {
                     $vlsm6_cidr_int   = (int)ltrim($rv6['result6']['prefix'], '/');
                     $vlsm6_network_ip = explode('/', $rv6['result6']['network_cidr'])[0];
                     $vlsm6_requirements = $reqs6;
                     $vr6 = vlsm6_allocate($vlsm6_network_ip, $vlsm6_cidr_int, $reqs6);
                     if (isset($vr6['error'])) {
-                        $vlsm6_error = $vr6['error'];
+                        $vlsm6['error'] = $vr6['error'];
                     } else {
-                        $vlsm6_result = $vr6['allocations'] ?? [];
+                        $vlsm6['result'] = $vr6['allocations'] ?? [];
                     }
                 }
             }
@@ -902,7 +904,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if (isset($vr6['error'])) {
                         $session_error = $vr6['error'];
                     } else {
-                        $vlsm6_result = $vr6['allocations'] ?? [];
+                        $vlsm6['result'] = $vr6['allocations'] ?? [];
                         try {
                             $db_path = $session_db_path !== '' ? $session_db_path
                                 : dirname(__DIR__) . '/data/sessions.sqlite';
@@ -958,7 +960,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if (isset($vr['error'])) {
                         $session_error = $vr['error'];
                     } else {
-                        $vlsm_result = $vr['allocations'] ?? [];
+                        $vlsm['result'] = $vr['allocations'] ?? [];
                         try {
                             $db_path = $session_db_path !== '' ? $session_db_path
                                 : dirname(__DIR__) . '/data/sessions.sqlite';
@@ -1114,9 +1116,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     $vlsm6_network_ip = explode('/', $rv6['result6']['network_cidr'])[0];
                                     $vr6 = vlsm6_allocate($vlsm6_network_ip, $vlsm6_cidr_int, $vlsm6_requirements);
                                     if (isset($vr6['error'])) {
-                                        $vlsm6_error = $vr6['error'];
+                                        $vlsm6['error'] = $vr6['error'];
                                     } else {
-                                        $vlsm6_result = $vr6['allocations'] ?? [];
+                                        $vlsm6['result'] = $vr6['allocations'] ?? [];
                                     }
                                 }
                             }
@@ -1142,9 +1144,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     $vlsm_network_ip = explode('/', $rv['result']['network_cidr'])[0];
                                     $vr = vlsm_allocate($vlsm_network_ip, $vlsm_cidr_int, $vlsm_requirements);
                                     if (isset($vr['error'])) {
-                                        $vlsm_error = $vr['error'];
+                                        $vlsm['error'] = $vr['error'];
                                     } else {
-                                        $vlsm_result = $vr['allocations'] ?? [];
+                                        $vlsm['result'] = $vr['allocations'] ?? [];
                                     }
                                 }
                             }
@@ -1273,7 +1275,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($get_vlsm6_network !== '') {
             $rv6 = resolve_ipv6_input($get_vlsm6_network, $get_vlsm6_cidr);
             if (!$rv6['result6']) {
-                $vlsm6_error = 'Parent network: ' . ($rv6['error6'] ?? 'Invalid input.');
+                $vlsm6['error'] = 'Parent network: ' . ($rv6['error6'] ?? 'Invalid input.');
             } else {
                 $vlsm6_network    = $rv6['ip'];
                 $vlsm6_cidr_input = ltrim($rv6['result6']['prefix'], '/');
@@ -1297,16 +1299,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                     }
                     if ($name6_too_long) {
-                        $vlsm6_error = 'Each requirement name must be 100 characters or fewer.';
+                        $vlsm6['error'] = 'Each requirement name must be 100 characters or fewer.';
                     } elseif ($reqs6 !== []) {
                         $vlsm6_requirements = $reqs6;
                         $vlsm6_cidr_int     = (int)ltrim((string)$rv6['result6']['prefix'], '/');
                         $vlsm6_network_ip   = explode('/', (string)$rv6['result6']['network_cidr'])[0];
                         $vr6 = vlsm6_allocate($vlsm6_network_ip, $vlsm6_cidr_int, $reqs6);
                         if (isset($vr6['error'])) {
-                            $vlsm6_error = $vr6['error'];
+                            $vlsm6['error'] = $vr6['error'];
                         } else {
-                            $vlsm6_result = $vr6['allocations'] ?? [];
+                            $vlsm6['result'] = $vr6['allocations'] ?? [];
                         }
                     }
                 }
@@ -1318,7 +1320,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($get_vlsm_network !== '') {
             $rv = resolve_ipv4_input($get_vlsm_network, $get_vlsm_cidr);
             if (!$rv['result']) {
-                $vlsm_error = 'Parent network: ' . ($rv['error'] ?? 'Invalid input.');
+                $vlsm['error'] = 'Parent network: ' . ($rv['error'] ?? 'Invalid input.');
             } else {
                 $vlsm_network    = $rv['ip'];
                 $vlsm_cidr_input = ltrim($rv['result']['netmask_cidr'], '/');
@@ -1339,9 +1341,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $vlsm_network_ip   = explode('/', $rv['result']['network_cidr'])[0];
                         $vr = vlsm_allocate($vlsm_network_ip, $vlsm_cidr_int, $reqs);
                         if (isset($vr['error'])) {
-                            $vlsm_error = $vr['error'];
+                            $vlsm['error'] = $vr['error'];
                         } else {
-                            $vlsm_result = $vr['allocations'] ?? [];
+                            $vlsm['result'] = $vr['allocations'] ?? [];
                         }
                     }
                 }
@@ -1358,7 +1360,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $current_cidr = (int)ltrim($result['netmask_cidr'], '/');
             $network_ip   = explode('/', $result['network_cidr'])[0];
             if ($new_pfx > $current_cidr) {
-                $split_result = split_subnet($network_ip, $current_cidr, $new_pfx, $split_max_subnets);
+                $splitter = ['result' => split_subnet($network_ip, $current_cidr, $new_pfx, $split_max_subnets)];
             }
         }
     } elseif ($result6 && isset($_GET['split_prefix6'])) {
@@ -1369,7 +1371,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $current_pfx6 = (int)ltrim($result6['prefix'], '/');
             $network_ipv6 = explode('/', $result6['network_cidr'])[0];
             if ($new_pfx6 > $current_pfx6) {
-                $split_result6 = split_subnet6($network_ipv6, $current_pfx6, $new_pfx6, $split_max_subnets);
+                $splitter6 = ['result' => split_subnet6($network_ipv6, $current_pfx6, $new_pfx6, $split_max_subnets)];
             }
         }
     }
@@ -1388,16 +1390,16 @@ if (
 // Build shareable URL
 $share_url = '';
 if ($result) {
-    $sp = $split_result ? ['split_prefix' => ltrim($input_split_prefix, '/')] : [];
+    $sp = isset($splitter['result']) ? ['split_prefix' => ltrim($input_split_prefix, '/')] : [];
     $share_url = '?' . http_build_query(
         ['tab' => 'ipv4', 'ip' => $input_ip, 'mask' => ltrim($result['netmask_cidr'], '/')] + $sp
     );
 } elseif ($result6) {
-    $sp6 = $split_result6 ? ['split_prefix6' => ltrim($input_split_prefix6, '/')] : [];
+    $sp6 = isset($splitter6['result']) ? ['split_prefix6' => ltrim($input_split_prefix6, '/')] : [];
     $share_url = '?' . http_build_query(
         ['tab' => 'ipv6', 'ipv6' => $input_ipv6, 'prefix' => ltrim($result6['prefix'], '/')] + $sp6
     );
-} elseif ($vlsm_result !== null && $vlsm_network !== '') {
+} elseif (isset($vlsm['result']) && $vlsm_network !== '') {
     $vlsm_names = array_map(fn($r) => $r['name'], $vlsm_requirements);
     $vlsm_qhosts = array_map(fn($r) => $r['hosts'], $vlsm_requirements);
     $share_url = '?' . http_build_query([
@@ -1407,7 +1409,7 @@ if ($result) {
         'vlsm_name'    => $vlsm_names,
         'vlsm_hosts'   => $vlsm_qhosts,
     ]);
-} elseif ($vlsm6_result !== null && $vlsm6_network !== '') {
+} elseif (isset($vlsm6['result']) && $vlsm6_network !== '') {
     $vlsm6_names  = array_map(fn($r) => $r['name'], $vlsm6_requirements);
     $vlsm6_qhosts = array_map(fn($r) => $r['hosts'], $vlsm6_requirements);
     $share_url = '?' . http_build_query([

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -230,10 +230,10 @@ if ($i < 3) {
         if ($split_result !== null || $split_error !== null) { $open_tool_ipv4 = 'split'; }
         elseif (!empty($supernet)) { $open_tool_ipv4 = 'supernet'; }
         elseif (!empty($range)) { $open_tool_ipv4 = 'range'; }
-        elseif ($tree_result !== null || $tree_error !== null) { $open_tool_ipv4 = 'tree'; }
-        elseif ($wildcard_result !== null || $wildcard_error !== null) { $open_tool_ipv4 = 'wildcard'; }
-        elseif (($lookup_result !== null || $lookup_error !== null) && $active_tab === 'ipv4') { $open_tool_ipv4 = 'lookup'; }
-        elseif (($diff_result !== null || $diff_error !== null) && $active_tab === 'ipv4') { $open_tool_ipv4 = 'diff'; }
+        elseif (!empty($tree)) { $open_tool_ipv4 = 'tree'; }
+        elseif (!empty($wildcard)) { $open_tool_ipv4 = 'wildcard'; }
+        elseif (!empty($lookup) && $active_tab === 'ipv4') { $open_tool_ipv4 = 'lookup'; }
+        elseif (!empty($diff) && $active_tab === 'ipv4') { $open_tool_ipv4 = 'diff'; }
         ?>
         <div class="tool-toolbar"<?= $open_tool_ipv4 ? ' data-open-tool="' . htmlspecialchars($open_tool_ipv4) . '"' : '' ?>>
             <button type="button" class="tool-trigger" data-tool="split" aria-expanded="false">Split Subnet</button>
@@ -402,10 +402,10 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Build Tree</button>
                         </div>
                     </form>
-                    <?php if ($tree_error) : ?>
-                        <div class="error"><?= htmlspecialchars($tree_error) ?></div>
-                    <?php elseif ($tree_result !== null) : ?>
-                        <?php $_tree_label = 'Tree: ' . (string)($tree_result['cidr'] ?? $tree_parent); ?>
+                    <?php if (!empty($tree['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($tree['error']) ?></div>
+                    <?php elseif (isset($tree['result'])) : ?>
+                        <?php $_tree_label = 'Tree: ' . (string)($tree['result']['cidr'] ?? $tree_parent); ?>
                         <div class="tree-view"
                              data-history-source="tree"
                              data-history-active="1"
@@ -437,7 +437,7 @@ if ($i < 3) {
                                     echo '</div>';
                                 }
                             }
-                            render_tree_node($tree_result);
+                            render_tree_node($tree['result']);
                             ?>
                         </div>
                     <?php endif; ?>
@@ -465,23 +465,23 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Convert</button>
                         </div>
                     </form>
-                    <?php if ($wildcard_error) : ?>
-                        <div class="error wildcard-error"><?= htmlspecialchars($wildcard_error) ?></div>
-                    <?php elseif ($wildcard_result !== null) : ?>
+                    <?php if (!empty($wildcard['error'])) : ?>
+                        <div class="error wildcard-error"><?= htmlspecialchars($wildcard['error']) ?></div>
+                    <?php elseif (isset($wildcard['result'])) : ?>
                         <?php $_wildcard_label = 'Wildcard: ' . $wildcard_input; ?>
                         <div class="split-list split-list--mt"
                              data-history-source="wildcard"
                              data-history-active="1"
                              data-history-label="<?= htmlspecialchars($_wildcard_label) ?>">
                             <div class="split-item" tabindex="0" role="button"
-                                 data-copy="<?= htmlspecialchars($wildcard_result['cidr']) ?>">
-                                <span class="split-subnet-text" id="wildcard-result-cidr">CIDR: <?= htmlspecialchars($wildcard_result['cidr']) ?></span>
-                                <?= copy_button($wildcard_result['cidr'], 'Copy CIDR ' . $wildcard_result['cidr']) ?>
+                                 data-copy="<?= htmlspecialchars($wildcard['result']['cidr']) ?>">
+                                <span class="split-subnet-text" id="wildcard-result-cidr">CIDR: <?= htmlspecialchars($wildcard['result']['cidr']) ?></span>
+                                <?= copy_button($wildcard['result']['cidr'], 'Copy CIDR ' . $wildcard['result']['cidr']) ?>
                             </div>
                             <div class="split-item" tabindex="0" role="button"
-                                 data-copy="<?= htmlspecialchars($wildcard_result['wildcard']) ?>">
-                                <span class="split-subnet-text" id="wildcard-result-mask">Wildcard: <?= htmlspecialchars($wildcard_result['wildcard']) ?></span>
-                                <?= copy_button($wildcard_result['wildcard'], 'Copy wildcard ' . $wildcard_result['wildcard']) ?>
+                                 data-copy="<?= htmlspecialchars($wildcard['result']['wildcard']) ?>">
+                                <span class="split-subnet-text" id="wildcard-result-mask">Wildcard: <?= htmlspecialchars($wildcard['result']['wildcard']) ?></span>
+                                <?= copy_button($wildcard['result']['wildcard'], 'Copy wildcard ' . $wildcard['result']['wildcard']) ?>
                             </div>
                         </div>
                     <?php endif; ?>
@@ -507,9 +507,9 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Lookup</button>
                         </div>
                     </form>
-                    <?php if ($active_tab === 'ipv4' && $lookup_error) : ?>
-                        <div class="error"><?= htmlspecialchars($lookup_error) ?></div>
-                    <?php elseif ($active_tab === 'ipv4' && $lookup_result !== null) : ?>
+                    <?php if ($active_tab === 'ipv4' && !empty($lookup['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($lookup['error']) ?></div>
+                    <?php elseif ($active_tab === 'ipv4' && isset($lookup['result'])) : ?>
                         <?php
                         $_lookup_ips_count   = count(array_filter(array_map('trim', explode("\n", $lookup_ips_input))));
                         $_lookup_cidrs_count = count(array_filter(array_map('trim', explode("\n", $lookup_cidrs_input))));
@@ -536,7 +536,7 @@ if ($i < 3) {
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <?php foreach ($lookup_result as $row) : ?>
+                                        <?php foreach ($lookup['result'] as $row) : ?>
                                             <tr>
                                                 <td class="lookup-table__cell" data-label="IP"><code><?= htmlspecialchars($row['ip']) ?></code></td>
                                                 <td class="lookup-table__cell" data-label="Deepest match">
@@ -558,7 +558,7 @@ if ($i < 3) {
                                     </tbody>
                                 </table>
                             </div>
-                            <div class="split-more"><?= count($lookup_result) ?> IP<?= count($lookup_result) !== 1 ? 's' : '' ?> looked up</div>
+                            <div class="split-more"><?= count($lookup['result']) ?> IP<?= count($lookup['result']) !== 1 ? 's' : '' ?> looked up</div>
                         </div>
                     <?php endif; ?>
                 </div>
@@ -583,10 +583,10 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Diff</button>
                         </div>
                     </form>
-                    <?php if ($active_tab === 'ipv4' && $diff_error) : ?>
-                        <div class="error"><?= htmlspecialchars($diff_error) ?></div>
-                    <?php elseif ($active_tab === 'ipv4' && $diff_result !== null) : ?>
-                        <?php include __DIR__ . '/_diff_result.php'; ?>
+                    <?php if ($active_tab === 'ipv4' && !empty($diff['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($diff['error']) ?></div>
+                    <?php elseif ($active_tab === 'ipv4' && isset($diff['result'])) : ?>
+                        <?php $diff_result = $diff['result']; include __DIR__ . '/_diff_result.php'; ?>
                     <?php endif; ?>
                 </div>
             </div>
@@ -750,8 +750,8 @@ if ($i < 3) {
         elseif (!empty($zoneid)) { $open_tool_ipv6 = 'zoneid'; }
         elseif (!empty($derive)) { $open_tool_ipv6 = 'derive'; }
         elseif (!empty($slaac)) { $open_tool_ipv6 = 'slaac'; }
-        elseif (($lookup_result !== null || $lookup_error !== null) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'lookup'; }
-        elseif (($diff_result !== null || $diff_error !== null) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'diff'; }
+        elseif (!empty($lookup) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'lookup'; }
+        elseif (!empty($diff) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'diff'; }
         ?>
         <div class="tool-toolbar"<?= $open_tool_ipv6 ? ' data-open-tool="' . htmlspecialchars($open_tool_ipv6) . '"' : '' ?>>
             <button type="button" class="tool-trigger" data-tool="split6" aria-expanded="false">Split Subnet</button>
@@ -1158,9 +1158,9 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Lookup</button>
                         </div>
                     </form>
-                    <?php if ($active_tab === 'ipv6' && $lookup_error) : ?>
-                        <div class="error"><?= htmlspecialchars($lookup_error) ?></div>
-                    <?php elseif ($active_tab === 'ipv6' && $lookup_result !== null) : ?>
+                    <?php if ($active_tab === 'ipv6' && !empty($lookup['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($lookup['error']) ?></div>
+                    <?php elseif ($active_tab === 'ipv6' && isset($lookup['result'])) : ?>
                         <?php
                         $_lookup_ips_count6   = count(array_filter(array_map('trim', explode("\n", $lookup_ips_input))));
                         $_lookup_cidrs_count6 = count(array_filter(array_map('trim', explode("\n", $lookup_cidrs_input))));
@@ -1187,7 +1187,7 @@ if ($i < 3) {
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <?php foreach ($lookup_result as $row) : ?>
+                                        <?php foreach ($lookup['result'] as $row) : ?>
                                             <tr>
                                                 <td class="lookup-table__cell" data-label="IP"><code><?= htmlspecialchars($row['ip']) ?></code></td>
                                                 <td class="lookup-table__cell" data-label="Deepest match">
@@ -1209,7 +1209,7 @@ if ($i < 3) {
                                     </tbody>
                                 </table>
                             </div>
-                            <div class="split-more"><?= count($lookup_result) ?> IP<?= count($lookup_result) !== 1 ? 's' : '' ?> looked up</div>
+                            <div class="split-more"><?= count($lookup['result']) ?> IP<?= count($lookup['result']) !== 1 ? 's' : '' ?> looked up</div>
                         </div>
                     <?php endif; ?>
                 </div>
@@ -1234,10 +1234,10 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Diff</button>
                         </div>
                     </form>
-                    <?php if ($active_tab === 'ipv6' && $diff_error) : ?>
-                        <div class="error"><?= htmlspecialchars($diff_error) ?></div>
-                    <?php elseif ($active_tab === 'ipv6' && $diff_result !== null) : ?>
-                        <?php include __DIR__ . '/_diff_result.php'; ?>
+                    <?php if ($active_tab === 'ipv6' && !empty($diff['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($diff['error']) ?></div>
+                    <?php elseif ($active_tab === 'ipv6' && isset($diff['result'])) : ?>
+                        <?php $diff_result = $diff['result']; include __DIR__ . '/_diff_result.php'; ?>
                     <?php endif; ?>
                 </div>
             </div>
@@ -1371,8 +1371,8 @@ if ($i < 3) {
         <?php
         $open_tool_vlsm = null;
         if ($session_save_id !== '' || $session_error !== null) { $open_tool_vlsm = 'session'; }
-        elseif ($overlap_result !== null || $overlap_error !== null) { $open_tool_vlsm = 'overlap'; }
-        elseif ($multi_overlap_result !== null || $multi_overlap_error !== null) { $open_tool_vlsm = 'multi'; }
+        elseif (!empty($overlap)) { $open_tool_vlsm = 'overlap'; }
+        elseif (!empty($multi_overlap)) { $open_tool_vlsm = 'multi'; }
         ?>
         <div class="tool-toolbar"<?= $open_tool_vlsm ? ' data-open-tool="' . htmlspecialchars($open_tool_vlsm) . '"' : '' ?>>
             <?php if ($session_enabled) : ?>
@@ -1449,9 +1449,9 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Check</button>
                         </div>
                     </form>
-                    <?php if ($overlap_error) : ?>
-                        <div class="error"><?= htmlspecialchars($overlap_error) ?></div>
-                    <?php elseif ($overlap_result !== null) : ?>
+                    <?php if (!empty($overlap['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($overlap['error']) ?></div>
+                    <?php elseif (isset($overlap['result'])) : ?>
                         <?php
                         $overlap_labels = [
                             'none'         => ['No overlap', 'overlap-none'],
@@ -1459,7 +1459,7 @@ if ($i < 3) {
                             'a_contains_b' => [$overlap_cidr_a . ' contains ' . $overlap_cidr_b, 'overlap-contains'],
                             'b_contains_a' => [$overlap_cidr_b . ' contains ' . $overlap_cidr_a, 'overlap-contains'],
                         ];
-                        [$label, $cls] = $overlap_labels[$overlap_result] ?? ['Unknown', ''];
+                        [$label, $cls] = $overlap_labels[$overlap['result']] ?? ['Unknown', ''];
                         ?>
                         <div class="overlap-result <?= htmlspecialchars($cls) ?>"><?= htmlspecialchars($label) ?></div>
                     <?php endif; ?>
@@ -1476,14 +1476,14 @@ if ($i < 3) {
                                   rows="4" autocomplete="off" spellcheck="false"><?= htmlspecialchars($multi_overlap_input) ?></textarea>
                         <button type="submit" class="splitter-btn">Check</button>
                     </form>
-                    <?php if ($multi_overlap_error) : ?>
-                        <div class="error"><?= htmlspecialchars($multi_overlap_error) ?></div>
-                    <?php elseif ($multi_overlap_result !== null) : ?>
-                        <?php if (count($multi_overlap_result) === 0) : ?>
+                    <?php if (!empty($multi_overlap['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($multi_overlap['error']) ?></div>
+                    <?php elseif (isset($multi_overlap['result'])) : ?>
+                        <?php if (count($multi_overlap['result']) === 0) : ?>
                             <div class="overlap-result overlap-none">No overlaps detected.</div>
                         <?php else : ?>
                             <ul class="multi-overlap-list">
-                                <?php foreach ($multi_overlap_result as $conflict) :
+                                <?php foreach ($multi_overlap['result'] as $conflict) :
                                     if ($conflict['relation'] === 'identical') {
                                         $rel_label = 'Identical';
                                     } elseif ($conflict['relation'] === 'a_contains_b') {

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -748,8 +748,8 @@ if ($i < 3) {
         elseif ($range6_result !== null || $range6_error !== null) { $open_tool_ipv6 = 'range6'; }
         elseif ($supernet6_result !== null || $supernet6_error !== null) { $open_tool_ipv6 = 'supernet6'; }
         elseif (!empty($zoneid)) { $open_tool_ipv6 = 'zoneid'; }
-        elseif ($derive_eui64 !== null || $derive_error !== null) { $open_tool_ipv6 = 'derive'; }
-        elseif ($slaac_address !== null || $slaac_error !== null) { $open_tool_ipv6 = 'slaac'; }
+        elseif (!empty($derive)) { $open_tool_ipv6 = 'derive'; }
+        elseif (!empty($slaac)) { $open_tool_ipv6 = 'slaac'; }
         elseif (($lookup_result !== null || $lookup_error !== null) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'lookup'; }
         elseif (($diff_result !== null || $diff_error !== null) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'diff'; }
         ?>
@@ -1020,17 +1020,17 @@ if ($i < 3) {
                                    placeholder="00:24:b9:7e:ab:cd"
                                    value="<?= htmlspecialchars($derive_input) ?>"
                                    autocomplete="off" spellcheck="false"
-                                   <?= $derive_error ? 'aria-invalid="true" aria-describedby="derive-error"' : '' ?>>
+                                   <?= !empty($derive['error']) ? 'aria-invalid="true" aria-describedby="derive-error"' : '' ?>>
                             <button type="submit" class="splitter-btn">Derive</button>
                         </div>
                     </form>
-                    <?php if ($derive_error) : ?>
-                        <div class="error" id="derive-error"><?= htmlspecialchars($derive_error) ?></div>
-                    <?php elseif ($derive_eui64 !== null) : ?>
-                        <?php if ($derive_warning) : ?>
-                            <div class="warning"><?= htmlspecialchars($derive_warning) ?></div>
+                    <?php if (!empty($derive['error'])) : ?>
+                        <div class="error" id="derive-error"><?= htmlspecialchars($derive['error']) ?></div>
+                    <?php elseif (isset($derive['eui64'])) : ?>
+                        <?php if (!empty($derive['warning'])) : ?>
+                            <div class="warning"><?= htmlspecialchars($derive['warning']) ?></div>
                         <?php endif; ?>
-                        <?php $_derive_label = 'Derive: ' . ($derive_mac_canonical ?? ''); ?>
+                        <?php $_derive_label = 'Derive: ' . ($derive['mac_canonical'] ?? ''); ?>
                         <dl class="derive-result"
                             data-history-source="derive"
                             data-history-active="1"
@@ -1038,28 +1038,28 @@ if ($i < 3) {
                             <div class="derive-result__row">
                                 <dt class="derive-result__label">MAC (canonical)</dt>
                                 <dd class="derive-result__value">
-                                    <code><?= htmlspecialchars((string)$derive_mac_canonical) ?></code>
+                                    <code><?= htmlspecialchars((string)($derive['mac_canonical'] ?? '')) ?></code>
                                 </dd>
                             </div>
                             <div class="derive-result__row">
                                 <dt class="derive-result__label">EUI-64<?= help_bubble('ipv6-derive-eui64', 'Modified EUI-64 interface identifier — the U/L (universal/local) bit in the first MAC byte is inverted, then the 16-bit value 0xFFFE is inserted between the OUI and the NIC half (RFC 4291 §2.5.1).') ?></dt>
                                 <dd class="derive-result__value">
-                                    <code><?= htmlspecialchars((string)$derive_eui64) ?></code>
-                                    <?= copy_button((string)$derive_eui64, 'Copy EUI-64 interface ID') ?>
+                                    <code><?= htmlspecialchars((string)($derive['eui64'] ?? '')) ?></code>
+                                    <?= copy_button((string)($derive['eui64'] ?? ''), 'Copy EUI-64 interface ID') ?>
                                 </dd>
                             </div>
                             <div class="derive-result__row">
                                 <dt class="derive-result__label">Link-local<?= help_bubble('ipv6-derive-ll', 'Link-local address — the fe80::/64 prefix concatenated with the EUI-64 interface identifier. Always assigned automatically to every IPv6-enabled interface (RFC 4291 §2.5.6).') ?></dt>
                                 <dd class="derive-result__value">
-                                    <code><?= htmlspecialchars((string)$derive_link_local) ?></code>
-                                    <?= copy_button((string)$derive_link_local, 'Copy link-local address') ?>
+                                    <code><?= htmlspecialchars((string)($derive['link_local'] ?? '')) ?></code>
+                                    <?= copy_button((string)($derive['link_local'] ?? ''), 'Copy link-local address') ?>
                                 </dd>
                             </div>
                             <div class="derive-result__row">
                                 <dt class="derive-result__label">Solicited-node<?= help_bubble('ipv6-derive-sn', 'Solicited-node multicast address — ff02::1:ff followed by the low 24 bits of the unicast address. Used by IPv6 Neighbor Discovery so a host only listens for resolution requests targeted at its own address (RFC 4291 §2.7.1).') ?></dt>
                                 <dd class="derive-result__value">
-                                    <code><?= htmlspecialchars((string)$derive_solicited_node) ?></code>
-                                    <?= copy_button((string)$derive_solicited_node, 'Copy solicited-node multicast address') ?>
+                                    <code><?= htmlspecialchars((string)($derive['solicited_node'] ?? '')) ?></code>
+                                    <?= copy_button((string)($derive['solicited_node'] ?? ''), 'Copy solicited-node multicast address') ?>
                                 </dd>
                             </div>
                         </dl>
@@ -1079,11 +1079,11 @@ if ($i < 3) {
                                    value="<?= htmlspecialchars($slaac_prefix_input) ?>"
                                    autocomplete="off" spellcheck="false"
                                    required
-                                   <?= $slaac_error ? 'aria-invalid="true" aria-describedby="slaac-error"' : '' ?>>
+                                   <?= !empty($slaac['error']) ? 'aria-invalid="true" aria-describedby="slaac-error"' : '' ?>>
                             <button type="submit" class="splitter-btn">Generate</button>
                             <button type="reset" class="splitter-btn-ghost">Reset</button>
                         </div>
-                        <details class="slaac-advanced"<?= $slaac_seed_was_provided ? ' open' : '' ?>>
+                        <details class="slaac-advanced"<?= !empty($slaac['seed_was_provided']) ? ' open' : '' ?>>
                             <summary>Advanced (seed for reproducibility)</summary>
                             <p class="slaac-advanced__hint">Optional 16-hex seed for reproducible output (RFC 8981 §3.3.1). Leave blank in production &mdash; every fresh generation should be cryptographically random.</p>
                             <label for="slaac_seed" class="sr-only">Seed (16 hex characters)</label>
@@ -1096,13 +1096,13 @@ if ($i < 3) {
                             <?= help_bubble('ipv6-slaac-seed', 'A 16-character hexadecimal seed (64 bits) makes the generated interface ID deterministic. Useful for reproducing examples in documentation or tests; never use a fixed seed in production because it defeats the privacy purpose of RFC 8981.') ?>
                         </details>
                     </form>
-                    <?php if ($slaac_error) : ?>
-                        <div class="error" id="slaac-error"><?= htmlspecialchars($slaac_error) ?></div>
-                    <?php elseif ($slaac_address !== null) : ?>
-                        <?php if ($slaac_warning) : ?>
-                            <div class="warning"><?= htmlspecialchars($slaac_warning) ?></div>
+                    <?php if (!empty($slaac['error'])) : ?>
+                        <div class="error" id="slaac-error"><?= htmlspecialchars($slaac['error']) ?></div>
+                    <?php elseif (isset($slaac['address'])) : ?>
+                        <?php if (!empty($slaac['warning'])) : ?>
+                            <div class="warning"><?= htmlspecialchars($slaac['warning']) ?></div>
                         <?php endif; ?>
-                        <?php $_slaac_label = 'SLAAC: ' . ($slaac_prefix ?? ''); ?>
+                        <?php $_slaac_label = 'SLAAC: ' . ($slaac['prefix'] ?? ''); ?>
                         <dl class="slaac-result"
                             data-history-source="slaac"
                             data-history-active="1"
@@ -1110,28 +1110,28 @@ if ($i < 3) {
                             <div class="slaac-result__row">
                                 <dt class="slaac-result__label">Prefix (canonical)</dt>
                                 <dd class="slaac-result__value">
-                                    <code><?= htmlspecialchars((string)$slaac_prefix) ?></code>
+                                    <code><?= htmlspecialchars((string)($slaac['prefix'] ?? '')) ?></code>
                                 </dd>
                             </div>
                             <div class="slaac-result__row">
                                 <dt class="slaac-result__label">Address<?= help_bubble('ipv6-slaac-addr', 'The full 128-bit IPv6 address: the supplied /64 prefix concatenated with the random 64-bit privacy interface identifier. This is what would be assigned to the host as a temporary SLAAC address per RFC 8981.') ?></dt>
                                 <dd class="slaac-result__value">
-                                    <code><?= htmlspecialchars((string)$slaac_address) ?></code>
-                                    <?= copy_button((string)$slaac_address, 'Copy SLAAC privacy address') ?>
+                                    <code><?= htmlspecialchars((string)($slaac['address'] ?? '')) ?></code>
+                                    <?= copy_button((string)($slaac['address'] ?? ''), 'Copy SLAAC privacy address') ?>
                                 </dd>
                             </div>
                             <div class="slaac-result__row">
                                 <dt class="slaac-result__label">Interface ID<?= help_bubble('ipv6-slaac-iid', 'The 64-bit random interface identifier in colon-separated hextet form. The U/L bit (second-lowest bit of the first byte) is cleared per RFC 4291 §2.5.1 so the address cannot be mistaken for an EUI-64 derived from a hardware MAC.') ?></dt>
                                 <dd class="slaac-result__value">
-                                    <code><?= htmlspecialchars((string)$slaac_interface_id) ?></code>
-                                    <?= copy_button((string)$slaac_interface_id, 'Copy interface ID') ?>
+                                    <code><?= htmlspecialchars((string)($slaac['interface_id'] ?? '')) ?></code>
+                                    <?= copy_button((string)($slaac['interface_id'] ?? ''), 'Copy interface ID') ?>
                                 </dd>
                             </div>
                             <div class="slaac-result__row">
                                 <dt class="slaac-result__label">Seed used<?= help_bubble('ipv6-slaac-seed-used', 'The 16-hex seed value that produced this address. If you supplied a seed it is echoed here; otherwise the random seed used internally is shown so you can reproduce the result later (e.g. by pasting it back into the Advanced field).') ?></dt>
                                 <dd class="slaac-result__value">
-                                    <code><?= htmlspecialchars((string)$slaac_seed_used) ?></code>
-                                    <?= copy_button((string)$slaac_seed_used, 'Copy seed') ?>
+                                    <code><?= htmlspecialchars((string)($slaac['seed_used'] ?? '')) ?></code>
+                                    <?= copy_button((string)($slaac['seed_used'] ?? ''), 'Copy seed') ?>
                                 </dd>
                             </div>
                         </dl>

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -745,7 +745,7 @@ if ($i < 3) {
         $open_tool_ipv6 = null;
         if ($split_result6 !== null || $split_error6 !== null) { $open_tool_ipv6 = 'split6'; }
         elseif ($ula_result !== null || $ula_error !== null) { $open_tool_ipv6 = 'ula'; }
-        elseif ($range6_result !== null || $range6_error !== null) { $open_tool_ipv6 = 'range6'; }
+        elseif (!empty($range6)) { $open_tool_ipv6 = 'range6'; }
         elseif ($supernet6_result !== null || $supernet6_error !== null) { $open_tool_ipv6 = 'supernet6'; }
         elseif (!empty($zoneid)) { $open_tool_ipv6 = 'zoneid'; }
         elseif (!empty($derive)) { $open_tool_ipv6 = 'derive'; }
@@ -882,11 +882,11 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Convert</button>
                         </div>
                     </form>
-                    <?php if ($range6_error) : ?>
-                        <div class="error"><?= htmlspecialchars($range6_error) ?></div>
-                    <?php elseif ($range6_result !== null) : ?>
-                        <?php if ($range6_warning) : ?>
-                            <div class="warning"><?= htmlspecialchars($range6_warning) ?></div>
+                    <?php if (!empty($range6['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($range6['error']) ?></div>
+                    <?php elseif (isset($range6['result'])) : ?>
+                        <?php if (!empty($range6['warning'])) : ?>
+                            <div class="warning"><?= htmlspecialchars($range6['warning']) ?></div>
                         <?php endif; ?>
                         <?php $_range6_label = 'Range: ' . $range6_start . ' → ' . $range6_end; ?>
                         <div class="split-list split-list--mt"
@@ -894,13 +894,13 @@ if ($i < 3) {
                              data-history-active="1"
                              data-history-label="<?= htmlspecialchars($_range6_label) ?>">
                             <button type="button" class="copy-all-btn" data-target="range6">Copy All</button>
-                            <?php foreach ($range6_result as $r6_cidr) : ?>
+                            <?php foreach ($range6['result'] as $r6_cidr) : ?>
                                 <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($r6_cidr) ?>">
                                     <span class="split-subnet-text"><?= htmlspecialchars($r6_cidr) ?></span>
                                     <?= copy_button($r6_cidr, 'Copy ' . $r6_cidr) ?>
                                 </div>
                             <?php endforeach; ?>
-                            <div class="split-more"><?= count($range6_result) ?> CIDR block<?= count($range6_result) !== 1 ? 's' : '' ?><?php if ($range6_total !== null) : ?> · <?= htmlspecialchars(is_string($range6_total) ? $range6_total : (string)$range6_total) ?> addresses<?php endif; ?></div>
+                            <div class="split-more"><?= count($range6['result']) ?> CIDR block<?= count($range6['result']) !== 1 ? 's' : '' ?><?php if (($range6['total'] ?? null) !== null) : ?> · <?= htmlspecialchars(is_string($range6['total']) ? $range6['total'] : (string)$range6['total']) ?> addresses<?php endif; ?></div>
                         </div>
                     <?php endif; ?>
                 </div>

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -227,7 +227,7 @@ if ($i < 3) {
 
         <?php
         $open_tool_ipv4 = null;
-        if ($split_result !== null || $split_error !== null) { $open_tool_ipv4 = 'split'; }
+        if (!empty($splitter)) { $open_tool_ipv4 = 'split'; }
         elseif (!empty($supernet)) { $open_tool_ipv4 = 'supernet'; }
         elseif (!empty($range)) { $open_tool_ipv4 = 'range'; }
         elseif (!empty($tree)) { $open_tool_ipv4 = 'tree'; }
@@ -264,26 +264,26 @@ if ($i < 3) {
                             <input type="text" name="split_prefix" class="splitter-input"
                                    placeholder="/25" value="<?= htmlspecialchars($input_split_prefix) ?>"
                                    autocomplete="off" spellcheck="false"
-                                   <?= $split_error ? 'aria-invalid="true" aria-describedby="split-error-ipv4"' : '' ?>>
+                                   <?= !empty($splitter['error']) ? 'aria-invalid="true" aria-describedby="split-error-ipv4"' : '' ?>>
                             <button type="submit" class="splitter-btn">Split</button>
                         </div>
                     </form>
-                    <?php if ($split_error) : ?>
-                        <div class="error" id="split-error-ipv4"><?= htmlspecialchars($split_error) ?></div>
-                    <?php elseif ($split_result && $split_result['showing'] > 0) : ?>
+                    <?php if (!empty($splitter['error'])) : ?>
+                        <div class="error" id="split-error-ipv4"><?= htmlspecialchars($splitter['error']) ?></div>
+                    <?php elseif (isset($splitter['result']) && $splitter['result']['showing'] > 0) : ?>
                         <div class="split-list" data-parent="<?= htmlspecialchars($result['cidr'] ?? '') ?>">
                             <button type="button" class="copy-all-btn" data-target="split">Copy All</button>
                             <button type="button" class="copy-all-btn copy-md-btn" data-target="split4">Copy as Markdown</button>
                             <button type="button" class="copy-all-btn copy-cisco-btn" data-target="split4">Copy as Cisco</button><?= help_bubble('copy-cisco-split4', 'Cisco output is generic IOS-style — one interface stanza per split subnet. Vendor-specific tweaks may be required.') ?>
                             <button type="button" class="ascii-export-btn">Export ASCII</button>
-                            <?php foreach ($split_result['subnets'] as $s) : ?>
+                            <?php foreach ($splitter['result']['subnets'] as $s) : ?>
                                 <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($s) ?>">
                                     <span class="split-subnet-text"><?= htmlspecialchars($s) ?></span>
                                     <?= copy_button($s, 'Copy ' . $s) ?>
                                 </div>
                             <?php endforeach; ?>
-                            <?php if ($split_result['total'] > $split_result['showing']) : ?>
-                                <div class="split-more">+&nbsp;<?= format_number($split_result['total'] - $split_result['showing']) ?> more</div>
+                            <?php if ($splitter['result']['total'] > $splitter['result']['showing']) : ?>
+                                <div class="split-more">+&nbsp;<?= format_number($splitter['result']['total'] - $splitter['result']['showing']) ?> more</div>
                             <?php endif; ?>
                         </div>
                     <?php endif; ?>
@@ -743,7 +743,7 @@ if ($i < 3) {
 
         <?php
         $open_tool_ipv6 = null;
-        if ($split_result6 !== null || $split_error6 !== null) { $open_tool_ipv6 = 'split6'; }
+        if (!empty($splitter6)) { $open_tool_ipv6 = 'split6'; }
         elseif (!empty($ula)) { $open_tool_ipv6 = 'ula'; }
         elseif (!empty($range6)) { $open_tool_ipv6 = 'range6'; }
         elseif (!empty($supernet6)) { $open_tool_ipv6 = 'supernet6'; }
@@ -783,27 +783,27 @@ if ($i < 3) {
                             <input type="text" name="split_prefix6" class="splitter-input"
                                    placeholder="/65" value="<?= htmlspecialchars($input_split_prefix6) ?>"
                                    autocomplete="off" spellcheck="false"
-                                   <?= $split_error6 ? 'aria-invalid="true" aria-describedby="split-error-ipv6"' : '' ?>>
+                                   <?= !empty($splitter6['error']) ? 'aria-invalid="true" aria-describedby="split-error-ipv6"' : '' ?>>
                             <button type="submit" class="splitter-btn">Split</button>
                         </div>
                     </form>
-                    <?php if ($split_error6) : ?>
-                        <div class="error" id="split-error-ipv6"><?= htmlspecialchars($split_error6) ?></div>
-                    <?php elseif ($split_result6 && $split_result6['showing'] > 0) : ?>
+                    <?php if (!empty($splitter6['error'])) : ?>
+                        <div class="error" id="split-error-ipv6"><?= htmlspecialchars($splitter6['error']) ?></div>
+                    <?php elseif (isset($splitter6['result']) && $splitter6['result']['showing'] > 0) : ?>
                         <div class="split-list" data-parent="<?= htmlspecialchars($result6['network_cidr'] ?? '') ?>">
                             <button type="button" class="copy-all-btn" data-target="split">Copy All</button>
                             <button type="button" class="copy-all-btn copy-md-btn" data-target="split6">Copy as Markdown</button>
                             <button type="button" class="copy-all-btn copy-cisco-btn" data-target="split6">Copy as Cisco</button><?= help_bubble('copy-cisco-split6', 'Cisco output is generic IOS-style — one interface stanza per split IPv6 subnet using ipv6 address. Vendor-specific tweaks may be required.') ?>
                             <button type="button" class="ascii-export-btn">Export ASCII</button>
-                            <?php foreach ($split_result6['subnets'] as $s) : ?>
+                            <?php foreach ($splitter6['result']['subnets'] as $s) : ?>
                                 <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($s) ?>">
                                     <span class="split-subnet-text"><?= htmlspecialchars($s) ?></span>
                                     <?= copy_button($s, 'Copy ' . $s) ?>
                                 </div>
                             <?php endforeach; ?>
                             <?php
-                                $total6   = $split_result6['total'];
-                                $showing6 = $split_result6['showing'];
+                                $total6   = $splitter6['result']['total'];
+                                $showing6 = $splitter6['result']['showing'];
                                 $has_more6 = is_numeric($total6) ? ($showing6 < (int)$total6) : true;
                                 $more_label6 = is_numeric($total6) ? format_number((int)$total6 - $showing6) . ' more' : $total6 . ' more';
                             ?>
@@ -1292,9 +1292,9 @@ if ($i < 3) {
                 <a href="?tab=vlsm" class="btn reset">Reset</a>
             </div>
         </form>
-        <?php if ($vlsm_error) : ?>
-            <div class="error"><?= htmlspecialchars($vlsm_error) ?></div>
-        <?php elseif ($vlsm_result !== null) : ?>
+        <?php if (!empty($vlsm['error'])) : ?>
+            <div class="error"><?= htmlspecialchars($vlsm['error']) ?></div>
+        <?php elseif (isset($vlsm['result'])) : ?>
             <div class="vlsm-results">
                 <p class="vlsm-sort-note">Results sorted largest-first for efficient allocation.<?= help_bubble('vlsm-sort', 'Subnets are allocated from largest to smallest so that larger blocks can be placed at aligned boundaries without wasting address space.') ?></p>
                 <table class="vlsm-table">
@@ -1308,7 +1308,7 @@ if ($i < 3) {
                         </tr>
                     </thead>
                     <tbody>
-                        <?php foreach ($vlsm_result as $alloc) :
+                        <?php foreach ($vlsm['result'] as $alloc) :
                             [$alloc_net_ip, $alloc_pfx] = explode('/', $alloc['subnet']);
                             $alloc_detail = calculate_subnet($alloc_net_ip, (int)$alloc_pfx);
                             ?>
@@ -1335,7 +1335,7 @@ if ($i < 3) {
             <?php
             $vlsm_total_hosts_req = 0;
             $vlsm_total_allocated = 0;
-            foreach ($vlsm_result as $alloc) {
+            foreach ($vlsm['result'] as $alloc) {
                 $vlsm_total_hosts_req += $alloc['hosts_needed'];
                 [, $vlsm_alloc_pfx] = explode('/', $alloc['subnet']);
                 $vlsm_total_allocated += (int)pow(2, 32 - (int)$vlsm_alloc_pfx);
@@ -1554,9 +1554,9 @@ if ($i < 3) {
                 <a href="?tab=vlsm6" class="btn reset">Reset</a>
             </div>
         </form>
-        <?php if ($vlsm6_error) : ?>
-            <div class="error"><?= htmlspecialchars($vlsm6_error) ?></div>
-        <?php elseif ($vlsm6_result !== null) : ?>
+        <?php if (!empty($vlsm6['error'])) : ?>
+            <div class="error"><?= htmlspecialchars($vlsm6['error']) ?></div>
+        <?php elseif (isset($vlsm6['result'])) : ?>
             <div class="vlsm-results">
                 <p class="vlsm-sort-note">Results sorted largest-first for efficient allocation.<?= help_bubble('vlsm6-sort', 'Subnets are allocated from largest to smallest so that larger blocks can be placed at aligned boundaries without wasting address space.') ?></p>
                 <table class="vlsm-table vlsm6-table">
@@ -1569,7 +1569,7 @@ if ($i < 3) {
                         </tr>
                     </thead>
                     <tbody>
-                        <?php foreach ($vlsm6_result as $alloc6) : ?>
+                        <?php foreach ($vlsm6['result'] as $alloc6) : ?>
                         <tr>
                             <td><?= htmlspecialchars($alloc6['name']) ?></td>
                             <td><?= htmlspecialchars((string)$alloc6['hosts_needed']) ?></td>
@@ -1593,7 +1593,7 @@ if ($i < 3) {
             $vlsm6_parent_total    = gmp_pow(gmp_init(2), 128 - $vlsm6_parent_cidr_int);
             $vlsm6_total_allocated = gmp_init(0);
             $vlsm6_total_hosts_req = gmp_init(0);
-            foreach ($vlsm6_result as $alloc6) {
+            foreach ($vlsm6['result'] as $alloc6) {
                 [, $vlsm6_alloc_pfx_str] = explode('/', $alloc6['subnet']);
                 $vlsm6_alloc_pfx = (int)$vlsm6_alloc_pfx_str;
                 $vlsm6_total_allocated = gmp_add(

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -747,7 +747,7 @@ if ($i < 3) {
         elseif ($ula_result !== null || $ula_error !== null) { $open_tool_ipv6 = 'ula'; }
         elseif ($range6_result !== null || $range6_error !== null) { $open_tool_ipv6 = 'range6'; }
         elseif ($supernet6_result !== null || $supernet6_error !== null) { $open_tool_ipv6 = 'supernet6'; }
-        elseif ($zoneid_address !== null || $zoneid_error !== null) { $open_tool_ipv6 = 'zoneid'; }
+        elseif (!empty($zoneid)) { $open_tool_ipv6 = 'zoneid'; }
         elseif ($derive_eui64 !== null || $derive_error !== null) { $open_tool_ipv6 = 'derive'; }
         elseif ($slaac_address !== null || $slaac_error !== null) { $open_tool_ipv6 = 'slaac'; }
         elseif (($lookup_result !== null || $lookup_error !== null) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'lookup'; }
@@ -971,30 +971,30 @@ if ($i < 3) {
                                    placeholder="fe80::1%eth0"
                                    value="<?= htmlspecialchars($zoneid_input) ?>"
                                    autocomplete="off" spellcheck="false"
-                                   <?= $zoneid_error ? 'aria-invalid="true" aria-describedby="zoneid-error"' : '' ?>>
+                                   <?= !empty($zoneid['error']) ? 'aria-invalid="true" aria-describedby="zoneid-error"' : '' ?>>
                             <button type="submit" class="splitter-btn">Parse</button>
                         </div>
                     </form>
-                    <?php if ($zoneid_error) : ?>
-                        <div class="error" id="zoneid-error"><?= htmlspecialchars($zoneid_error) ?></div>
-                    <?php elseif ($zoneid_address !== null) : ?>
-                        <?php if ($zoneid_warning) : ?>
-                            <div class="warning"><?= htmlspecialchars($zoneid_warning) ?></div>
+                    <?php if (!empty($zoneid['error'])) : ?>
+                        <div class="error" id="zoneid-error"><?= htmlspecialchars($zoneid['error']) ?></div>
+                    <?php elseif (isset($zoneid['address'])) : ?>
+                        <?php if (!empty($zoneid['warning'])) : ?>
+                            <div class="warning"><?= htmlspecialchars($zoneid['warning']) ?></div>
                         <?php endif; ?>
-                        <?php $_zoneid_label = 'Zone ID: ' . $zoneid_address . ($zoneid_zone_id !== null ? '%' . $zoneid_zone_id : ''); ?>
+                        <?php $_zoneid_label = 'Zone ID: ' . $zoneid['address'] . (($zoneid['zone_id'] ?? null) !== null ? '%' . $zoneid['zone_id'] : ''); ?>
                         <dl class="zoneid-result"
                             data-history-source="zoneid"
                             data-history-active="1"
                             data-history-label="<?= htmlspecialchars($_zoneid_label) ?>">
                             <div class="zoneid-result__row">
                                 <dt class="zoneid-result__label">Address</dt>
-                                <dd class="zoneid-result__value"><code><?= htmlspecialchars($zoneid_address) ?></code></dd>
+                                <dd class="zoneid-result__value"><code><?= htmlspecialchars($zoneid['address']) ?></code></dd>
                             </div>
                             <div class="zoneid-result__row">
                                 <dt class="zoneid-result__label">Zone ID</dt>
                                 <dd class="zoneid-result__value">
-                                    <?php if ($zoneid_zone_id !== null) : ?>
-                                        <code><?= htmlspecialchars($zoneid_zone_id) ?></code>
+                                    <?php if (($zoneid['zone_id'] ?? null) !== null) : ?>
+                                        <code><?= htmlspecialchars($zoneid['zone_id']) ?></code>
                                     <?php else : ?>
                                         <span class="zoneid-result__empty" aria-label="no zone identifier">&mdash;</span>
                                     <?php endif; ?>
@@ -1002,7 +1002,7 @@ if ($i < 3) {
                             </div>
                             <div class="zoneid-result__row">
                                 <dt class="zoneid-result__label">Link-local</dt>
-                                <dd class="zoneid-result__value"><?= $zoneid_is_link_local ? 'Yes' : 'No' ?></dd>
+                                <dd class="zoneid-result__value"><?= !empty($zoneid['is_link_local']) ? 'Yes' : 'No' ?></dd>
                             </div>
                         </dl>
                     <?php endif; ?>

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -228,8 +228,8 @@ if ($i < 3) {
         <?php
         $open_tool_ipv4 = null;
         if ($split_result !== null || $split_error !== null) { $open_tool_ipv4 = 'split'; }
-        elseif ($supernet_result !== null || $supernet_error !== null) { $open_tool_ipv4 = 'supernet'; }
-        elseif ($range_result !== null || $range_error !== null) { $open_tool_ipv4 = 'range'; }
+        elseif (!empty($supernet)) { $open_tool_ipv4 = 'supernet'; }
+        elseif (!empty($range)) { $open_tool_ipv4 = 'range'; }
         elseif ($tree_result !== null || $tree_error !== null) { $open_tool_ipv4 = 'tree'; }
         elseif ($wildcard_result !== null || $wildcard_error !== null) { $open_tool_ipv4 = 'wildcard'; }
         elseif (($lookup_result !== null || $lookup_error !== null) && $active_tab === 'ipv4') { $open_tool_ipv4 = 'lookup'; }
@@ -303,15 +303,15 @@ if ($i < 3) {
                             <button type="submit" name="supernet_action" value="summarise" class="splitter-btn">Summarise Routes</button><?= help_bubble('supernet-summarise', 'Computes the minimal set of non-overlapping CIDRs that exactly covers the listed networks. Unlike Find Supernet, this avoids including addresses outside the input ranges.') ?>
                         </div>
                     </form>
-                    <?php if ($supernet_error) : ?>
-                        <div class="error"><?= htmlspecialchars($supernet_error) ?></div>
-                    <?php elseif ($supernet_result !== null) : ?>
+                    <?php if (!empty($supernet['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($supernet['error']) ?></div>
+                    <?php elseif (isset($supernet['result'])) : ?>
                         <?php
                         $_supernet_inputs = count(array_filter(array_map('trim', explode("\n", $supernet_input))));
                         if ($supernet_action === 'find') {
                             $_supernet_label = 'Supernet: ' . $_supernet_inputs . ' CIDR' . ($_supernet_inputs !== 1 ? 's' : '');
                         } else {
-                            $_supernet_outs  = count($supernet_result['summaries'] ?? []);
+                            $_supernet_outs  = count($supernet['result']['summaries'] ?? []);
                             $_supernet_label = 'Summarise: ' . $_supernet_inputs . ' → ' . $_supernet_outs;
                         }
                         ?>
@@ -320,7 +320,7 @@ if ($i < 3) {
                                  data-history-source="supernet"
                                  data-history-active="1"
                                  data-history-label="<?= htmlspecialchars($_supernet_label) ?>">
-                                <?= htmlspecialchars($supernet_result['supernet'] ?? '') ?>
+                                <?= htmlspecialchars($supernet['result']['supernet'] ?? '') ?>
                             </div>
                         <?php else : ?>
                             <div class="split-list split-list--mt"
@@ -328,13 +328,13 @@ if ($i < 3) {
                                  data-history-active="1"
                                  data-history-label="<?= htmlspecialchars($_supernet_label) ?>">
                                 <button type="button" class="copy-all-btn" data-target="supernet">Copy All</button>
-                                <?php foreach ($supernet_result['summaries'] ?? [] as $s) : ?>
+                                <?php foreach ($supernet['result']['summaries'] ?? [] as $s) : ?>
                                     <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($s) ?>">
                                         <span class="split-subnet-text"><?= htmlspecialchars($s) ?></span>
                                         <?= copy_button($s, 'Copy ' . $s) ?>
                                     </div>
                                 <?php endforeach; ?>
-                                <?php $s_count = count($supernet_result['summaries'] ?? []);
+                                <?php $s_count = count($supernet['result']['summaries'] ?? []);
                                       $i_count = count(array_filter(explode("\n", $supernet_input))); ?>
                                 <div class="split-more"><?= $s_count ?> prefix<?= $s_count !== 1 ? 'es' : '' ?> from <?= $i_count ?> input<?= $i_count !== 1 ? 's' : '' ?></div>
                             </div>
@@ -363,22 +363,22 @@ if ($i < 3) {
                             <button type="submit" class="splitter-btn">Convert</button>
                         </div>
                     </form>
-                    <?php if ($range_error) : ?>
-                        <div class="error"><?= htmlspecialchars($range_error) ?></div>
-                    <?php elseif ($range_result !== null) : ?>
+                    <?php if (!empty($range['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($range['error']) ?></div>
+                    <?php elseif (isset($range['result'])) : ?>
                         <?php $_range_label = 'Range: ' . $range_start . ' → ' . $range_end; ?>
                         <div class="split-list split-list--mt"
                              data-history-source="range"
                              data-history-active="1"
                              data-history-label="<?= htmlspecialchars($_range_label) ?>">
                             <button type="button" class="copy-all-btn" data-target="range">Copy All</button>
-                            <?php foreach ($range_result as $r_cidr) : ?>
+                            <?php foreach ($range['result'] as $r_cidr) : ?>
                                 <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($r_cidr) ?>">
                                     <span class="split-subnet-text"><?= htmlspecialchars($r_cidr) ?></span>
                                     <?= copy_button($r_cidr, 'Copy ' . $r_cidr) ?>
                                 </div>
                             <?php endforeach; ?>
-                            <div class="split-more"><?= count($range_result) ?> CIDR block<?= count($range_result) !== 1 ? 's' : '' ?></div>
+                            <div class="split-more"><?= count($range['result']) ?> CIDR block<?= count($range['result']) !== 1 ? 's' : '' ?></div>
                         </div>
                     <?php endif; ?>
                 </div>
@@ -744,9 +744,9 @@ if ($i < 3) {
         <?php
         $open_tool_ipv6 = null;
         if ($split_result6 !== null || $split_error6 !== null) { $open_tool_ipv6 = 'split6'; }
-        elseif ($ula_result !== null || $ula_error !== null) { $open_tool_ipv6 = 'ula'; }
+        elseif (!empty($ula)) { $open_tool_ipv6 = 'ula'; }
         elseif (!empty($range6)) { $open_tool_ipv6 = 'range6'; }
-        elseif ($supernet6_result !== null || $supernet6_error !== null) { $open_tool_ipv6 = 'supernet6'; }
+        elseif (!empty($supernet6)) { $open_tool_ipv6 = 'supernet6'; }
         elseif (!empty($zoneid)) { $open_tool_ipv6 = 'zoneid'; }
         elseif (!empty($derive)) { $open_tool_ipv6 = 'derive'; }
         elseif (!empty($slaac)) { $open_tool_ipv6 = 'slaac'; }
@@ -833,23 +833,23 @@ if ($i < 3) {
                             </div>
                         </div>
                     </form>
-                    <?php if ($ula_error) : ?>
-                        <div class="error"><?= htmlspecialchars($ula_error) ?></div>
-                    <?php elseif ($ula_result !== null) : ?>
-                        <?php $_ula_label = 'ULA: ' . (string)($ula_result['prefix'] ?? ''); ?>
+                    <?php if (!empty($ula['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($ula['error']) ?></div>
+                    <?php elseif (isset($ula['result'])) : ?>
+                        <?php $_ula_label = 'ULA: ' . (string)($ula['result']['prefix'] ?? ''); ?>
                         <div class="ula-result"
                              data-history-source="ula"
                              data-history-active="1"
                              data-history-label="<?= htmlspecialchars($_ula_label) ?>">
-                            <div class="overlap-result overlap-contains"><?= htmlspecialchars($ula_result['prefix'] ?? '') ?></div>
+                            <div class="overlap-result overlap-contains"><?= htmlspecialchars($ula['result']['prefix'] ?? '') ?></div>
                             <div class="ula-meta">
-                                <span>Global ID: <code><?= htmlspecialchars($ula_result['global_id'] ?? '') ?></code></span>
-                                <span>Available /64s: <strong><?= format_number((int)($ula_result['available_64s'] ?? 0)) ?></strong></span>
+                                <span>Global ID: <code><?= htmlspecialchars($ula['result']['global_id'] ?? '') ?></code></span>
+                                <span>Available /64s: <strong><?= format_number((int)($ula['result']['available_64s'] ?? 0)) ?></strong></span>
                             </div>
-                            <?php if (!empty($ula_result['example_64s'])) : ?>
+                            <?php if (!empty($ula['result']['example_64s'])) : ?>
                             <div class="split-list split-list--mt">
                                 <button type="button" class="copy-all-btn" data-target="ula">Copy All</button>
-                                <?php foreach ($ula_result['example_64s'] as $ex64) : ?>
+                                <?php foreach ($ula['result']['example_64s'] as $ex64) : ?>
                                     <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($ex64) ?>">
                                         <span class="split-subnet-text"><?= htmlspecialchars($ex64) ?></span>
                                         <?= copy_button($ex64, 'Copy ' . $ex64) ?>
@@ -920,15 +920,15 @@ if ($i < 3) {
                             <button type="submit" name="supernet6_action" value="summarise" class="splitter-btn">Summarise Routes</button><?= help_bubble('supernet6-summarise', 'Computes the minimal set of non-overlapping IPv6 CIDRs that exactly covers the listed networks. Unlike Find Supernet, this avoids including addresses outside the input ranges.') ?>
                         </div>
                     </form>
-                    <?php if ($supernet6_error) : ?>
-                        <div class="error"><?= htmlspecialchars($supernet6_error) ?></div>
-                    <?php elseif ($supernet6_result !== null) : ?>
+                    <?php if (!empty($supernet6['error'])) : ?>
+                        <div class="error"><?= htmlspecialchars($supernet6['error']) ?></div>
+                    <?php elseif (isset($supernet6['result'])) : ?>
                         <?php
                         $_supernet6_inputs = count(array_filter(array_map('trim', explode("\n", $supernet6_input))));
                         if ($supernet6_action === 'find') {
                             $_supernet6_label = 'Supernet6: ' . $_supernet6_inputs . ' CIDR' . ($_supernet6_inputs !== 1 ? 's' : '');
                         } else {
-                            $_supernet6_outs  = count($supernet6_result['summaries'] ?? []);
+                            $_supernet6_outs  = count($supernet6['result']['summaries'] ?? []);
                             $_supernet6_label = 'Summarise6: ' . $_supernet6_inputs . ' → ' . $_supernet6_outs;
                         }
                         ?>
@@ -937,7 +937,7 @@ if ($i < 3) {
                                  data-history-source="supernet6"
                                  data-history-active="1"
                                  data-history-label="<?= htmlspecialchars($_supernet6_label) ?>">
-                                <?= htmlspecialchars($supernet6_result['supernet'] ?? '') ?>
+                                <?= htmlspecialchars($supernet6['result']['supernet'] ?? '') ?>
                             </div>
                         <?php else : ?>
                             <div class="split-list split-list--mt"
@@ -945,13 +945,13 @@ if ($i < 3) {
                                  data-history-active="1"
                                  data-history-label="<?= htmlspecialchars($_supernet6_label) ?>">
                                 <button type="button" class="copy-all-btn" data-target="supernet6">Copy All</button>
-                                <?php foreach ($supernet6_result['summaries'] ?? [] as $s6) : ?>
+                                <?php foreach ($supernet6['result']['summaries'] ?? [] as $s6) : ?>
                                     <div class="split-item" tabindex="0" role="button" data-copy="<?= htmlspecialchars($s6) ?>">
                                         <span class="split-subnet-text"><?= htmlspecialchars($s6) ?></span>
                                         <?= copy_button($s6, 'Copy ' . $s6) ?>
                                     </div>
                                 <?php endforeach; ?>
-                                <?php $s6_count = count($supernet6_result['summaries'] ?? []);
+                                <?php $s6_count = count($supernet6['result']['summaries'] ?? []);
                                       $i6_count = count(array_filter(explode("\n", $supernet6_input))); ?>
                                 <div class="split-more"><?= $s6_count ?> prefix<?= $s6_count !== 1 ? 'es' : '' ?> from <?= $i6_count ?> input<?= $i6_count !== 1 ? 's' : '' ?></div>
                             </div>

--- a/docs/superpowers/plans/v3.4.0-living-doc.md
+++ b/docs/superpowers/plans/v3.4.0-living-doc.md
@@ -35,7 +35,7 @@ its PR opens.
 | 2 | T2 | Cleanup batch — doc typo + RangeTest DI + ul_bit_flipped docblock | in-review (PR #376) | `d153c81` | T1 |
 | 3 | T3 | Extract `copy_button()` helper | in-review (PR #377) | `8f98ea2` | T2 |
 | 4 | T4 | Split `functions-derive6.php` → zone6/derive6/slaac6 | in-review (PR #378) | `3b4b5eb` | T3 |
-| 5 | T5 | `request.php` flat globals → per-tool arrays | pending | — | T4 |
+| 5 | T5 | `request.php` flat globals → per-tool arrays | in-review (PR #379) | `eebfc09` | T4 |
 | 6 | T6 | IPv6 type-detection → `functions-type6.php` | pending | — | T5 |
 | 7 | T7 | Per-tool URL routes (`/ipv6/<tool>`) | pending | — | T6 |
 | 8 | T8 | IPv6 reverse-DNS (rdns6) | pending | — | T7 |
@@ -107,3 +107,28 @@ Document the consultant output verbatim in the PR description.
 - Seeded Memory MCP entity `project:subnet-calculator:release:v3.4.0`
   plus the two relations above.
 - Tracking PR: [#375](https://github.com/seanmousseau/Subnet-Calculator/pull/375) (`release/v3.4.0` → `main`).
+
+### Task 5 — 2026-05-08 — request.php flat globals → per-tool arrays
+
+- Branch `feature/v3.4.0-request-globals-refactor` cut from `release/v3.4.0` at `996f9e9`.
+- Converted **14 tools** from flat per-tool globals into single per-tool associative arrays:
+  `zoneid`, `derive`, `slaac`, `range6`, `supernet`, `supernet6`, `range`, `ula`, `lookup`, `diff`,
+  `overlap`, `multi_overlap`, `tree`, `wildcard`, `splitter`, `splitter6`, `vlsm`, `vlsm6`.
+- `sc_run_zoneid` / `sc_run_derive` / `sc_run_slaac` / `sc_run_range6` / `sc_run_lookup` /
+  `sc_run_diff` helpers refactored from by-reference output args to plain `array` returns.
+- **Out of scope (kept flat):** `$result/$error/$input_ip/$input_mask` and IPv6 counterparts —
+  `$error`/`$error6` are dual-purpose CAPTCHA-banner + calc errors, falling under the cross-tool
+  exclusion clause; `$result`/`$result6` are already arrays from `calculate_subnet*()`. Submitted
+  form-state scalars (`$vlsm_network`, `$vlsm_cidr_input`, `$vlsm_requirements`, `$tree_parent`,
+  etc.) stay flat — they're echoed back into form fields, not tool outputs. `rdns` does not exist
+  as a flat-global set in `request.php` (rendering reads from `$result['reverse_zones']`).
+- `_diff_result.php` partial unchanged: layout.php aliases `$diff_result = $diff['result']` at the
+  include site so the partial keeps its existing surface area.
+- Per-tool commits (zoneid pattern lock, derive+slaac, range6, supernet/supernet6/range/ula,
+  lookup/diff/overlap/tree/wildcard, splitter/vlsm), plus a final phpcs-polish commit wrapping
+  long `array{}` docblocks under PSR-12's 120-char limit. 7 commits total ending at `eebfc09`.
+- **QA gates green:** PHPUnit 475/475 (1120 assertions, 14 skipped); PHPStan L9 clean; PHPCS
+  PSR-12 0/0; Spectral 0 errors; Semgrep 0 findings; npm lint 0 errors; **Playwright 1228/1228**
+  (matches the v3.3.0 baseline, rendered HTML byte-identical).
+- Tracking PR: [#379](https://github.com/seanmousseau/Subnet-Calculator/pull/379)
+  (`feature/v3.4.0-request-globals-refactor` → `release/v3.4.0`).


### PR DESCRIPTION
## Summary

Closes v3.3.0 carry-forward item #3.

Collapses 14 tools' flat per-tool globals in `Subnet-Calculator/includes/request.php` into per-tool associative arrays. Each tool's result fields move from `$<tool>_field` to `$<tool>['field']`, and the empty-state default is `$<tool> = []`. All template echo sites in `Subnet-Calculator/templates/layout.php` (and the `_diff_result.php` partial) updated to read `$<tool>['field'] ?? ''`.

### Tools converted (14)

`zoneid`, `derive`, `slaac`, `range6`, `supernet`, `supernet6`, `range`, `ula`, `lookup`, `diff`, `overlap`, `multi_overlap`, `tree`, `wildcard`, `splitter`, `splitter6`, `vlsm`, `vlsm6`.

`sc_run_zoneid`, `sc_run_derive`, `sc_run_slaac`, `sc_run_range6`, `sc_run_lookup`, `sc_run_diff` helpers refactored from by-reference output arguments to plain `array` return signatures — the dispatch sites now read `$<tool> = sc_run_<tool>(...)` directly.

### Out of scope / left flat

- **`$result`, `$error`, `$input_ip`, `$input_mask`, `$result6`, `$error6`, `$input_ipv6`, `$input_prefix`** — `$error` / `$error6` are dual-purpose CAPTCHA banner strings AND IPv4/IPv6 calc errors; per the cross-tool exclusion clause in the task brief these stay flat. `$result` / `$result6` are already structured arrays returned by `calculate_subnet()` / `calculate_subnet6()` — no flat-globals to collapse.
- **Submitted form-state scalars** (`$vlsm_network`, `$vlsm_cidr_input`, `$vlsm_requirements`, `$range_start`, `$supernet_action`, `$ula_global_id_input`, `$tree_parent`, `$tree_children`, etc.) — these are POST/GET inputs the template echoes back into form fields, not tool outputs.
- **Cross-tool / page-level globals** (`$share_url`, `$canonical_url`, `$bg_override_style`, `$session_save_id`, `$session_load_id`, `$session_error`, `$active_tab`).
- **`rdns`** — does not exist as a flat-global set in `request.php`; the rdns rendering reads from `$result['reverse_zones']` directly.

### `_diff_result.php` partial — minimal-diff approach

The diff result partial template references `$diff_result` directly. Rather than rewrite the partial, the layout.php include sites alias `$diff_result = $diff['result']` immediately before `include __DIR__ . '/_diff_result.php'`. This keeps the partial's surface area unchanged.

## UI parity

Rendered HTML byte-identical. Empty-state defaults (`$<tool> = []`) ensure echo sites with `?? ''` continue to render the same empty fields as before. Playwright suite green at the v3.3.0 baseline count of **1228/1228**.

The formal `ui-ux-pro-max` consultation is intentionally skipped — the refactor is purely shape-level (container-shape change, identical field names and values).

## Test plan

- [x] PHPUnit green — 475 tests, 1120 assertions, 14 skipped (no GMP)
- [x] PHPStan L9 clean
- [x] PHPCS PSR-12 clean — 0 errors, 0 warnings
- [x] Spectral OpenAPI lint — 0 errors
- [x] Semgrep — 0 findings (PHP / OWASP / SQL injection rule packs)
- [x] npm lint (ESLint + Stylelint) — 0 errors
- [x] Playwright matches baseline — **1228/1228**

## Per-tool commit history

```
eebfc09 style(v3.4.0): wrap long array{} docblocks to satisfy PSR-12 120-char limit
9b997cc refactor(v3.4.0): collapse splitter, splitter6, vlsm, vlsm6 flat globals into arrays
6fa4dc2 refactor(v3.4.0): collapse lookup, diff, overlap, multi_overlap, tree, wildcard flat globals into arrays
248063c refactor(v3.4.0): collapse supernet, supernet6, range, ula flat globals into arrays
5aa1eff refactor(v3.4.0): collapse range6 flat globals into $range6 array
9024c1f refactor(v3.4.0): collapse derive and slaac flat globals into arrays
3ea5ba4 refactor(v3.4.0): collapse zoneid flat globals into $zoneid array (pattern lock)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)