### PR TITLE
feat(v3.4.0): IPv4-mapped / NAT64 (mapped6)

### DIFF
--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -63,6 +63,8 @@ tags:
     description: VLSM session persistence
   - name: RDNS
     description: Reverse-DNS zone generation
+  - name: Mapped6
+    description: IPv4-mapped IPv6 and NAT64 conversion
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -350,6 +352,7 @@ paths:
                     - "POST /api/v1/ula"
                     - "POST /api/v1/rdns"
                     - "POST /api/v1/rdns6"
+                    - "POST /api/v1/mapped6"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -1732,6 +1735,109 @@ paths:
                   arpa: "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
         "400":
           description: Invalid input (invalid address, prefix out of range, or non-nibble-aligned prefix)
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /mapped6:
+    post:
+      operationId: mappedNat64Convert
+      tags: [Mapped6]
+      summary: Convert between IPv4, IPv4-mapped IPv6, and NAT64 IPv6
+      description: |
+        Bidirectional conversion between an IPv4 dotted-quad, an
+        IPv4-mapped IPv6 address (`::ffff:0:0/96`, RFC 4291 §2.5.5.2),
+        and a NAT64 IPv6 address (RFC 6052). Accepts any of the three
+        forms as `input` and returns all four representations
+        (IPv4, IPv4-mapped, NAT64, NAT64 prefix used).
+
+        The default NAT64 prefix is the well-known `64:ff9b::/96`. An
+        operator-supplied custom NAT64 prefix is accepted via
+        `nat64_prefix` and must be in `/96` form — the other RFC 6052
+        prefix lengths (`/32`, `/40`, `/48`, `/56`, `/64`) are not
+        supported by this endpoint.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [input]
+              properties:
+                input:
+                  type: string
+                  description: An IPv4 address, an IPv4-mapped IPv6 address, or a NAT64 IPv6 address within the supplied prefix.
+                  example: "192.0.2.1"
+                nat64_prefix:
+                  type: string
+                  description: NAT64 prefix in `/96` form. Defaults to `64:ff9b::/96`.
+                  default: "64:ff9b::/96"
+                  example: "64:ff9b::/96"
+            examples:
+              ipv4-in:
+                summary: IPv4 input
+                value: { input: "192.0.2.1" }
+              mapped-in:
+                summary: IPv4-mapped IPv6 input
+                value: { input: "::ffff:192.0.2.1" }
+              nat64-in:
+                summary: NAT64 IPv6 input (well-known prefix)
+                value: { input: "64:ff9b::c000:201" }
+              custom-prefix:
+                summary: Custom /96 NAT64 prefix
+                value: { input: "192.0.2.1", nat64_prefix: "2001:db8:1::/96" }
+      responses:
+        "200":
+          description: All four representations of the address
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [input, ipv4, ipv4_mapped, nat64, nat64_prefix]
+                        properties:
+                          input:        { type: string, example: "192.0.2.1" }
+                          ipv4:         { type: string, example: "192.0.2.1" }
+                          ipv4_mapped:  { type: string, example: "::ffff:192.0.2.1" }
+                          nat64:        { type: string, example: "64:ff9b::c000:201" }
+                          nat64_prefix: { type: string, example: "64:ff9b::/96" }
+              example:
+                ok: true
+                data:
+                  input: "192.0.2.1"
+                  ipv4: "192.0.2.1"
+                  ipv4_mapped: "::ffff:192.0.2.1"
+                  nat64: "64:ff9b::c000:201"
+                  nat64_prefix: "64:ff9b::/96"
+        "400":
+          description: Invalid input (unparseable address, not within supplied prefix, or non-/96 NAT64 prefix)
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/mapped6.php
+++ b/Subnet-Calculator/api/v1/handlers/mapped6.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body         = api_body();
+$raw_input    = $body['input']        ?? null;
+$raw_prefix   = $body['nat64_prefix'] ?? null;
+
+if (!is_string($raw_input) || trim($raw_input) === '') {
+    json_err('Field "input" (string) is required.', 400);
+}
+$input = trim($raw_input);
+
+$prefix = NAT64_DEFAULT_PREFIX;
+if ($raw_prefix !== null && $raw_prefix !== '') {
+    if (!is_string($raw_prefix)) {
+        json_err('Field "nat64_prefix" must be a string in /96 form.', 400);
+    }
+    $prefix = trim($raw_prefix);
+}
+
+try {
+    if (filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+        $v4     = $input;
+        $mapped = ipv4_to_mapped($v4);
+        $nat64  = ipv4_to_nat64($v4, $prefix);
+    } elseif (is_ipv4_mapped($input)) {
+        $v4     = mapped_to_ipv4($input);
+        $mapped = $input;
+        $nat64  = ipv4_to_nat64($v4, $prefix);
+    } elseif (is_nat64($input, $prefix)) {
+        $v4     = nat64_to_ipv4($input, $prefix);
+        $mapped = ipv4_to_mapped($v4);
+        $nat64  = $input;
+    } else {
+        json_err(
+            'Input is not IPv4, IPv4-mapped IPv6, or NAT64 IPv6 within the supplied prefix.',
+            400
+        );
+    }
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'input'        => $input,
+    'ipv4'         => $v4,
+    'ipv4_mapped'  => $mapped,
+    'nat64'        => $nat64,
+    'nat64_prefix' => $prefix,
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -27,6 +27,7 @@ require $base . 'functions-zone6.php';
 require $base . 'functions-derive6.php';
 require $base . 'functions-slaac6.php';
 require $base . 'functions-rdns6.php';
+require $base . 'functions-mapped6.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -111,6 +112,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/ula',
             'POST /api/v1/rdns',
             'POST /api/v1/rdns6',
+            'POST /api/v1/mapped6',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -234,6 +236,9 @@ switch ($route_key) {
         break;
     case 'POST /rdns6':
         require __DIR__ . '/handlers/rdns6.php';
+        break;
+    case 'POST /mapped6':
+        require __DIR__ . '/handlers/mapped6.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-admin-settings.php
+++ b/Subnet-Calculator/includes/functions-admin-settings.php
@@ -126,7 +126,7 @@ function settings_schema(): array
             'type' => 'multiselect', 'default' => [],
             'values' => [
                 'ipv4', 'ipv6', 'vlsm', 'vlsm6', 'overlap', 'split',
-                'supernet', 'ula', 'rdns', 'rdns6', 'bulk', 'range', 'tree',
+                'supernet', 'ula', 'rdns', 'rdns6', 'mapped6', 'bulk', 'range', 'tree',
                 'tree-presets', 'lookup', 'diff', 'wildcard', 'sessions',
                 'changelog', 'schemas',
             ],

--- a/Subnet-Calculator/includes/functions-mapped6.php
+++ b/Subnet-Calculator/includes/functions-mapped6.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+// IPv4-mapped IPv6 (RFC 4291 §2.5.5.2) and NAT64 (RFC 6052) conversion
+// helpers.
+//
+// Supports the IPv4-mapped prefix `::ffff:0:0/96` and the well-known NAT64
+// prefix `64:ff9b::/96`, plus operator-supplied custom NAT64 prefixes
+// (must be /96 — RFC 6052 §2.2 also defines /32, /40, /48, /56, /64
+// variants but this tool covers only the most common /96 form).
+
+const MAPPED6_PREFIX_BIN  = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff";
+const NAT64_DEFAULT_PREFIX = '64:ff9b::/96';
+
+/**
+ * Return true if $address parses as a valid IPv6 literal whose top 96
+ * bits are `::ffff:0:0` (the IPv4-mapped IPv6 prefix). Returns false
+ * for invalid input rather than throwing.
+ */
+function is_ipv4_mapped(string $address): bool
+{
+    $bin = @inet_pton($address);
+    return $bin !== false
+        && strlen($bin) === 16
+        && substr($bin, 0, 12) === MAPPED6_PREFIX_BIN;
+}
+
+/**
+ * Convert an IPv4 address (dotted-quad) to its IPv4-mapped IPv6 form.
+ *
+ * @throws InvalidArgumentException if $v4 is not a valid IPv4 literal.
+ */
+function ipv4_to_mapped(string $v4): string
+{
+    $bin = @inet_pton($v4);
+    if ($bin === false || strlen($bin) !== 4) {
+        throw new InvalidArgumentException('Invalid IPv4 address');
+    }
+    $v6bin = MAPPED6_PREFIX_BIN . $bin;
+    $out   = @inet_ntop($v6bin);
+    if ($out === false) {
+        throw new InvalidArgumentException('Failed to format IPv4-mapped IPv6 address');
+    }
+    return $out;
+}
+
+/**
+ * Extract the embedded IPv4 from an IPv4-mapped IPv6 address.
+ *
+ * @throws InvalidArgumentException if $v6 is not a valid IPv4-mapped
+ *         IPv6 literal.
+ */
+function mapped_to_ipv4(string $v6): string
+{
+    if (!is_ipv4_mapped($v6)) {
+        throw new InvalidArgumentException('Not an IPv4-mapped IPv6 address');
+    }
+    $bin = inet_pton($v6);
+    /** @var string $bin — guaranteed by is_ipv4_mapped() */
+    $out = @inet_ntop(substr($bin, 12, 4));
+    if ($out === false) {
+        throw new InvalidArgumentException('Failed to extract IPv4 from mapped address');
+    }
+    return $out;
+}
+
+/**
+ * Parse a `<address>/96` prefix string and return the binary
+ * representation of its top 12 bytes.
+ *
+ * @throws InvalidArgumentException if $prefix is not a /96 literal.
+ *
+ * @internal helper for the NAT64 functions.
+ */
+function _nat64_prefix_bin(string $prefix): string
+{
+    if (preg_match('#^(.+)/96$#', $prefix, $m) !== 1) {
+        throw new InvalidArgumentException('NAT64 prefix must be /96');
+    }
+    $bin = @inet_pton($m[1]);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid NAT64 prefix address');
+    }
+    return substr($bin, 0, 12);
+}
+
+/**
+ * Return true if $address is a valid IPv6 literal whose top 96 bits
+ * match the supplied NAT64 prefix. Returns false (no throw) for any
+ * invalid input — callers that need strict validation should use
+ * nat64_to_ipv4() / ipv4_to_nat64().
+ */
+function is_nat64(string $address, string $prefix = NAT64_DEFAULT_PREFIX): bool
+{
+    $bin = @inet_pton($address);
+    if ($bin === false || strlen($bin) !== 16) {
+        return false;
+    }
+    try {
+        return substr($bin, 0, 12) === _nat64_prefix_bin($prefix);
+    } catch (InvalidArgumentException) {
+        return false;
+    }
+}
+
+/**
+ * Embed an IPv4 address inside the supplied NAT64 prefix.
+ *
+ * @throws InvalidArgumentException if $v4 is not a valid IPv4 literal,
+ *         or $prefix is not a /96 NAT64 prefix.
+ */
+function ipv4_to_nat64(string $v4, string $prefix = NAT64_DEFAULT_PREFIX): string
+{
+    $v4bin = @inet_pton($v4);
+    if ($v4bin === false || strlen($v4bin) !== 4) {
+        throw new InvalidArgumentException('Invalid IPv4 address');
+    }
+    $prefBin = _nat64_prefix_bin($prefix);
+    $out     = @inet_ntop($prefBin . $v4bin);
+    if ($out === false) {
+        throw new InvalidArgumentException('Failed to format NAT64 IPv6 address');
+    }
+    return $out;
+}
+
+/**
+ * Extract the embedded IPv4 from a NAT64 IPv6 address.
+ *
+ * @throws InvalidArgumentException if $v6 is not within $prefix or
+ *         $prefix is not a /96 NAT64 prefix.
+ */
+function nat64_to_ipv4(string $v6, string $prefix = NAT64_DEFAULT_PREFIX): string
+{
+    if (!is_nat64($v6, $prefix)) {
+        throw new InvalidArgumentException('Address is not within the supplied NAT64 prefix');
+    }
+    $bin = inet_pton($v6);
+    /** @var string $bin — guaranteed by is_nat64() */
+    $out = @inet_ntop(substr($bin, 12, 4));
+    if ($out === false) {
+        throw new InvalidArgumentException('Failed to extract IPv4 from NAT64 address');
+    }
+    return $out;
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -331,6 +331,71 @@ function sc_run_rdns6(string $address, string $prefix_input): array
     ];
 }
 
+// ─── IPv4-mapped / NAT64 helper (shared by POST handler and GET shareable URL) ─
+
+/**
+ * Run mapped6 conversions against any of the three supported input forms
+ * (IPv4, IPv4-mapped IPv6, NAT64 IPv6 within the supplied /96 prefix) and
+ * return all four representations. Empty input returns []. (v3.4.0 Task 9)
+ *
+ * @param array<string,mixed> $input
+ *
+ * @return array{
+ *     input?: string,
+ *     ipv4?: string,
+ *     ipv4_mapped?: string,
+ *     nat64?: string,
+ *     nat64_prefix?: string,
+ *     error?: string|null
+ * }
+ */
+function sc_run_mapped6(array $input): array
+{
+    $raw    = trim((string)($input['input'] ?? ''));
+    $prefix = trim((string)($input['nat64_prefix'] ?? ''));
+    if ($prefix === '') {
+        $prefix = NAT64_DEFAULT_PREFIX;
+    }
+    if ($raw === '') {
+        return [];
+    }
+    try {
+        if (filter_var($raw, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            $v4     = $raw;
+            $mapped = ipv4_to_mapped($v4);
+            $nat64  = ipv4_to_nat64($v4, $prefix);
+        } elseif (is_ipv4_mapped($raw)) {
+            $v4     = mapped_to_ipv4($raw);
+            $mapped = $raw;
+            $nat64  = ipv4_to_nat64($v4, $prefix);
+        } elseif (is_nat64($raw, $prefix)) {
+            $v4     = nat64_to_ipv4($raw, $prefix);
+            $mapped = ipv4_to_mapped($v4);
+            $nat64  = $raw;
+        } else {
+            return [
+                'input'        => $raw,
+                'nat64_prefix' => $prefix,
+                'error'        => 'Input is not IPv4, IPv4-mapped IPv6, or NAT64 IPv6 within the supplied prefix.',
+            ];
+        }
+    } catch (\InvalidArgumentException $e) {
+        return [
+            'input'        => $raw,
+            'nat64_prefix' => $prefix,
+            'error'        => $e->getMessage(),
+        ];
+    }
+    return [
+        'input'        => $raw,
+        'ipv4'         => $v4,
+        'ipv4_mapped'  => $mapped,
+        'nat64'        => $nat64,
+        'nat64_prefix' => $prefix,
+        'error'        => null,
+    ];
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -464,6 +529,12 @@ $rdns6_prefix_input  = '';
 /** @var array{address?: string, prefix?: int, arpa?: string, error?: string} */
 $rdns6 = [];
 
+// v3.4.0 Task 9 — IPv4-mapped / NAT64 (mapped6)
+$mapped6_input        = '';
+$mapped6_prefix_input = '';
+/** @var array{input?: string, ipv4?: string, ipv4_mapped?: string, nat64?: string, nat64_prefix?: string, error?: string|null} */
+$mapped6 = [];
+
 $ula_global_id_input = '';
 /** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
 $ula = [];
@@ -526,6 +597,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_derive        = isset($_POST['derive_mac']);
     $is_slaac         = isset($_POST['slaac_prefix']);
     $is_rdns6         = isset($_POST['rdns6_address']);
+    $is_mapped6       = isset($_POST['mapped6_input']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -533,7 +605,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_tool = $is_splitter || $is_overlap || $is_multi_overlap || $is_vlsm
         || $is_vlsm6 || $is_supernet || $is_supernet6 || $is_ula || $is_session_save || $is_range
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
-        || $is_derive || $is_slaac || $is_rdns6;
+        || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -934,6 +1006,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $rdns6 = sc_run_rdns6($rdns6_address_input, $rdns6_prefix_input);
     }
 
+    if ($is_mapped6 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $mapped6_input        = trim((string)($_POST['mapped6_input']        ?? ''));
+        $mapped6_prefix_input = trim((string)($_POST['mapped6_nat64_prefix'] ?? ''));
+        $mapped6 = sc_run_mapped6([
+            'input'        => $mapped6_input,
+            'nat64_prefix' => $mapped6_prefix_input,
+        ]);
+    }
+
     if ($is_ula && !$form_blocked) {
         $ula_global_id_input = trim((string)($_POST['ula_global_id'] ?? ''));
         $ur = generate_ula_prefix($ula_global_id_input);
@@ -1321,6 +1403,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $rdns6_address_input = trim((string)($_GET['rdns6_address'] ?? ''));
         $rdns6_prefix_input  = trim((string)($_GET['rdns6_prefix']  ?? ''));
         $rdns6 = sc_run_rdns6($rdns6_address_input, $rdns6_prefix_input);
+    }
+
+    // IPv4-mapped / NAT64 shareable GET URL (v3.4.0 Task 9)
+    if ($active_tab === 'ipv6' && isset($_GET['mapped6_input'])) {
+        $mapped6_input        = trim((string)($_GET['mapped6_input']        ?? ''));
+        $mapped6_prefix_input = trim((string)($_GET['mapped6_nat64_prefix'] ?? ''));
+        $mapped6 = sc_run_mapped6([
+            'input'        => $mapped6_input,
+            'nat64_prefix' => $mapped6_prefix_input,
+        ]);
     }
 
     // Supernet6 / summarise6 shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -19,6 +19,7 @@ require __DIR__ . '/includes/functions-zone6.php';
 require __DIR__ . '/includes/functions-derive6.php';
 require __DIR__ . '/includes/functions-slaac6.php';
 require __DIR__ . '/includes/functions-rdns6.php';
+require __DIR__ . '/includes/functions-mapped6.php';
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -763,9 +763,10 @@ if ($i < 3) {
         elseif (!empty($lookup) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'lookup'; }
         elseif (!empty($diff) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'diff'; }
         elseif (!empty($rdns6)) { $open_tool_ipv6 = 'rdns6'; }
+        elseif (!empty($mapped6)) { $open_tool_ipv6 = 'mapped6'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -782,6 +783,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="lookup" aria-expanded="false">IP Lookup</button>
             <button type="button" class="tool-trigger" data-tool="diff" aria-expanded="false">Subnet Diff</button>
             <button type="button" class="tool-trigger" data-tool="rdns6" aria-expanded="false">Reverse DNS</button>
+            <button type="button" class="tool-trigger" data-tool="mapped6" aria-expanded="false">IPv4-mapped / NAT64</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -1309,6 +1311,75 @@ if ($i < 3) {
                                     <code><?= htmlspecialchars((string)$rdns6['arpa']) ?></code>
                                     <?= copy_button((string)$rdns6['arpa'], 'Copy ip6.arpa zone name') ?>
                                 </dd>
+                            </div>
+                        </dl>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="mapped6">
+                <div class="overlap-panel">
+                    <div class="overlap-title">IPv4-mapped / NAT64 (mapped6)<?= help_bubble('ipv6-mapped6', 'Bidirectional convert between IPv4, IPv4-mapped IPv6 (::ffff:0:0/96, RFC 4291) and NAT64 IPv6 (64:ff9b::/96 default, RFC 6052). Accepts any of the three forms; renders all four representations. Custom NAT64 prefix supported via the Advanced disclosure (must be /96).') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="mapped6_input">Address<?= help_bubble('mapped6-input', 'Any one of: an IPv4 dotted-quad (192.0.2.1), an IPv4-mapped IPv6 (::ffff:192.0.2.1), or a NAT64 IPv6 within the supplied prefix (64:ff9b::c000:201).') ?></label>
+                                <input type="text" id="mapped6_input" name="mapped6_input"
+                                       value="<?= htmlspecialchars($mapped6_input ?? '') ?>"
+                                       placeholder="192.0.2.1"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($mapped6['error']) ? 'aria-invalid="true" aria-describedby="mapped6-error"' : '' ?>>
+                            </div>
+                        </div>
+                        <details class="slaac-advanced"<?= ($mapped6_prefix_input ?? '') !== '' ? ' open' : '' ?>>
+                            <summary>Advanced — custom NAT64 prefix</summary>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="mapped6_nat64_prefix">NAT64 prefix <span class="label-footnote">(/96 only)</span><?= help_bubble('mapped6-nat64-prefix', 'Optional NAT64 prefix in /96 form. Defaults to the well-known 64:ff9b::/96 (RFC 6052). Operator-supplied custom prefixes such as 2001:db8:1::/96 are accepted. Non-/96 prefixes are rejected.') ?></label>
+                                    <input type="text" id="mapped6_nat64_prefix" name="mapped6_nat64_prefix"
+                                           value="<?= htmlspecialchars($mapped6_prefix_input ?? '') ?>"
+                                           placeholder="64:ff9b::/96"
+                                           autocomplete="off" spellcheck="false">
+                                </div>
+                            </div>
+                        </details>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Convert</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($mapped6['error'])) : ?>
+                        <div class="error" id="mapped6-error"><?= htmlspecialchars((string)$mapped6['error']) ?></div>
+                    <?php elseif (isset($mapped6['ipv4'])) : ?>
+                        <?php $_mapped6_label = 'mapped6: ' . $mapped6['input']; ?>
+                        <dl class="zoneid-result"
+                            data-history-source="mapped6"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_mapped6_label) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">IPv4</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$mapped6['ipv4']) ?></code>
+                                    <?= copy_button((string)$mapped6['ipv4'], 'Copy IPv4 address') ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">IPv4-mapped IPv6</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$mapped6['ipv4_mapped']) ?></code>
+                                    <?= copy_button((string)$mapped6['ipv4_mapped'], 'Copy IPv4-mapped IPv6') ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">NAT64 IPv6</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$mapped6['nat64']) ?></code>
+                                    <?= copy_button((string)$mapped6['nat64'], 'Copy NAT64 IPv6') ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">NAT64 prefix</dt>
+                                <dd class="zoneid-result__value"><code><?= htmlspecialchars((string)$mapped6['nat64_prefix']) ?></code></dd>
                             </div>
                         </dl>
                     <?php endif; ?>

--- a/docs/ipv6-mapped6.md
+++ b/docs/ipv6-mapped6.md
@@ -1,0 +1,120 @@
+# IPv4-mapped / NAT64 (mapped6)
+
+The IPv4-mapped / NAT64 tool is in the **Tool Drawer** on the IPv6 tab.
+Enter an IPv4 dotted-quad, an IPv4-mapped IPv6 (`::ffff:0:0/96`, RFC 4291),
+or a NAT64 IPv6 (`64:ff9b::/96` default, RFC 6052), and the tool returns
+all four representations of the same address.
+
+The drawer auto-opens via the per-tool URL route `/ipv6/mapped6`.
+
+## Synopsis
+
+| Input         | Required | Type   | Notes                                                                 |
+|---------------|----------|--------|-----------------------------------------------------------------------|
+| Address       | Yes      | string | Any of: IPv4 (`192.0.2.1`), IPv4-mapped (`::ffff:192.0.2.1`), or NAT64 IPv6 within the supplied prefix (`64:ff9b::c000:201`) |
+| NAT64 prefix  | No       | string | `/96` form. Defaults to the well-known `64:ff9b::/96`                  |
+
+| Output        | Type   | Notes                                                  |
+|---------------|--------|--------------------------------------------------------|
+| input         | string | Echoed input                                           |
+| ipv4          | string | Embedded IPv4 dotted-quad                              |
+| ipv4_mapped   | string | `::ffff:a.b.c.d` form (RFC 4291)                       |
+| nat64         | string | NAT64 IPv6 within `nat64_prefix` (RFC 6052)            |
+| nat64_prefix  | string | The /96 prefix used (well-known or custom)             |
+
+## What is IPv4-mapped IPv6?
+
+RFC 4291 §2.5.5.2 reserves `::ffff:0:0/96` as the "IPv4-mapped IPv6 address"
+prefix. It exists so dual-stack sockets can represent any IPv4 peer as
+an IPv6 address without losing information — the bottom 32 bits are the
+plain IPv4 address. PHP's `inet_pton()` / `inet_ntop()` handle the
+canonical `::ffff:a.b.c.d` rendering natively.
+
+## What is NAT64?
+
+RFC 6052 defines an algorithmic mapping from IPv4 into a designated
+IPv6 prefix, used by NAT64 gateways to make IPv4-only services
+reachable from IPv6-only clients. The most common deployment uses
+the well-known prefix **`64:ff9b::/96`** (RFC 6052 §2.1) where the
+bottom 32 bits encode the IPv4 address.
+
+This tool covers the **/96** variant, which is the only form widely
+deployed in practice. RFC 6052 also defines `/32`, `/40`, `/48`,
+`/56`, and `/64` variants with non-trivial bit-shifting around the
+"u-octet" — those are intentionally out of scope here.
+
+## Examples
+
+| Input               | NAT64 prefix     | IPv4         | IPv4-mapped              | NAT64 IPv6              |
+|---------------------|------------------|--------------|--------------------------|-------------------------|
+| `192.0.2.1`         | (default)        | `192.0.2.1`  | `::ffff:192.0.2.1`       | `64:ff9b::c000:201`     |
+| `::ffff:192.0.2.1`  | (default)        | `192.0.2.1`  | `::ffff:192.0.2.1`       | `64:ff9b::c000:201`     |
+| `64:ff9b::c000:201` | (default)        | `192.0.2.1`  | `::ffff:192.0.2.1`       | `64:ff9b::c000:201`     |
+| `192.0.2.1`         | `2001:db8:1::/96`| `192.0.2.1`  | `::ffff:192.0.2.1`       | `2001:db8:1::c000:201`  |
+
+## Validation rules
+
+- **Address** must parse as either a valid IPv4 dotted-quad, a valid
+  IPv4-mapped IPv6 literal (top 96 bits = `::ffff:0:0`), or a valid
+  IPv6 literal whose top 96 bits match the supplied NAT64 prefix.
+  Anything else is rejected with a 400.
+- **NAT64 prefix**, when provided, must be in `/96` form. Non-`/96`
+  prefixes (e.g. `/64`) are rejected — see the discussion above.
+
+## API
+
+`POST /api/v1/mapped6`
+
+```json
+{
+  "input": "192.0.2.1"
+}
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "input": "192.0.2.1",
+    "ipv4": "192.0.2.1",
+    "ipv4_mapped": "::ffff:192.0.2.1",
+    "nat64": "64:ff9b::c000:201",
+    "nat64_prefix": "64:ff9b::/96"
+  }
+}
+```
+
+A custom NAT64 prefix:
+
+```json
+{
+  "input": "192.0.2.1",
+  "nat64_prefix": "2001:db8:1::/96"
+}
+```
+
+## Errors
+
+| Error                                                                                     | Cause                                                          |
+|-------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `Input is not IPv4, IPv4-mapped IPv6, or NAT64 IPv6 within the supplied prefix.`          | Address does not match any of the three accepted forms         |
+| `Invalid IPv4 address`                                                                    | Not a valid dotted-quad                                        |
+| `Not an IPv4-mapped IPv6 address`                                                         | IPv6 literal lacks the `::ffff:0:0/96` prefix                  |
+| `NAT64 prefix must be /96`                                                                | Custom prefix is not in `/96` form                             |
+| `Invalid NAT64 prefix address`                                                            | Custom prefix's address part does not parse as an IPv6 literal |
+| `Address is not within the supplied NAT64 prefix`                                         | NAT64 input doesn't match the supplied (or default) prefix     |
+
+## Shareable URLs
+
+The tool supports the standard tab + tool URL pattern, plus the per-tool
+route from v3.4.0 Task 7:
+
+```text
+/ipv6/mapped6?mapped6_input=192.0.2.1
+?tab=ipv6&mapped6_input=192.0.2.1&mapped6_nat64_prefix=2001:db8:1::/96
+```
+
+Open the link and the mapped6 drawer auto-opens with the result already
+calculated.

--- a/docs/superpowers/plans/v3.4.0-living-doc.md
+++ b/docs/superpowers/plans/v3.4.0-living-doc.md
@@ -39,7 +39,7 @@ its PR opens.
 | 6 | T6 | IPv6 type-detection → `functions-type6.php` | in-review (PR #380) | `19f0731` | T5 |
 | 7 | T7 | Per-tool URL routes (`/ipv6/<tool>`) | in-review (PR #381) | `c1ba078` | T6 |
 | 8 | T8 | IPv6 reverse-DNS (rdns6) | in-review (PR #382) | `6c63844` | T7 |
-| 9 | T9 | IPv4-mapped / NAT64 (mapped6) | pending | — | T8 |
+| 9 | T9 | IPv4-mapped / NAT64 (mapped6) | in-review (PR #383) | `0720b50` | T8 |
 | 10 | T10 | Bulk endpoint covers new IPv6 endpoints | pending | — | T9 |
 | 11 | T11 | A11y audit + fix 5 new IPv6 drawers | pending | — | T10 |
 | 12 | T12 | Release cut → tag → publish → deploy | pending | — | T11 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Binary / Hex Panel: binary.md
     - Reverse DNS Zones: rdns.md
     - IPv6 Reverse DNS (rdns6): ipv6-rdns6.md
+    - IPv4-mapped / NAT64 (mapped6): ipv6-mapped6.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -2803,6 +2803,138 @@ async def test_ipv6_rdns6_ui(page: Page) -> None:
               await panel.locator(".zoneid-result__row").count(), 0)
 
 
+async def test_api_mapped6(page: Page) -> None:
+    section("API — POST /api/v1/mapped6")
+    # IPv4 input → all four representations
+    status, data = _api_post("mapped6", {"input": "192.0.2.1"})
+    assert_eq("api mapped6: HTTP 200", status, 200)
+    assert_eq("api mapped6: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api mapped6: ipv4 echoed", d.get("ipv4"), "192.0.2.1")
+    assert_eq("api mapped6: ipv4_mapped", d.get("ipv4_mapped"), "::ffff:192.0.2.1")
+    assert_eq("api mapped6: nat64 default", d.get("nat64"), "64:ff9b::c000:201")
+    assert_eq("api mapped6: nat64_prefix default",
+              d.get("nat64_prefix"), "64:ff9b::/96")
+
+    # IPv4-mapped input → same outputs
+    status2, data2 = _api_post("mapped6", {"input": "::ffff:192.0.2.1"})
+    assert_eq("api mapped6 (mapped in): HTTP 200", status2, 200)
+    assert_eq("api mapped6 (mapped in): ipv4",
+              data2.get("data", {}).get("ipv4"), "192.0.2.1")
+    assert_eq("api mapped6 (mapped in): nat64",
+              data2.get("data", {}).get("nat64"), "64:ff9b::c000:201")
+
+    # NAT64 input (default prefix) → same outputs
+    status3, data3 = _api_post("mapped6", {"input": "64:ff9b::c000:201"})
+    assert_eq("api mapped6 (nat64 in): HTTP 200", status3, 200)
+    assert_eq("api mapped6 (nat64 in): ipv4",
+              data3.get("data", {}).get("ipv4"), "192.0.2.1")
+    assert_eq("api mapped6 (nat64 in): ipv4_mapped",
+              data3.get("data", {}).get("ipv4_mapped"), "::ffff:192.0.2.1")
+
+    # Custom /96 prefix
+    status4, data4 = _api_post("mapped6", {
+        "input": "192.0.2.1",
+        "nat64_prefix": "2001:db8:1::/96",
+    })
+    assert_eq("api mapped6 (custom /96): HTTP 200", status4, 200)
+    assert_eq("api mapped6 (custom /96): nat64",
+              data4.get("data", {}).get("nat64"), "2001:db8:1::c000:201")
+    assert_eq("api mapped6 (custom /96): nat64_prefix echoed",
+              data4.get("data", {}).get("nat64_prefix"), "2001:db8:1::/96")
+
+    # Non-/96 prefix → 400
+    status5, data5 = _api_post("mapped6", {
+        "input": "192.0.2.1",
+        "nat64_prefix": "2001:db8::/64",
+    })
+    assert_eq("api mapped6 (non-/96): HTTP 400", status5, 400)
+    assert_eq("api mapped6 (non-/96): ok=false", data5.get("ok"), False)
+
+    # Missing input → 400
+    status6, _ = _api_post("mapped6", {})
+    assert_eq("api mapped6: missing input → 400", status6, 400)
+
+    # Garbage input → 400
+    status7, _ = _api_post("mapped6", {"input": "not-an-address"})
+    assert_eq("api mapped6: invalid input → 400", status7, 400)
+
+
+async def test_ipv6_mapped6_ui(page: Page) -> None:
+    section("IPv6 IPv4-mapped / NAT64 (mapped6) UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # T7 per-tool URL routing — /ipv6/mapped6 should auto-open the drawer.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=mapped6")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='mapped6']")
+    assert_eq("mapped6 UI: panel exists", await panel.count(), 1)
+
+    # Submit IPv4 address
+    await page.fill("#mapped6_input", "192.0.2.1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='mapped6'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='mapped6']")
+    rows = panel.locator(".zoneid-result__row")
+    # 4 rows: IPv4 / IPv4-mapped / NAT64 / NAT64 prefix
+    assert_eq("mapped6 UI: four result rows", await rows.count(), 4)
+
+    ipv4_text   = (await rows.nth(0).locator(".zoneid-result__value code").text_content() or "").strip()
+    mapped_text = (await rows.nth(1).locator(".zoneid-result__value code").text_content() or "").strip()
+    nat64_text  = (await rows.nth(2).locator(".zoneid-result__value code").text_content() or "").strip()
+    prefix_text = (await rows.nth(3).locator(".zoneid-result__value code").text_content() or "").strip()
+    assert_eq("mapped6 UI: ipv4 row",        ipv4_text,   "192.0.2.1")
+    assert_eq("mapped6 UI: ipv4_mapped row", mapped_text, "::ffff:192.0.2.1")
+    assert_eq("mapped6 UI: nat64 row",       nat64_text,  "64:ff9b::c000:201")
+    assert_eq("mapped6 UI: nat64_prefix row", prefix_text, "64:ff9b::/96")
+    assert_eq("mapped6 UI: no error band",
+              await panel.locator(".error").count(), 0)
+
+    # Click each copy button (rows 0..2 — prefix row has no copy button)
+    await rows.nth(0).locator(".subnet-copy").click()
+    await page.wait_for_timeout(50)
+    assert_eq("mapped6 UI: copy IPv4",
+              await page.evaluate("window.__lastClipboard"), "192.0.2.1")
+
+    await rows.nth(1).locator(".subnet-copy").click()
+    await page.wait_for_timeout(50)
+    assert_eq("mapped6 UI: copy IPv4-mapped",
+              await page.evaluate("window.__lastClipboard"), "::ffff:192.0.2.1")
+
+    await rows.nth(2).locator(".subnet-copy").click()
+    await page.wait_for_timeout(50)
+    assert_eq("mapped6 UI: copy NAT64",
+              await page.evaluate("window.__lastClipboard"), "64:ff9b::c000:201")
+
+    # Error path — non-/96 NAT64 prefix
+    await navigate(page, APP_URL + "?tab=ipv6&tool=mapped6")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#mapped6_input", "192.0.2.1")
+    # Open the advanced disclosure and supply a non-/96 prefix
+    await page.evaluate(
+        "document.querySelector(\"#panel-ipv6 .tool-panel[data-tool='mapped6'] details.slaac-advanced\").open = true"
+    )
+    await page.fill("#mapped6_nat64_prefix", "2001:db8::/64")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='mapped6'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='mapped6']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("mapped6 UI: error band on non-/96",
+                len(err_text) > 0, f"got: {err_text!r}")
+    assert_eq("mapped6 UI: no result rows on error",
+              await panel.locator(".zoneid-result__row").count(), 0)
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -7490,6 +7622,8 @@ async def main() -> None:
             await test_api_slaac(page)
             await test_ipv6_rdns6_ui(page)
             await test_api_rdns6(page)
+            await test_ipv6_mapped6_ui(page)
+            await test_api_mapped6(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)
             await test_tooltips_accessibility(page)

--- a/testing/unit/Mapped6Test.php
+++ b/testing/unit/Mapped6Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class Mapped6Test extends TestCase
+{
+    public function testIsIpv4MappedTrue(): void
+    {
+        $this->assertTrue(is_ipv4_mapped('::ffff:192.0.2.1'));
+        $this->assertTrue(is_ipv4_mapped('::ffff:c000:0201'));
+    }
+
+    public function testIsIpv4MappedFalse(): void
+    {
+        $this->assertFalse(is_ipv4_mapped('2001:db8::1'));
+        $this->assertFalse(is_ipv4_mapped('64:ff9b::c000:0201'));
+    }
+
+    public function testIpv4ToMapped(): void
+    {
+        $this->assertSame('::ffff:192.0.2.1', ipv4_to_mapped('192.0.2.1'));
+    }
+
+    public function testMappedToIpv4(): void
+    {
+        $this->assertSame('192.0.2.1', mapped_to_ipv4('::ffff:192.0.2.1'));
+    }
+
+    public function testMappedToIpv4RejectsNonMapped(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        mapped_to_ipv4('2001:db8::1');
+    }
+
+    public function testIsNat64DefaultPrefix(): void
+    {
+        $this->assertTrue(is_nat64('64:ff9b::c000:0201'));
+        $this->assertFalse(is_nat64('::ffff:192.0.2.1'));
+    }
+
+    public function testIpv4ToNat64Default(): void
+    {
+        // inet_ntop renders as compressed form
+        $this->assertSame(
+            '64:ff9b::c000:201',
+            ipv4_to_nat64('192.0.2.1')
+        );
+    }
+
+    public function testNat64ToIpv4Default(): void
+    {
+        $this->assertSame('192.0.2.1', nat64_to_ipv4('64:ff9b::c000:0201'));
+    }
+
+    public function testNat64CustomPrefixSlash96(): void
+    {
+        $this->assertSame(
+            '2001:db8:1::c000:201',
+            ipv4_to_nat64('192.0.2.1', '2001:db8:1::/96')
+        );
+        $this->assertSame(
+            '192.0.2.1',
+            nat64_to_ipv4('2001:db8:1::c000:201', '2001:db8:1::/96')
+        );
+    }
+
+    public function testNat64RejectsNonSlash96(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv4_to_nat64('192.0.2.1', '2001:db8::/64');
+    }
+
+    public function testEdgeCasesAllZerosAndAllOnes(): void
+    {
+        $this->assertSame('::ffff:0.0.0.0', ipv4_to_mapped('0.0.0.0'));
+        $this->assertSame('::ffff:255.255.255.255', ipv4_to_mapped('255.255.255.255'));
+    }
+
+    public function testIpv4ToMappedRejectsInvalidV4(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv4_to_mapped('not-an-ip');
+    }
+
+    public function testNat64ToIpv4RejectsOutOfPrefix(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        nat64_to_ipv4('::ffff:192.0.2.1');  // mapped, not NAT64
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -18,6 +18,7 @@ require $base . 'functions-zone6.php';
 require $base . 'functions-derive6.php';
 require $base . 'functions-slaac6.php';
 require $base . 'functions-rdns6.php';
+require $base . 'functions-mapped6.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary
New tool F. Bidirectional convert between IPv4, IPv4-mapped IPv6 (`::ffff:0:0/96`, RFC 4291), and NAT64 IPv6 (`64:ff9b::/96` default per RFC 6052; any `/96` prefix supported via Advanced disclosure).

- Module: `Subnet-Calculator/includes/functions-mapped6.php` — 6 public helpers (`is_ipv4_mapped`, `ipv4_to_mapped`, `mapped_to_ipv4`, `is_nat64`, `ipv4_to_nat64`, `nat64_to_ipv4`) plus `NAT64_DEFAULT_PREFIX` constant.
- API: `POST /api/v1/mapped6` (handler at `Subnet-Calculator/api/v1/handlers/mapped6.php`, mirrors the rdns6 inline-script convention from T8 — no named `handle_mapped6()` function).
- Drawer: IPv6 tab → "IPv4-mapped / NAT64"; auto-opens at `/ipv6/mapped6` via the T7 per-tool URL routing. Single text input accepts any of the three forms; Advanced disclosure (reusing the `slaac-advanced` class for visual parity) carries the optional custom NAT64 prefix.
- Result: four rows — IPv4 / IPv4-mapped / NAT64 / NAT64 prefix. First three rows have copy buttons; prefix row is read-only.
- OpenAPI: new `/mapped6` operation with four request examples, `Mapped6` tag added to global `tags:`.
- Admin: `mapped6` added to `api_allowed_endpoints` allowlist values.
- Docs: `docs/ipv6-mapped6.md` (Synopsis / Inputs / Outputs / Examples / Validation / API / Errors / Shareable URLs); nav entry under Calculator.

## Design parity (v2.9.0 + rdns6)
- Drawer markup follows the rdns6 / zoneid / derive pattern: `tool-panel[data-tool=...]` → `overlap-panel` → form → `zoneid-result` `<dl>` for outputs.
- Help bubbles on the title and every input via `help_bubble()`.
- `<details class="slaac-advanced">` reused for the NAT64-prefix Advanced disclosure to match SLAAC privacy's existing visual treatment.
- Copy buttons via `copy_button()`; `data-history-source="mapped6"` set on the result `<dl>` so it integrates with the existing history tray.
- Error band uses the standard `.error` class with `aria-invalid` + `aria-describedby` on the input on failure.

## Test plan
- [x] PHPUnit — new `Mapped6Test` (13 cases, 18 assertions); full suite: 497 tests, 1147 assertions, 14 skipped (pre-existing GMP-platform skips).
- [x] PHPStan L9 (`--memory-limit=512M`) — clean.
- [x] PHPCS PSR-12 — clean (file-level docblock dropped to `//` comments per PSR-12 file-header rule).
- [x] Spectral lint on `openapi.yaml` — clean (added `Mapped6` to global `tags:` to satisfy `operation-tag-defined`).
- [x] Semgrep (`p/php`, `p/owasp-top-ten`, `p/sql-injection`, project rules) — 0 findings.
- [x] `npm run lint` — only pre-existing warnings.
- [x] `make test-docker` — 1324/1324 Playwright assertions pass, including 2 new test groups (`test_ipv6_mapped6_ui`, `test_api_mapped6`).

## Deviations
- The handler validates `nat64_prefix` is a string before passing through; non-string values get a 400 (the spec only documented invalid-prefix as a 400, so this is a strict superset).
- Result `<dl>` has 4 rows (not 3 as suggested in the task); the fourth row echoes which NAT64 prefix was used so the user can confirm it matches their intent — particularly important when a custom Advanced prefix is supplied.
- All `inet_ntop()`-rendered values matched the test expectations exactly — no test-expectation rewrites were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)