### PR TITLE
feat(v3.4.0): IPv6 reverse-DNS (rdns6)

### DIFF
--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -349,6 +349,7 @@ paths:
                     - "POST /api/v1/slaac-privacy"
                     - "POST /api/v1/ula"
                     - "POST /api/v1/rdns"
+                    - "POST /api/v1/rdns6"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -1669,6 +1670,94 @@ paths:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
             X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /rdns6:
+    post:
+      operationId: ipv6ToArpa
+      tags: [RDNS]
+      summary: Generate an ip6.arpa zone name for an IPv6 address (RFC 3596)
+      description: |
+        Generates the ip6.arpa zone-delegation name for an IPv6 address
+        and an optional nibble-aligned prefix length. With no prefix (or
+        /128) returns the full reverse name (32 nibbles + ".ip6.arpa").
+        Prefix must be a multiple of 4 — RFC 3596's nibble-boundary
+        requirement for delegation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [address]
+              properties:
+                address:
+                  type: string
+                  description: IPv6 address (compressed or expanded form).
+                  example: "2001:db8::1"
+                prefix:
+                  type: integer
+                  description: Optional prefix length, 0..128, multiple of 4.
+                  minimum: 0
+                  maximum: 128
+                  example: 64
+            examples:
+              full-128:
+                summary: Full reverse name (no prefix)
+                value: { address: "2001:db8::1" }
+              zone-64:
+                summary: /64 zone delegation
+                value: { address: "2001:db8::", prefix: 64 }
+      responses:
+        "200":
+          description: ip6.arpa name
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [address, prefix, arpa]
+                        properties:
+                          address: { type: string,  example: "2001:db8::" }
+                          prefix:  { type: integer, example: 64 }
+                          arpa:    { type: string,  example: "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa" }
+              example:
+                ok: true
+                data:
+                  address: "2001:db8::"
+                  prefix: 64
+                  arpa: "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+        "400":
+          description: Invalid input (invalid address, prefix out of range, or non-nibble-aligned prefix)
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
           content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
   /bulk:
     post:

--- a/Subnet-Calculator/api/v1/handlers/rdns6.php
+++ b/Subnet-Calculator/api/v1/handlers/rdns6.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body       = api_body();
+$raw_addr   = $body['address'] ?? null;
+$raw_prefix = $body['prefix']  ?? null;
+
+if (!is_string($raw_addr) || trim($raw_addr) === '') {
+    json_err('Field "address" (string) is required.', 400);
+}
+$address = trim($raw_addr);
+
+$prefix = null;
+if ($raw_prefix !== null && $raw_prefix !== '') {
+    if (is_int($raw_prefix)) {
+        $prefix = $raw_prefix;
+    } elseif (is_string($raw_prefix) && preg_match('/^-?\d+$/', $raw_prefix) === 1) {
+        $prefix = (int) $raw_prefix;
+    } else {
+        json_err('Field "prefix" must be an integer 0..128 (multiple of 4).', 400);
+    }
+}
+
+try {
+    $arpa = ipv6_to_arpa($address, $prefix);
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'address' => $address,
+    'prefix'  => $prefix ?? 128,
+    'arpa'    => $arpa,
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -26,6 +26,7 @@ require $base . 'functions-supernet6.php';
 require $base . 'functions-zone6.php';
 require $base . 'functions-derive6.php';
 require $base . 'functions-slaac6.php';
+require $base . 'functions-rdns6.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -109,6 +110,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/slaac-privacy',
             'POST /api/v1/ula',
             'POST /api/v1/rdns',
+            'POST /api/v1/rdns6',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -229,6 +231,9 @@ switch ($route_key) {
         break;
     case 'POST /rdns':
         require __DIR__ . '/handlers/rdns.php';
+        break;
+    case 'POST /rdns6':
+        require __DIR__ . '/handlers/rdns6.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-admin-settings.php
+++ b/Subnet-Calculator/includes/functions-admin-settings.php
@@ -126,7 +126,7 @@ function settings_schema(): array
             'type' => 'multiselect', 'default' => [],
             'values' => [
                 'ipv4', 'ipv6', 'vlsm', 'vlsm6', 'overlap', 'split',
-                'supernet', 'ula', 'rdns', 'bulk', 'range', 'tree',
+                'supernet', 'ula', 'rdns', 'rdns6', 'bulk', 'range', 'tree',
                 'tree-presets', 'lookup', 'diff', 'wildcard', 'sessions',
                 'changelog', 'schemas',
             ],

--- a/Subnet-Calculator/includes/functions-rdns6.php
+++ b/Subnet-Calculator/includes/functions-rdns6.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * IPv6 reverse-DNS helpers (RFC 3596).
+ *
+ * Generates ip6.arpa zone names from an IPv6 address and optional
+ * prefix length. Prefix length must be a multiple of 4 — the RFC's
+ * nibble-boundary requirement for delegation.
+ */
+
+/**
+ * Convert an IPv6 address (and optional nibble-aligned prefix length) to
+ * its ip6.arpa form per RFC 3596.
+ *
+ * When $prefix is null (or 128), returns the full reverse name (32
+ * nibbles + ".ip6.arpa"). When $prefix is a non-128 multiple of 4,
+ * returns the corresponding zone-delegation name (the most-significant
+ * $prefix/4 nibbles, reversed and dotted, followed by ".ip6.arpa").
+ * A prefix of 0 returns the bare suffix "ip6.arpa".
+ *
+ * @throws InvalidArgumentException if $address is not a valid IPv6
+ *         literal, or $prefix is not in [0, 128] or not nibble-aligned.
+ */
+function ipv6_to_arpa(string $address, ?int $prefix = null): string
+{
+    $bin = @inet_pton($address);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid IPv6 address');
+    }
+
+    $prefix = $prefix ?? 128;
+    if ($prefix < 0 || $prefix > 128) {
+        throw new InvalidArgumentException('Prefix length must be 0..128');
+    }
+    if ($prefix % 4 !== 0) {
+        throw new InvalidArgumentException(
+            'Prefix length must be a multiple of 4 for ip6.arpa zone delegation'
+        );
+    }
+
+    $hex         = bin2hex($bin); // 32 nibbles, lowercase
+    $nibbles     = (int) ($prefix / 4);
+    $significant = substr($hex, 0, $nibbles);
+    if ($significant === '') {
+        return 'ip6.arpa';
+    }
+    $reversed = strrev($significant);
+    $dotted   = implode('.', str_split($reversed));
+    return $dotted . '.ip6.arpa';
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -299,6 +299,38 @@ function sc_run_slaac(string $prefix, string $seed): array
     ];
 }
 
+// ─── IPv6 reverse-DNS helper (shared by POST handler and GET shareable URL) ─
+
+/**
+ * Run ipv6_to_arpa() and return an associative array with keys:
+ * address, prefix, arpa, error. Empty input returns []. (v3.4.0 Task 8)
+ *
+ * @return array{address?: string, prefix?: int, arpa?: string, error?: string}
+ */
+function sc_run_rdns6(string $address, string $prefix_input): array
+{
+    if ($address === '') {
+        return [];
+    }
+    $prefix = null;
+    if ($prefix_input !== '') {
+        if (preg_match('/^-?\d+$/', $prefix_input) !== 1) {
+            return ['error' => 'Prefix must be an integer 0..128 (multiple of 4).'];
+        }
+        $prefix = (int) $prefix_input;
+    }
+    try {
+        $arpa = ipv6_to_arpa($address, $prefix);
+    } catch (\InvalidArgumentException $e) {
+        return ['error' => $e->getMessage()];
+    }
+    return [
+        'address' => $address,
+        'prefix'  => $prefix ?? 128,
+        'arpa'    => $arpa,
+    ];
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -426,6 +458,12 @@ $slaac_seed_input   = '';
 /** @var array{prefix?: string, address?: string, interface_id?: string, seed_used?: ?string, seed_was_provided?: bool, warning?: ?string, error?: string} */
 $slaac = [];
 
+// v3.4.0 Task 8 — IPv6 reverse-DNS (rdns6)
+$rdns6_address_input = '';
+$rdns6_prefix_input  = '';
+/** @var array{address?: string, prefix?: int, arpa?: string, error?: string} */
+$rdns6 = [];
+
 $ula_global_id_input = '';
 /** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
 $ula = [];
@@ -487,6 +525,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_zoneid        = isset($_POST['zoneid_input']);
     $is_derive        = isset($_POST['derive_mac']);
     $is_slaac         = isset($_POST['slaac_prefix']);
+    $is_rdns6         = isset($_POST['rdns6_address']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -494,7 +533,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_tool = $is_splitter || $is_overlap || $is_multi_overlap || $is_vlsm
         || $is_vlsm6 || $is_supernet || $is_supernet6 || $is_ula || $is_session_save || $is_range
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
-        || $is_derive || $is_slaac;
+        || $is_derive || $is_slaac || $is_rdns6;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -888,6 +927,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $slaac = sc_run_slaac($slaac_prefix_input, $slaac_seed_input);
     }
 
+    if ($is_rdns6 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $rdns6_address_input = trim((string)($_POST['rdns6_address'] ?? ''));
+        $rdns6_prefix_input  = trim((string)($_POST['rdns6_prefix']  ?? ''));
+        $rdns6 = sc_run_rdns6($rdns6_address_input, $rdns6_prefix_input);
+    }
+
     if ($is_ula && !$form_blocked) {
         $ula_global_id_input = trim((string)($_POST['ula_global_id'] ?? ''));
         $ur = generate_ula_prefix($ula_global_id_input);
@@ -1268,6 +1314,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $slaac_prefix_input = trim((string)($_GET['slaac_prefix'] ?? ''));
         $slaac_seed_input   = trim((string)($_GET['slaac_seed']   ?? ''));
         $slaac = sc_run_slaac($slaac_prefix_input, $slaac_seed_input);
+    }
+
+    // IPv6 reverse-DNS shareable GET URL (v3.4.0 Task 8)
+    if ($active_tab === 'ipv6' && isset($_GET['rdns6_address'])) {
+        $rdns6_address_input = trim((string)($_GET['rdns6_address'] ?? ''));
+        $rdns6_prefix_input  = trim((string)($_GET['rdns6_prefix']  ?? ''));
+        $rdns6 = sc_run_rdns6($rdns6_address_input, $rdns6_prefix_input);
     }
 
     // Supernet6 / summarise6 shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -18,6 +18,7 @@ require __DIR__ . '/includes/functions-range6.php';
 require __DIR__ . '/includes/functions-zone6.php';
 require __DIR__ . '/includes/functions-derive6.php';
 require __DIR__ . '/includes/functions-slaac6.php';
+require __DIR__ . '/includes/functions-rdns6.php';
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -762,9 +762,10 @@ if ($i < 3) {
         elseif (!empty($slaac)) { $open_tool_ipv6 = 'slaac'; }
         elseif (!empty($lookup) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'lookup'; }
         elseif (!empty($diff) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'diff'; }
+        elseif (!empty($rdns6)) { $open_tool_ipv6 = 'rdns6'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -780,6 +781,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="slaac" aria-expanded="false">SLAAC Privacy</button>
             <button type="button" class="tool-trigger" data-tool="lookup" aria-expanded="false">IP Lookup</button>
             <button type="button" class="tool-trigger" data-tool="diff" aria-expanded="false">Subnet Diff</button>
+            <button type="button" class="tool-trigger" data-tool="rdns6" aria-expanded="false">Reverse DNS</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -1255,6 +1257,60 @@ if ($i < 3) {
                         <div class="error"><?= htmlspecialchars($diff['error']) ?></div>
                     <?php elseif ($active_tab === 'ipv6' && isset($diff['result'])) : ?>
                         <?php $diff_result = $diff['result']; include __DIR__ . '/_diff_result.php'; ?>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="rdns6">
+                <div class="overlap-panel">
+                    <div class="overlap-title">Reverse DNS (rdns6)<?= help_bubble('ipv6-rdns6', 'Generates the ip6.arpa zone-delegation name for an IPv6 address per RFC 3596. With no prefix (or /128) returns the full reverse name. The prefix length must be a multiple of 4 — that is the nibble boundary required for delegation.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="rdns6_address">IPv6 address<?= help_bubble('rdns6-address', 'Any valid IPv6 literal (compressed or expanded form). Example: 2001:db8::1 or fe80::1.') ?></label>
+                                <input type="text" id="rdns6_address" name="rdns6_address"
+                                       value="<?= htmlspecialchars($rdns6_address_input ?? '') ?>"
+                                       placeholder="2001:db8::1"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($rdns6['error']) ? 'aria-invalid="true" aria-describedby="rdns6-error"' : '' ?>>
+                            </div>
+                            <div class="form-group form-group--mask">
+                                <label for="rdns6_prefix">Prefix <span class="label-footnote">(optional, /4 boundary)</span><?= help_bubble('rdns6-prefix', 'Optional prefix length for zone-delegation form. Must be a multiple of 4 (0, 4, 8, …, 128). Common choices: /48 for ISP delegation, /56 for sub-allocation, /64 for a single LAN. Leave blank or set to 128 for the full reverse name.') ?></label>
+                                <input type="number" id="rdns6_prefix" name="rdns6_prefix" min="0" max="128" step="4"
+                                       value="<?= htmlspecialchars($rdns6_prefix_input ?? '') ?>"
+                                       placeholder="64"
+                                       autocomplete="off">
+                            </div>
+                        </div>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Generate</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($rdns6['error'])) : ?>
+                        <div class="error" id="rdns6-error"><?= htmlspecialchars($rdns6['error']) ?></div>
+                    <?php elseif (isset($rdns6['arpa'])) : ?>
+                        <?php $_rdns6_label = 'rdns6: ' . $rdns6['address'] . '/' . $rdns6['prefix']; ?>
+                        <dl class="zoneid-result"
+                            data-history-source="rdns6"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_rdns6_label) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Address</dt>
+                                <dd class="zoneid-result__value"><code><?= htmlspecialchars((string)$rdns6['address']) ?></code></dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Prefix</dt>
+                                <dd class="zoneid-result__value"><code>/<?= htmlspecialchars((string)$rdns6['prefix']) ?></code></dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">ip6.arpa zone</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$rdns6['arpa']) ?></code>
+                                    <?= copy_button((string)$rdns6['arpa'], 'Copy ip6.arpa zone name') ?>
+                                </dd>
+                            </div>
+                        </dl>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/ipv6-rdns6.md
+++ b/docs/ipv6-rdns6.md
@@ -1,0 +1,101 @@
+# IPv6 Reverse DNS (rdns6)
+
+The IPv6 reverse-DNS tool is in the **Tool Drawer** on the IPv6 tab. Enter
+an IPv6 address with an optional nibble-aligned prefix length, and the tool
+returns the corresponding `ip6.arpa` zone-delegation name per RFC 3596.
+
+This is the IPv6 counterpart to the IPv4 [Reverse DNS Zones](rdns.md) tool,
+focused on producing a clean, copy-pasteable zone name. Use the IPv4 rdns
+tool for full BIND zone-file generation; the IPv6 reverse-DNS tool is
+deliberately scoped to the zone name itself.
+
+## Synopsis
+
+| Input        | Required | Type    | Notes                                       |
+|--------------|----------|---------|---------------------------------------------|
+| Address      | Yes      | string  | Any valid IPv6 literal (compressed/expanded)|
+| Prefix       | No       | integer | 0..128, must be a multiple of 4             |
+
+| Output  | Type    | Notes                                                      |
+|---------|---------|------------------------------------------------------------|
+| address | string  | Echoed input address                                       |
+| prefix  | integer | Echoed prefix (defaults to 128 when omitted)               |
+| arpa    | string  | The `ip6.arpa` zone-delegation name (RFC 3596)             |
+
+## What is `ip6.arpa`?
+
+The `ip6.arpa` namespace is the IPv6 reverse-DNS tree. Every IPv6 address
+maps to a unique PTR record under `ip6.arpa` formed by reversing the 32
+nibbles of the address and joining them with dots.
+
+For zone delegation, you publish a name covering the most-significant
+N nibbles (where N = prefix / 4), reversed. RFC 3596 requires N to land
+on a nibble boundary — a multiple of 4 bits — because the DNS hierarchy
+splits one nibble per label.
+
+## Examples
+
+| Address       | Prefix | `ip6.arpa` name                                                            |
+|---------------|--------|---------------------------------------------------------------------------|
+| `2001:db8::1` | (none) | `1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa` |
+| `2001:db8:abcd::` | 48 | `d.c.b.a.8.b.d.0.1.0.0.2.ip6.arpa`                                          |
+| `2001:db8::`  | 64     | `0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa`                                |
+| `fe80::1`     | 64     | `0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa`                                |
+| `2001:db8::`  | 0      | `ip6.arpa`                                                                |
+
+## Validation rules
+
+- **Address** must parse via `inet_pton()` to a 16-byte IPv6 literal. Both
+  compressed (`2001:db8::1`) and expanded (`2001:0db8:0000:…`) forms work
+  and canonicalise to the same nibble sequence.
+- **Prefix** (if present) must be in the range `0..128` and must be a
+  multiple of 4. Non-nibble-aligned values such as `49` or `65` are
+  rejected with a clear error — RFC 3596 zone delegation has no defined
+  representation off a nibble boundary.
+- A prefix of `0` returns the bare suffix `ip6.arpa`.
+
+## API
+
+`POST /api/v1/rdns6`
+
+```json
+{
+  "address": "2001:db8::",
+  "prefix": 64
+}
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "address": "2001:db8::",
+    "prefix": 64,
+    "arpa": "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+  }
+}
+```
+
+The `prefix` field is optional — omit it (or pass `128`) to get the full
+reverse name for a single host.
+
+## Errors
+
+| Error                                                              | Cause                                          |
+|--------------------------------------------------------------------|------------------------------------------------|
+| `Invalid IPv6 address`                                             | Address fails `inet_pton()`                    |
+| `Prefix length must be 0..128`                                     | Prefix outside the legal IPv6 prefix range     |
+| `Prefix length must be a multiple of 4 for ip6.arpa zone delegation` | Non-nibble-aligned prefix (e.g. `/49`, `/65`) |
+
+## Shareable URLs
+
+The tool supports the standard tab + tool URL pattern:
+
+```text
+?tab=ipv6&rdns6_address=2001:db8::&rdns6_prefix=64
+```
+
+Open the link and the rdns6 drawer auto-opens with the result already
+calculated.

--- a/docs/superpowers/plans/v3.4.0-living-doc.md
+++ b/docs/superpowers/plans/v3.4.0-living-doc.md
@@ -38,7 +38,7 @@ its PR opens.
 | 5 | T5 | `request.php` flat globals → per-tool arrays | in-review (PR #379) | `eebfc09` | T4 |
 | 6 | T6 | IPv6 type-detection → `functions-type6.php` | in-review (PR #380) | `19f0731` | T5 |
 | 7 | T7 | Per-tool URL routes (`/ipv6/<tool>`) | in-review (PR #381) | `c1ba078` | T6 |
-| 8 | T8 | IPv6 reverse-DNS (rdns6) | pending | — | T7 |
+| 8 | T8 | IPv6 reverse-DNS (rdns6) | in-review (PR #382) | `6c63844` | T7 |
 | 9 | T9 | IPv4-mapped / NAT64 (mapped6) | pending | — | T8 |
 | 10 | T10 | Bulk endpoint covers new IPv6 endpoints | pending | — | T9 |
 | 11 | T11 | A11y audit + fix 5 new IPv6 drawers | pending | — | T10 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - IPv6 ULA Generator: ula.md
     - Binary / Hex Panel: binary.md
     - Reverse DNS Zones: rdns.md
+    - IPv6 Reverse DNS (rdns6): ipv6-rdns6.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -2709,6 +2709,100 @@ async def test_api_rdns(page: Page) -> None:
     assert_contains("api rdns: /25 zone has classless format", data5.get("data", {}).get("zone", ""), "/25")
 
 
+async def test_api_rdns6(page: Page) -> None:
+    section("API — POST /api/v1/rdns6")
+    # /64 zone delegation
+    status, data = _api_post("rdns6", {"address": "2001:db8::1", "prefix": 64})
+    assert_eq("api rdns6: HTTP 200", status, 200)
+    assert_eq("api rdns6: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api rdns6: address echoed", d.get("address"), "2001:db8::1")
+    assert_eq("api rdns6: prefix echoed", d.get("prefix"), 64)
+    assert_eq("api rdns6: arpa /64",
+              d.get("arpa"), "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa")
+
+    # No prefix → full reverse name
+    status2, data2 = _api_post("rdns6", {"address": "2001:db8::1"})
+    assert_eq("api rdns6: HTTP 200 (no prefix)", status2, 200)
+    assert_eq("api rdns6: full reverse name",
+              data2.get("data", {}).get("arpa"),
+              "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa")
+    assert_eq("api rdns6: prefix defaults to 128",
+              data2.get("data", {}).get("prefix"), 128)
+
+    # Non-nibble-aligned prefix → 400
+    status3, data3 = _api_post("rdns6", {"address": "2001:db8::", "prefix": 49})
+    assert_eq("api rdns6: /49 → 400", status3, 400)
+    assert_eq("api rdns6 err: ok=false", data3.get("ok"), False)
+
+    # Missing address → 400
+    status4, _ = _api_post("rdns6", {})
+    assert_eq("api rdns6: missing address → 400", status4, 400)
+
+    # Invalid address → 400
+    status5, _ = _api_post("rdns6", {"address": "not-an-address"})
+    assert_eq("api rdns6: invalid address → 400", status5, 400)
+
+
+async def test_ipv6_rdns6_ui(page: Page) -> None:
+    section("IPv6 reverse-DNS (rdns6) UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # T7 per-tool URL routing — /ipv6/rdns6 should auto-open the drawer.
+    # Test harness serves under /testing/sc/ so use the ?tool= equivalent that
+    # the rewrite produces (works regardless of base path).
+    await navigate(page, APP_URL + "?tab=ipv6&tool=rdns6")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='rdns6']")
+    assert_eq("rdns6 UI: panel exists", await panel.count(), 1)
+
+    # Submit address + /64 prefix
+    await page.fill("#rdns6_address", "2001:db8::1")
+    await page.fill("#rdns6_prefix", "64")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='rdns6'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='rdns6']")
+    rows = panel.locator(".zoneid-result__row")
+    assert_eq("rdns6 UI: three result rows", await rows.count(), 3)
+    arpa_text = await rows.nth(2).locator(".zoneid-result__value code").text_content() or ""
+    assert_eq("rdns6 UI: arpa zone /64",
+              arpa_text.strip(),
+              "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa")
+    assert_eq("rdns6 UI: no error band",
+              await panel.locator(".error").count(), 0)
+
+    # Click copy button
+    await rows.nth(2).locator(".subnet-copy").click()
+    await page.wait_for_timeout(50)
+    clip = await page.evaluate("window.__lastClipboard")
+    assert_eq("rdns6 UI: copy ip6.arpa zone",
+              clip, "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa")
+
+    # Error path — non-nibble-aligned
+    await navigate(page, APP_URL + "?tab=ipv6&tool=rdns6")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#rdns6_address", "2001:db8::")
+    await page.fill("#rdns6_prefix", "49")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='rdns6'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='rdns6']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("rdns6 UI: error band visible on /49",
+                len(err_text) > 0, f"got: {err_text!r}")
+    assert_eq("rdns6 UI: no result rows on error",
+              await panel.locator(".zoneid-result__row").count(), 0)
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -7394,6 +7488,8 @@ async def main() -> None:
             await test_ipv6_slaac_copy_buttons(page)
             await test_ipv6_slaac_shareable_url(page)
             await test_api_slaac(page)
+            await test_ipv6_rdns6_ui(page)
+            await test_api_rdns6(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)
             await test_tooltips_accessibility(page)

--- a/testing/unit/Rdns6Test.php
+++ b/testing/unit/Rdns6Test.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class Rdns6Test extends TestCase
+{
+    public function testFullAddressArpa(): void
+    {
+        $r = ipv6_to_arpa('2001:db8::1');
+        $this->assertSame(
+            '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+            $r
+        );
+    }
+
+    public function testZoneDelegationAtSlash48(): void
+    {
+        $r = ipv6_to_arpa('2001:db8:abcd::', 48);
+        $this->assertSame('d.c.b.a.8.b.d.0.1.0.0.2.ip6.arpa', $r);
+    }
+
+    public function testZoneDelegationAtSlash64(): void
+    {
+        $r = ipv6_to_arpa('2001:db8::', 64);
+        $this->assertSame('0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa', $r);
+    }
+
+    public function testRejectsNonNibbleAlignedPrefix(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv6_to_arpa('2001:db8::', 49);
+    }
+
+    public function testFullSlash128IsFullArpa(): void
+    {
+        $r1 = ipv6_to_arpa('2001:db8::1', 128);
+        $r2 = ipv6_to_arpa('2001:db8::1');
+        $this->assertSame($r2, $r1);
+    }
+
+    public function testLinkLocal(): void
+    {
+        $r = ipv6_to_arpa('fe80::1', 64);
+        $this->assertSame('0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa', $r);
+    }
+
+    public function testRejectsInvalidAddress(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv6_to_arpa('not-an-address');
+    }
+
+    public function testZeroPrefixReturnsBareSuffix(): void
+    {
+        $r = ipv6_to_arpa('2001:db8::', 0);
+        $this->assertSame('ip6.arpa', $r);
+    }
+
+    public function testRejectsPrefixOutOfRange(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv6_to_arpa('2001:db8::', 129);
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -17,6 +17,7 @@ require $base . 'functions-supernet6.php';
 require $base . 'functions-zone6.php';
 require $base . 'functions-derive6.php';
 require $base . 'functions-slaac6.php';
+require $base . 'functions-rdns6.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

New tool E (Task 8): IPv6 reverse-DNS. Generates `ip6.arpa` zone names from an IPv6 address + optional nibble-aligned prefix (RFC 3596).

- Module: `Subnet-Calculator/includes/functions-rdns6.php` — `ipv6_to_arpa($address, ?$prefix)`
- API: `POST /api/v1/rdns6` (mirrors the existing `/rdns` operation shape; added to meta listing + admin allowlist)
- OpenAPI: `/rdns6` operation + 200/400/401/404/429 responses
- Drawer: IPv6 tab → "Reverse DNS"; auto-opens via `/ipv6/rdns6` (T7 per-tool URL routing — `rdns6` added to the `$ipv6_tool_whitelist`)
- Helper: `sc_run_rdns6()` in `request.php` follows the post-T5 per-tool array pattern (`$rdns6 = []` empty default, helper returns `array{address?, prefix?, arpa?, error?}`, dispatched on POST `rdns6_address` and GET hydration via `?rdns6_address=…&rdns6_prefix=…`)
- Tests: 9 PHPUnit cases (`testing/unit/Rdns6Test.php`) + 2 Playwright groups (`test_ipv6_rdns6_ui`, `test_api_rdns6`)
- Docs: `docs/ipv6-rdns6.md` (new page mirroring the structure of `docs/ipv6-zone-id.md`) + `mkdocs.yml` nav entry under "Calculator"

## Parity with the v4 `rdns` drawer

The v4 `rdns` tool generates a full BIND zone file (SOA + NS + PTR records) and has a richer input surface (cidr, ns, hostmaster, ttl, serial, domain). This rdns6 tool is deliberately scoped to the **zone name** itself — the natural fit for IPv6 reverse delegation, where operators most often need the right `ip6.arpa` label rather than a full zone-file body. The drawer UX, copy buttons, error/result rendering, and shareable URL pattern all mirror the existing IPv6 tools (zoneid, derive, slaac). No new design tokens, no new top-level tab, dark-text on teal buttons, `help_bubble()` on every input, `copy_button()` on the output.

## Constraints honoured

- New tool slug is `rdns6` (whitelisted in T7's `$ipv6_tool_whitelist`).
- Public API name is `ipv6_to_arpa` (matches Rdns6Test assertions).
- Non-nibble-aligned prefixes rejected with `InvalidArgumentException` (RFC 3596 boundary requirement).

## Test plan

- [x] PHPUnit (Rdns6Test green, full suite 484 tests, +9 new)
- [x] PHPStan L9, PHPCS PSR-12, Spectral, Semgrep, npm lint clean
- [x] Playwright tests: full suite 1275/1275 passed (UI drawer + API both green)
- [x] OpenAPI Spectral: zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)