### PR TITLE
feat(v3.4.0): per-tool URL routes

### DIFF
--- a/Subnet-Calculator/.htaccess
+++ b/Subnet-Calculator/.htaccess
@@ -60,6 +60,19 @@
     # Block session database directory and API internals
     RewriteRule ^data/ - [F,L]
     RewriteRule ^api/v1/handlers/ - [F,L]
+
+    # v3.4.0: per-tool URL routes — back-compat with ?tab=&tool=
+    # /ipv4/<tool> and /ipv6/<tool> rewrite to index.php?tab=&tool=
+    # The !-f / !-d guards prevent clobbering real assets that match the pattern.
+    # QSA preserves shareable query params (e.g. ?address=…). L stops further rewrite.
+    # Legacy ?tab=&tool= URLs continue to be accepted as input with no redirect
+    # (iframe and bookmark back-compat).
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(ipv4|ipv6)/([a-z0-9-]+)/?$ index.php?tab=$1&tool=$2 [QSA,L]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(ipv4|ipv6)/?$ index.php?tab=$1 [QSA,L]
 </IfModule>
 
 # Block SQLite database files and API internals regardless of location

--- a/Subnet-Calculator/assets/app.js
+++ b/Subnet-Calculator/assets/app.js
@@ -78,14 +78,48 @@ document.querySelectorAll('.results').forEach(results => {
 
 // ── Share URL: show full URL and copy it ─────────────────────────────────────
 const _base = window.location.origin + window.location.pathname;
+
+// v3.4.0 — convert legacy ?tab=&tool= share queries into canonical
+// /ipv[46]/<tool> paths. Legacy URLs continue to be accepted by the
+// server (no redirect), but canonical form is what we now emit. The
+// helper accepts a query string starting with "?" and returns a full
+// absolute URL anchored at the current document path. When tab is
+// vlsm/vlsm6 (no per-tool routes) or tab is missing, it returns the
+// legacy form unchanged so we don't accidentally break those tabs.
+function buildShareUrl(qs) {
+    if (typeof qs !== 'string' || qs.charAt(0) !== '?') return _base + (qs || '');
+    // Strip any prior /ipv[46](/<tool>)? path segment so we don't double them.
+    const cleanBase = _base.replace(/\/(ipv[46])(\/[a-z0-9-]+)?\/?$/, '/');
+    let params;
+    try {
+        params = new URLSearchParams(qs.slice(1));
+    } catch (_e) {
+        return _base + qs;
+    }
+    const tab = params.get('tab');
+    if (tab !== 'ipv4' && tab !== 'ipv6') {
+        // vlsm / vlsm6 / unknown → leave the legacy form intact.
+        return _base + qs;
+    }
+    const tool = params.get('tool');
+    params.delete('tab');
+    let path = cleanBase.replace(/\/?$/, '') + '/' + tab;
+    if (tool && /^[a-z0-9-]{1,32}$/.test(tool)) {
+        path += '/' + tool;
+        params.delete('tool');
+    }
+    const remaining = params.toString();
+    return path + (remaining ? '?' + remaining : '');
+}
+
 document.querySelectorAll('.share-url').forEach(el => {
     // Override server-provided absolute URL with window.location for reverse-proxy accuracy
     const btn = el.closest('.share-bar')?.querySelector('.share-copy');
-    if (btn) el.textContent = _base + btn.dataset.copy;
+    if (btn) el.textContent = buildShareUrl(btn.dataset.copy);
 });
 document.querySelectorAll('.share-copy').forEach(btn => {
     btn.addEventListener('click', () => {
-        copyText(_base + btn.dataset.copy, 'Link copied!');
+        copyText(buildShareUrl(btn.dataset.copy), 'Link copied!');
     });
 });
 

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -342,6 +342,30 @@ function sc_run_diff(
 $get_tab    = $_GET['tab'] ?? $default_tab;
 $active_tab = in_array($get_tab, ['ipv4', 'ipv6', 'vlsm', 'vlsm6'], true) ? $get_tab : 'ipv4';
 
+// v3.4.0 (#382) — per-tool URL routes. Apache rewrites /ipv4/<tool> and
+// /ipv6/<tool> to index.php?tab=…&tool=…; we accept ?tool= as a fallback
+// signal to auto-open the matching tool drawer when no other GET param
+// (e.g. derive_mac, supernet_action) implies a tool. Legacy
+// ?tab=&tool= URLs work the same way as the rewritten path. Whitelist
+// keeps any garbage out of the template's data-open-tool attribute.
+$get_tool       = (string)($_GET['tool'] ?? '');
+$requested_tool = preg_match('/^[a-z0-9-]{1,32}$/', $get_tool) === 1 ? $get_tool : '';
+
+// v3.4.0 — when the URL is /ipv4/<tool> or /ipv6/<tool>, the browser sees
+// the longer path and resolves all relative URLs (assets/app.js,
+// assets/app.css, ?tab=ipv6 nav links, share-bar copy targets, …) against
+// it, breaking everything. Compute the real app base path by stripping
+// the /ipv[46](/<tool>)? suffix from REQUEST_URI; the template emits a
+// <base href> so relative URLs resolve to the app root regardless of
+// which canonical URL the user landed on.
+$_req_path = strtok($_SERVER['REQUEST_URI'] ?? '/', '?');
+$app_base_path = preg_replace(
+    '#/(ipv4|ipv6)(/[a-z0-9-]+)?/?$#',
+    '/',
+    (string)$_req_path
+);
+unset($_req_path);
+
 $result = $error = null;
 $input_ip = $input_mask = '';
 

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <?php // v3.4.0 — anchor relative URLs to the app root so /ipv6/derive
+          // and other per-tool routes resolve assets and nav links correctly. ?>
+    <base href="<?= htmlspecialchars($app_base_path) ?>">
     <meta name="description" content="<?= htmlspecialchars($page_description) ?>">
     <meta property="og:title"       content="<?= htmlspecialchars($page_title) ?>">
     <meta property="og:description" content="<?= htmlspecialchars($page_description) ?>">
@@ -234,6 +237,13 @@ if ($i < 3) {
         elseif (!empty($wildcard)) { $open_tool_ipv4 = 'wildcard'; }
         elseif (!empty($lookup) && $active_tab === 'ipv4') { $open_tool_ipv4 = 'lookup'; }
         elseif (!empty($diff) && $active_tab === 'ipv4') { $open_tool_ipv4 = 'diff'; }
+        // v3.4.0 — fallback: /ipv4/<tool> rewrites to ?tool=<tool>; honour it
+        // when no other GET trigger has already chosen a tool above.
+        $ipv4_tool_whitelist = ['split','supernet','range','tree','tree-editor','wildcard','lookup','diff'];
+        if ($open_tool_ipv4 === null && $active_tab === 'ipv4'
+            && in_array($requested_tool, $ipv4_tool_whitelist, true)) {
+            $open_tool_ipv4 = $requested_tool;
+        }
         ?>
         <div class="tool-toolbar"<?= $open_tool_ipv4 ? ' data-open-tool="' . htmlspecialchars($open_tool_ipv4) . '"' : '' ?>>
             <button type="button" class="tool-trigger" data-tool="split" aria-expanded="false">Split Subnet</button>
@@ -752,6 +762,13 @@ if ($i < 3) {
         elseif (!empty($slaac)) { $open_tool_ipv6 = 'slaac'; }
         elseif (!empty($lookup) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'lookup'; }
         elseif (!empty($diff) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'diff'; }
+        // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
+        // when no other GET trigger has already chosen a tool above.
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff'];
+        if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
+            && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
+            $open_tool_ipv6 = $requested_tool;
+        }
         ?>
         <div class="tool-toolbar"<?= $open_tool_ipv6 ? ' data-open-tool="' . htmlspecialchars($open_tool_ipv6) . '"' : '' ?>>
             <button type="button" class="tool-trigger" data-tool="split6" aria-expanded="false">Split Subnet</button>

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -56,7 +56,7 @@ Either side may be empty (but not both). Malformed CIDRs are rejected up front w
 Diff inputs can be passed via GET parameters, which auto-opens the tool drawer and renders the result groups on page load — handy for change-review tickets, runbooks, and chat shares. The textareas accept URL-encoded newlines (`%0A`):
 
 ```text
-/?tab=ipv4&diff_before=10.0.0.0%2F24%0A192.168.0.0%2F24&diff_after=10.0.0.0%2F23%0A192.168.1.0%2F24
+/ipv4/diff?diff_before=10.0.0.0%2F24%0A192.168.0.0%2F24&diff_after=10.0.0.0%2F23%0A192.168.1.0%2F24
 ```
 
 The `tab` parameter selects which panel (`ipv4` or `ipv6`) hosts the diff drawer; the payload itself is family-agnostic.

--- a/docs/ipv6-derive.md
+++ b/docs/ipv6-derive.md
@@ -60,7 +60,7 @@ The tool supports the standard shareable-URL pattern. The colon
 separators must be URL-encoded as `%3A`:
 
 ```text
-?tab=ipv6&derive_mac=00%3A24%3Ab9%3A7e%3Aab%3Acd
+/ipv6/derive?derive_mac=00%3A24%3Ab9%3A7e%3Aab%3Acd
 ```
 
 The drawer auto-opens and all four rows hydrate from the URL.

--- a/docs/ipv6-slaac-privacy.md
+++ b/docs/ipv6-slaac-privacy.md
@@ -132,8 +132,8 @@ The IPv6 tab hydrates from query parameters. Either parameter alone
 will trigger the calculation; the seed is optional.
 
 ```text
-?tab=ipv6&slaac_prefix=2001:db8:1:2::/64
-?tab=ipv6&slaac_prefix=2001:db8:1:2::/64&slaac_seed=a8d3f4e10c529837
+/ipv6/slaac?slaac_prefix=2001:db8:1:2::/64
+/ipv6/slaac?slaac_prefix=2001:db8:1:2::/64&slaac_seed=a8d3f4e10c529837
 ```
 
 A shareable URL **with** a seed makes the result reproducible &mdash;

--- a/docs/ipv6-zone-id.md
+++ b/docs/ipv6-zone-id.md
@@ -54,7 +54,7 @@ The parser supports the standard shareable-URL pattern. The percent sign
 in a zone identifier must be URL-encoded as `%25`:
 
 ```text
-?tab=ipv6&zoneid_input=fe80::1%25eth0
+/ipv6/zoneid?zoneid_input=fe80::1%25eth0
 ```
 
 PHP decodes the `%25` back to a literal `%` server-side, so the parser

--- a/docs/ipv6.md
+++ b/docs/ipv6.md
@@ -75,7 +75,7 @@ Response shape:
 ### Shareable URL
 
 ```text
-?tab=ipv6&tool=range6&range6_start=2001:db8::&range6_end=2001:db8::ffff
+/ipv6/range6?range6_start=2001:db8::&range6_end=2001:db8::ffff
 ```
 
 ## Supernet & Summarise (v3.3.0)
@@ -111,7 +111,7 @@ curl -sX POST https://example.org/api/v1/supernet6 \
 ### Shareable URL
 
 ```text
-?tab=ipv6&tool=supernet6&supernet6_action=find&supernet6_input=2001:db8::/64%0A2001:db8:0:1::/64
+/ipv6/supernet6?supernet6_action=find&supernet6_input=2001:db8::/64%0A2001:db8:0:1::/64
 ```
 
 ## REST API

--- a/docs/lookup.md
+++ b/docs/lookup.md
@@ -37,7 +37,7 @@ Click **Copy All** to copy every row as tab-separated text.
 Lookup inputs can be passed via GET parameters, which auto-opens the tool drawer and renders the results table on page load — handy for bookmarks, documentation, ticket links, and chat shares. The textareas accept URL-encoded newlines (`%0A`):
 
 ```text
-/?tab=ipv4&lookup_cidrs=10.0.0.0%2F8%0A10.1.0.0%2F16&lookup_ips=10.1.2.3%0A8.8.8.8
+/ipv4/lookup?lookup_cidrs=10.0.0.0%2F8%0A10.1.0.0%2F16&lookup_ips=10.1.2.3%0A8.8.8.8
 ```
 
 The `tab` parameter selects which panel (`ipv4` or `ipv6`) hosts the lookup drawer; the `lookup_cidrs` and `lookup_ips` payload itself is family-agnostic and can mix IPv4 and IPv6 lines on either tab.

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -7,7 +7,7 @@ The **Share** bar appears below calculation results when `$show_share_bar = true
 Example:
 
 ```text
-https://example.com/subnet-calculator/?tab=ipv4&ip=192.168.1.0&mask=%2F24
+https://example.com/subnet-calculator/ipv4?ip=192.168.1.0&mask=%2F24
 ```
 
 Set `$canonical_url` in `config.php` to control the base URL used when building shareable links. If left empty the app auto-derives it from the current request.

--- a/docs/superpowers/plans/v3.4.0-living-doc.md
+++ b/docs/superpowers/plans/v3.4.0-living-doc.md
@@ -37,7 +37,7 @@ its PR opens.
 | 4 | T4 | Split `functions-derive6.php` → zone6/derive6/slaac6 | in-review (PR #378) | `3b4b5eb` | T3 |
 | 5 | T5 | `request.php` flat globals → per-tool arrays | in-review (PR #379) | `eebfc09` | T4 |
 | 6 | T6 | IPv6 type-detection → `functions-type6.php` | in-review (PR #380) | `19f0731` | T5 |
-| 7 | T7 | Per-tool URL routes (`/ipv6/<tool>`) | pending | — | T6 |
+| 7 | T7 | Per-tool URL routes (`/ipv6/<tool>`) | in-review (PR #381) | `c1ba078` | T6 |
 | 8 | T8 | IPv6 reverse-DNS (rdns6) | pending | — | T7 |
 | 9 | T9 | IPv4-mapped / NAT64 (mapped6) | pending | — | T8 |
 | 10 | T10 | Bulk endpoint covers new IPv6 endpoints | pending | — | T9 |

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -545,6 +545,99 @@ async def test_ipv6_shareable_url(page: Page) -> None:
     assert_eq("GET auto-calc IPv6: prefix length", await result_value(page, "Prefix Length"), "/8")
 
 
+async def test_per_tool_routes_equivalence(page: Page) -> None:
+    # v3.4.0 — Apache rewrites /ipv[46]/<tool> and /ipv[46] to the existing
+    # ?tab=&tool= form. The two URL forms must render identical content so
+    # that bookmarks and iframe consumers using the legacy form stay valid.
+    section("v3.4.0 — per-tool URL routes: canonical vs legacy equivalence")
+
+    # Bare tab routes
+    await navigate(page, APP_URL + "ipv4")
+    canonical_ipv4 = await page.locator("#main-content").inner_html()
+    await navigate(page, APP_URL + "?tab=ipv4")
+    legacy_ipv4 = await page.locator("#main-content").inner_html()
+    assert_true("/ipv4 vs ?tab=ipv4 render identical content",
+                canonical_ipv4 == legacy_ipv4)
+
+    await navigate(page, APP_URL + "ipv6")
+    canonical_ipv6 = await page.locator("#main-content").inner_html()
+    await navigate(page, APP_URL + "?tab=ipv6")
+    legacy_ipv6 = await page.locator("#main-content").inner_html()
+    assert_true("/ipv6 vs ?tab=ipv6 render identical content",
+                canonical_ipv6 == legacy_ipv6)
+
+    # Per-tool routes — derive opens the IPv6 derive drawer
+    await navigate(page, APP_URL + "ipv6/derive")
+    canonical_derive = await page.locator(
+        '#panel-ipv6 .tool-panel[data-tool="derive"]'
+    ).count()
+    assert_true("/ipv6/derive renders derive tool panel",
+                canonical_derive > 0)
+
+    # Drawer should be auto-opened on canonical route. JS reads
+    # data-open-tool from PHP and toggles aria-expanded after load — wait
+    # for it instead of asserting synchronously, otherwise the JS may not
+    # have run yet on slower CI.
+    try:
+        await page.wait_for_selector(
+            '#panel-ipv6 .tool-trigger[data-tool="derive"][aria-expanded="true"]',
+            timeout=3000,
+        )
+        drawer_open = True
+    except Exception:
+        drawer_open = False
+    assert_true("/ipv6/derive auto-opens the derive tool drawer",
+                drawer_open)
+
+    # Same drawer must auto-open via the legacy ?tab=&tool= form
+    await navigate(page, APP_URL + "?tab=ipv6&tool=derive")
+    try:
+        await page.wait_for_selector(
+            '#panel-ipv6 .tool-trigger[data-tool="derive"][aria-expanded="true"]',
+            timeout=3000,
+        )
+        legacy_drawer_open = True
+    except Exception:
+        legacy_drawer_open = False
+    assert_true("?tab=ipv6&tool=derive auto-opens the derive drawer (legacy form)",
+                legacy_drawer_open)
+
+
+async def test_legacy_query_param_url_no_redirect(_page: Page) -> None:
+    # v3.4.0 — legacy ?tab=&tool= URLs MUST NOT auto-redirect to the canonical
+    # form. iframe embedders and bookmarks rely on the legacy form continuing
+    # to work unchanged.
+    section("v3.4.0 — legacy ?tab=&tool= URL is not redirected")
+
+    resp = _SESSION.get(_APP_BASE + "?tab=ipv6&tool=derive",
+                        allow_redirects=False, timeout=10)
+    assert_eq("legacy URL returns 200 (no redirect)", resp.status_code, 200)
+    assert_true("legacy URL has no Location header",
+                "location" not in {k.lower() for k in resp.headers})
+
+    # Canonical form returns 200 directly (Apache mod_rewrite is internal,
+    # so the client never sees a redirect for this either).
+    resp2 = _SESSION.get(_APP_BASE + "ipv6/derive",
+                         allow_redirects=False, timeout=10)
+    assert_eq("canonical /ipv6/derive returns 200", resp2.status_code, 200)
+
+
+async def test_canonical_route_with_query_params(page: Page) -> None:
+    # v3.4.0 — Apache QSA must preserve query params on the rewritten path.
+    section("v3.4.0 — per-tool route preserves query string (QSA)")
+
+    await navigate(page, APP_URL + "ipv6/derive?derive_mac=00%3A24%3Ab9%3A7e%3Aab%3Acd")
+    # Page rendered + IPv6 panel exists
+    main_html = await page.locator("#main-content").count()
+    assert_true("canonical route + query string renders without 404",
+                main_html > 0)
+    derive_panel = await page.locator(
+        '#panel-ipv6 .tool-panel[data-tool="derive"]'
+    ).count()
+    assert_true("derive tool panel present on canonical route",
+                derive_panel > 0)
+
+
 async def test_iframe(page: Page) -> None:
     IFRAME_HARNESS = APP_URL + "iframe-test.html"
 
@@ -7149,6 +7242,9 @@ async def main() -> None:
             await test_ipv6_errors(page)
             await test_ipv6_splitter(page)
             await test_ipv6_shareable_url(page)
+            await test_per_tool_routes_equivalence(page)
+            await test_legacy_query_param_url_no_redirect(page)
+            await test_canonical_route_with_query_params(page)
             await test_iframe(page)
             await test_theme_toggle(page)
             await test_tab_switch(page)


### PR DESCRIPTION
## Summary
Architecture item D. Both URL forms accepted; canonical output uses `/ipv[46]/<tool>`.

- Apache `.htaccess` rewrites `/ipv[46]/<tool>` and bare `/ipv[46]` to the existing query-param form, with `!-f` / `!-d` guards so real assets keep resolving.
- `request.php` accepts `?tool=` as a fallback signal and computes `$app_base_path`; `layout.php` emits a `<base href>` so relative URLs resolve to the app root regardless of which canonical URL the user landed on.
- `app.js` `buildShareUrl()` rewrites legacy share queries to canonical `/ipv[46]/<tool>` path form when both `tab` and `tool` are encoded. VLSM tabs (no per-tool routes) stay on the legacy form.
- Legacy `?tab=&tool=` URLs continue to be accepted unchanged — **no redirect**, so iframe embedders and bookmarks are not broken.
- Docs deep links updated to canonical form (7 files: `diff.md`, `sharing.md`, `ipv6.md`, `ipv6-derive.md`, `ipv6-slaac-privacy.md`, `ipv6-zone-id.md`, `lookup.md`). Internal specs/plans that historically describe the legacy form are left untouched.

## Test plan
- [x] PHPUnit green (475 tests, 1120 assertions)
- [x] PHPStan L9 / PHPCS PSR-12 / Spectral / Semgrep / npm lint clean
- [x] Playwright: 3 new test groups (10 assertions) — route equivalence, no-redirect on legacy form, canonical+QSA
- [x] Existing 1228 Playwright tests still green (1238/1238 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)