### PR TITLE
refactor(v3.4.0): IPv6 type detection → functions-type6.php

### DIFF
--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -18,6 +18,7 @@ require $base . 'functions-ipv4.php';
 require $base . 'functions-ipv6.php';
 require $base . 'functions-split.php';
 require $base . 'functions-util.php';
+require $base . 'functions-type6.php';
 require $base . 'functions-vlsm.php';
 require $base . 'functions-vlsm6.php';
 require $base . 'functions-supernet.php';

--- a/Subnet-Calculator/includes/functions-type6.php
+++ b/Subnet-Calculator/includes/functions-type6.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * IPv6 address classification helpers.
+ *
+ * Extracted from functions-util.php in v3.4.0 (architecture item C).
+ * Owns pure classification logic (loopback, ULA, link-local,
+ * multicast, GUA, IPv4-mapped, NAT64, etc.). The address-type
+ * *badge* renderer stays in functions-util.php.
+ *
+ * Public function names unchanged.
+ */
+
+function get_ipv6_type(string $ip): string
+{
+    $bin = inet_pton($ip);
+    if ($bin === false) {
+        return 'Unknown';
+    }
+    $unpacked = unpack('C*', $bin);
+    if ($unpacked === false || count($unpacked) < 16) {
+        return 'Unknown';
+    }
+    $b = array_values($unpacked);
+    if ($bin === str_repeat("\x00", 15) . "\x01") {
+        return 'Loopback';
+    }
+    if ($bin === str_repeat("\x00", 16)) {
+        return 'Unspecified';
+    }
+    if (substr($bin, 0, 10) === str_repeat("\x00", 10) && substr($bin, 10, 2) === "\xff\xff") {
+        return 'IPv4-mapped';
+    }
+    if ($b[0] === 0xFF) {
+        return 'Multicast';
+    }
+    if ($b[0] === 0xFE && ($b[1] & 0xC0) === 0x80) {
+        return 'Link-local';
+    }
+    if (($b[0] & 0xFE) === 0xFC) {
+        return 'Unique Local';
+    }
+    if ($b[0] === 0x20 && $b[1] === 0x01 && $b[2] === 0x0D && $b[3] === 0xB8) {
+        return 'Documentation';
+    }
+    if ($b[0] === 0x20 && $b[1] === 0x01 && $b[2] === 0x00 && $b[3] === 0x00) {
+        return 'Teredo';
+    }
+    if ($b[0] === 0x20 && $b[1] === 0x02) {
+        return '6to4';
+    }
+    if ($b[0] === 0x00 && $b[1] === 0x64 && $b[2] === 0xFF && $b[3] === 0x9B) {
+        if ($b[4] === 0x00 && $b[5] === 0x01) {
+            return 'NAT64 (local)';
+        }
+                                                               return 'NAT64';
+    }
+    if (($b[0] & 0xE0) === 0x20) {
+        return 'Global Unicast';
+    }
+    return 'Unknown';
+}

--- a/Subnet-Calculator/includes/functions-util.php
+++ b/Subnet-Calculator/includes/functions-util.php
@@ -2,7 +2,17 @@
 
 declare(strict_types=1);
 
-// ─── Address type detection ───────────────────────────────────────────────────
+/**
+ * Generic UI/template helpers.
+ *
+ * IPv4 address classification, address-type badge class mapping,
+ * locale-aware number formatting, and the help-bubble / copy-button
+ * HTML renderers. IPv6 classification lives in functions-type6.php
+ * as of v3.4.0 (architecture item C); the badge-class mapper below
+ * still covers both IPv4 and IPv6 type strings (UI concern).
+ */
+
+// ─── Address type detection (IPv4) ───────────────────────────────────────────
 
 function get_ipv4_type(string $ip): string
 {
@@ -58,55 +68,7 @@ function get_ipv4_type(string $ip): string
     return 'Public';
 }
 
-function get_ipv6_type(string $ip): string
-{
-    $bin = inet_pton($ip);
-    if ($bin === false) {
-        return 'Unknown';
-    }
-    $unpacked = unpack('C*', $bin);
-    if ($unpacked === false || count($unpacked) < 16) {
-        return 'Unknown';
-    }
-    $b = array_values($unpacked);
-    if ($bin === str_repeat("\x00", 15) . "\x01") {
-        return 'Loopback';
-    }
-    if ($bin === str_repeat("\x00", 16)) {
-        return 'Unspecified';
-    }
-    if (substr($bin, 0, 10) === str_repeat("\x00", 10) && substr($bin, 10, 2) === "\xff\xff") {
-        return 'IPv4-mapped';
-    }
-    if ($b[0] === 0xFF) {
-        return 'Multicast';
-    }
-    if ($b[0] === 0xFE && ($b[1] & 0xC0) === 0x80) {
-        return 'Link-local';
-    }
-    if (($b[0] & 0xFE) === 0xFC) {
-        return 'Unique Local';
-    }
-    if ($b[0] === 0x20 && $b[1] === 0x01 && $b[2] === 0x0D && $b[3] === 0xB8) {
-        return 'Documentation';
-    }
-    if ($b[0] === 0x20 && $b[1] === 0x01 && $b[2] === 0x00 && $b[3] === 0x00) {
-        return 'Teredo';
-    }
-    if ($b[0] === 0x20 && $b[1] === 0x02) {
-        return '6to4';
-    }
-    if ($b[0] === 0x00 && $b[1] === 0x64 && $b[2] === 0xFF && $b[3] === 0x9B) {
-        if ($b[4] === 0x00 && $b[5] === 0x01) {
-            return 'NAT64 (local)';
-        }
-                                                               return 'NAT64';
-    }
-    if (($b[0] & 0xE0) === 0x20) {
-        return 'Global Unicast';
-    }
-    return 'Unknown';
-}
+// IPv6 classification (get_ipv6_type) lives in functions-type6.php as of v3.4.0.
 
 function type_badge_class(string $type): string
 {

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -6,6 +6,7 @@ require __DIR__ . '/includes/functions-ipv4.php';
 require __DIR__ . '/includes/functions-ipv6.php';
 require __DIR__ . '/includes/functions-split.php';
 require __DIR__ . '/includes/functions-util.php';
+require __DIR__ . '/includes/functions-type6.php';
 require __DIR__ . '/includes/functions-vlsm.php';
 require __DIR__ . '/includes/functions-vlsm6.php';
 require __DIR__ . '/includes/functions-supernet.php';

--- a/docs/superpowers/plans/v3.4.0-living-doc.md
+++ b/docs/superpowers/plans/v3.4.0-living-doc.md
@@ -36,7 +36,7 @@ its PR opens.
 | 3 | T3 | Extract `copy_button()` helper | in-review (PR #377) | `8f98ea2` | T2 |
 | 4 | T4 | Split `functions-derive6.php` → zone6/derive6/slaac6 | in-review (PR #378) | `3b4b5eb` | T3 |
 | 5 | T5 | `request.php` flat globals → per-tool arrays | in-review (PR #379) | `eebfc09` | T4 |
-| 6 | T6 | IPv6 type-detection → `functions-type6.php` | pending | — | T5 |
+| 6 | T6 | IPv6 type-detection → `functions-type6.php` | in-review (PR #380) | `19f0731` | T5 |
 | 7 | T7 | Per-tool URL routes (`/ipv6/<tool>`) | pending | — | T6 |
 | 8 | T8 | IPv6 reverse-DNS (rdns6) | pending | — | T7 |
 | 9 | T9 | IPv4-mapped / NAT64 (mapped6) | pending | — | T8 |

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -9,6 +9,7 @@ require $base . 'functions-ipv4.php';
 require $base . 'functions-ipv6.php';
 require $base . 'functions-split.php';
 require $base . 'functions-util.php';
+require $base . 'functions-type6.php';
 require $base . 'functions-vlsm.php';
 require $base . 'functions-vlsm6.php';
 require $base . 'functions-supernet.php';


### PR DESCRIPTION
Architecture item C. Internal restructure; no API change, no UI change.

Moves `get_ipv6_type()` from `functions-util.php` into a new `functions-type6.php`. `functions-util.php` keeps generic UI/template helpers (`help_bubble`, `copy_button`, `type_badge_class`, `get_ipv4_type`, `format_number`).

Loaded centrally via `index.php`, `api/v1/index.php`, and `testing/unit/bootstrap.php`.

## Verification
- PHPUnit: 475 tests, 1120 assertions (matches T5 baseline)
- PHPStan L9: clean
- PHPCS PSR-12: clean
- Spectral: clean
- Semgrep: 0 findings
- Playwright (make test-docker): 1228/1228 passed