### PR TITLE
feat(v3.4.0): bulk endpoint covers new IPv6 endpoints

### DIFF
--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -1871,28 +1871,72 @@ paths:
       tags: [Bulk]
       summary: Calculate multiple subnets in a single request
       description: |
-        Accepts up to 50 CIDR inputs and returns a per-item result array.
-        Individual failures do not abort the request; each item carries its own ok/error status.
-        IPv6 items require the PHP GMP extension.
+        Two request modes are supported, selected by the body shape:
+
+        - **Legacy CIDR mode** — body contains `cidrs[]`. Resolves each CIDR
+          via /ipv4 or /ipv6 logic. Per-item envelope: `{input, ok, data?, error?}`.
+        - **Multi-op mode (v3.4.0)** — body contains `items[]`. Each item
+          has its own `op` slug and `params` payload. Supported ops:
+          `range6`, `supernet6`, `zone-id`, `derive`, `slaac-privacy`,
+          `rdns6`, `mapped6`. Per-item envelope: `{op, ok, error?, ...result}`
+          where `...result` matches the standalone endpoint's success body.
+
+        Up to 50 entries per request. Individual failures do not abort the
+        request — each item carries its own ok/error status. IPv6 ops
+        require the PHP GMP extension.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              required: [cidrs]
-              properties:
-                cidrs:
-                  type: array
-                  minItems: 1
-                  maxItems: 50
-                  items: { type: string }
-                  example: ["10.0.0.0/24", "2001:db8::/32"]
-                type:
-                  type: string
-                  enum: [auto, ipv4, ipv6]
-                  default: auto
-                  description: Force all items to a specific IP version. `auto` detects per-item.
+              oneOf:
+                - type: object
+                  required: [cidrs]
+                  properties:
+                    cidrs:
+                      type: array
+                      minItems: 1
+                      maxItems: 50
+                      items: { type: string }
+                      example: ["10.0.0.0/24", "2001:db8::/32"]
+                    type:
+                      type: string
+                      enum: [auto, ipv4, ipv6]
+                      default: auto
+                      description: Force all items to a specific IP version. `auto` detects per-item.
+                - type: object
+                  required: [items]
+                  properties:
+                    items:
+                      type: array
+                      minItems: 1
+                      maxItems: 50
+                      items:
+                        type: object
+                        required: [op, params]
+                        properties:
+                          op:
+                            type: string
+                            enum: [range6, supernet6, zone-id, derive, slaac-privacy, rdns6, mapped6]
+                          params:
+                            type: object
+                            description: Per-op parameters; shape matches the corresponding standalone endpoint's request body.
+                  example:
+                    items:
+                      - op: range6
+                        params: { start: "2001:db8::", end: "2001:db8::ff" }
+                      - op: supernet6
+                        params: { action: find, cidrs: ["2001:db8:0::/48", "2001:db8:1::/48"] }
+                      - op: zone-id
+                        params: { input: "fe80::1%eth0" }
+                      - op: derive
+                        params: { mac: "00:11:22:33:44:55" }
+                      - op: slaac-privacy
+                        params: { prefix: "2001:db8::/64", seed: "deadbeefcafef00d" }
+                      - op: rdns6
+                        params: { address: "2001:db8::1", prefix: 64 }
+                      - op: mapped6
+                        params: { input: "192.0.2.1" }
       responses:
         "200":
           description: Per-item calculation results
@@ -1909,13 +1953,18 @@ paths:
                         properties:
                           results:
                             type: array
+                            description: |
+                              In legacy `cidrs[]` mode, each entry is `{input, ok, data?, error?}`.
+                              In multi-op `items[]` mode, each entry is
+                              `{op, ok, error?, ...result}` where `...result` matches the
+                              corresponding standalone endpoint's success body.
                             items:
                               type: object
-                              required: [input, ok]
                               properties:
-                                input: { type: string }
+                                input: { type: string, description: "Present in legacy cidrs[] mode." }
+                                op:    { type: string, description: "Present in multi-op items[] mode." }
                                 ok:    { type: boolean }
-                                data:  { description: "Present when ok is true. Shape matches /ipv4 or /ipv6 response data." }
+                                data:  { description: "Legacy cidrs[] mode — present when ok is true. Shape matches /ipv4 or /ipv6 response data." }
                                 error: { type: string, description: "Present when ok is false." }
               example:
                 ok: true

--- a/Subnet-Calculator/api/v1/handlers/bulk.php
+++ b/Subnet-Calculator/api/v1/handlers/bulk.php
@@ -6,7 +6,33 @@ if ($method !== 'POST') {
     json_err('Method not allowed.', 405);
 }
 
-$body  = api_body();
+$body = api_body();
+
+// ── Multi-op mode (v3.4.0) ───────────────────────────────────────────────────
+//
+// When the request body contains an `items[]` array, dispatch each item to
+// its corresponding op handler (range6, supernet6, zone-id, derive,
+// slaac-privacy, rdns6, mapped6). Per-item errors are returned as
+// `{op, ok: false, error}` envelopes; the request itself succeeds with HTTP
+// 200 as long as the top-level shape is valid.
+if (array_key_exists('items', $body)) {
+    $items = $body['items'];
+    if (!is_array($items) || count($items) === 0) {
+        json_err('Field "items" must be a non-empty array.');
+    }
+    if (count($items) > 50) {
+        json_err('Maximum 50 items per request.');
+    }
+
+    $gmp_loaded = extension_loaded('gmp');
+    if (!$gmp_loaded) {
+        json_err('The /bulk multi-op mode requires the PHP GMP extension.', 503);
+    }
+
+    json_ok(['results' => bulk_dispatch_ops(array_values($items))]);
+}
+
+// ── Legacy single-op mode (CIDR resolution) ──────────────────────────────────
 $cidrs = $body['cidrs'] ?? [];
 $type  = trim((string)($body['type'] ?? 'auto'));
 

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -39,6 +39,7 @@ require $base . 'functions-tree-presets.php';
 require $base . 'functions-lookup.php';
 require $base . 'functions-diff.php';
 require $base . 'functions-apikeys.php';
+require $base . 'functions-bulk.php';
 require $base . 'functions-admin-auth.php';
 
 header('Content-Type: application/json; charset=utf-8');

--- a/Subnet-Calculator/includes/functions-bulk.php
+++ b/Subnet-Calculator/includes/functions-bulk.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+// Bulk multi-op dispatcher (v3.4.0).
+//
+// The legacy /bulk endpoint accepts a flat `cidrs[]` array and resolves each
+// entry as IPv4 or IPv6 via resolve_*_input(). This dispatcher complements
+// that mode by accepting a heterogeneous `items[]` array where each item
+// carries its own `op` slug + `params` payload, so callers can mix the
+// v3.3.0 IPv6 endpoints (range6, supernet6, zone-id, derive, slaac-privacy)
+// and the v3.4.0 endpoints (rdns6, mapped6) in a single round-trip.
+//
+// Per-item envelope on success: { op, ok: true, ...result }
+// Per-item envelope on error:   { op, ok: false, error: <string> }
+//
+// Errors thrown by underlying functions (InvalidArgumentException) and
+// shape-level errors (`['error' => ...]` returns) are normalised into the
+// `ok: false` envelope. The dispatcher never throws on per-item failures —
+// it always returns one envelope per input item. Top-level shape errors
+// (e.g. missing `op`, unsupported op) are also reported per-item.
+
+const BULK_SUPPORTED_OPS = [
+    'range6',
+    'supernet6',
+    'zone-id',
+    'derive',
+    'slaac-privacy',
+    'rdns6',
+    'mapped6',
+];
+
+/**
+ * Dispatch a list of bulk items to their per-op handlers.
+ *
+ * @param array<int, mixed> $items
+ * @return array<int, array<string, mixed>>
+ */
+function bulk_dispatch_ops(array $items): array
+{
+    $out = [];
+    foreach ($items as $item) {
+        $out[] = bulk_dispatch_one($item);
+    }
+    return $out;
+}
+
+/**
+ * @param mixed $item
+ * @return array<string, mixed>
+ */
+function bulk_dispatch_one($item): array
+{
+    if (!is_array($item)) {
+        return ['op' => '', 'ok' => false, 'error' => 'Item must be an object.'];
+    }
+
+    $op_raw = $item['op'] ?? '';
+    $op     = is_string($op_raw) ? trim($op_raw) : '';
+    if ($op === '') {
+        return ['op' => '', 'ok' => false, 'error' => 'Field "op" is required.'];
+    }
+
+    if (!in_array($op, BULK_SUPPORTED_OPS, true)) {
+        return [
+            'op'    => $op,
+            'ok'    => false,
+            'error' => 'Unsupported op "' . $op . '". Supported: '
+                . implode(', ', BULK_SUPPORTED_OPS) . '.',
+        ];
+    }
+
+    $params_raw = $item['params'] ?? [];
+    $params     = is_array($params_raw) ? $params_raw : [];
+
+    try {
+        switch ($op) {
+            case 'range6':
+                return _bulk_op_range6($params);
+            case 'supernet6':
+                return _bulk_op_supernet6($params);
+            case 'zone-id':
+                return _bulk_op_zone_id($params);
+            case 'derive':
+                return _bulk_op_derive($params);
+            case 'slaac-privacy':
+                return _bulk_op_slaac_privacy($params);
+            case 'rdns6':
+                return _bulk_op_rdns6($params);
+            case 'mapped6':
+                return _bulk_op_mapped6($params);
+        }
+    } catch (\InvalidArgumentException $e) {
+        return ['op' => $op, 'ok' => false, 'error' => $e->getMessage()];
+    } catch (\Throwable $e) {
+        return ['op' => $op, 'ok' => false, 'error' => $e->getMessage()];
+    }
+
+    // Unreachable — switch is exhaustive over the supported ops.
+    return ['op' => $op, 'ok' => false, 'error' => 'Internal dispatcher error.'];
+}
+
+// ── Per-op adapters ──────────────────────────────────────────────────────────
+//
+// Each adapter takes the per-item `params` array, validates the minimal fields
+// the underlying pure function expects, calls it, and returns the success
+// envelope. Validation errors throw InvalidArgumentException so the wrapping
+// switch catches them uniformly.
+
+/**
+ * @param array<string, mixed> $p
+ * @return array<string, mixed>
+ */
+function _bulk_op_range6(array $p): array
+{
+    $start = isset($p['start']) && is_string($p['start']) ? trim($p['start']) : '';
+    $end   = isset($p['end'])   && is_string($p['end'])   ? trim($p['end'])   : '';
+    if ($start === '') {
+        throw new \InvalidArgumentException('Field "start" is required.');
+    }
+    if ($end === '') {
+        throw new \InvalidArgumentException('Field "end" is required.');
+    }
+    $r = range6_to_cidrs($start, $end);
+    if (isset($r['error'])) {
+        throw new \InvalidArgumentException((string)$r['error']);
+    }
+    return [
+        'op'              => 'range6',
+        'ok'              => true,
+        'cidrs'           => $r['cidrs'] ?? [],
+        'count'           => $r['count'] ?? 0,
+        'total_addresses' => $r['total_addresses'] ?? 0,
+        'truncated'       => $r['truncated'] ?? false,
+        'cap'             => $r['cap'] ?? 256,
+    ];
+}
+
+/**
+ * @param array<string, mixed> $p
+ * @return array<string, mixed>
+ */
+function _bulk_op_supernet6(array $p): array
+{
+    $action_raw = $p['action'] ?? 'find';
+    $action     = is_string($action_raw) ? trim($action_raw) : 'find';
+    if (!in_array($action, ['find', 'summarise'], true)) {
+        throw new \InvalidArgumentException('Field "action" must be "find" or "summarise".');
+    }
+    $cidrs_raw = $p['cidrs'] ?? [];
+    if (!is_array($cidrs_raw) || count($cidrs_raw) === 0) {
+        throw new \InvalidArgumentException('Field "cidrs" must be a non-empty array.');
+    }
+    if (count($cidrs_raw) > 50) {
+        throw new \InvalidArgumentException('Maximum 50 CIDRs per item.');
+    }
+    $lines = array_values(array_filter(array_map(
+        static fn($c) => trim((string)$c),
+        $cidrs_raw
+    )));
+    if (count($lines) === 0) {
+        throw new \InvalidArgumentException('Field "cidrs" must contain at least one non-empty entry.');
+    }
+
+    if ($action === 'find') {
+        $r = supernet6_find($lines);
+        if (isset($r['error'])) {
+            throw new \InvalidArgumentException((string)$r['error']);
+        }
+        return ['op' => 'supernet6', 'ok' => true, 'supernet' => $r['supernet'] ?? ''];
+    }
+
+    $r = summarise6_cidrs($lines);
+    if (isset($r['error'])) {
+        throw new \InvalidArgumentException((string)$r['error']);
+    }
+    return ['op' => 'supernet6', 'ok' => true, 'summaries' => $r['summaries'] ?? []];
+}
+
+/**
+ * @param array<string, mixed> $p
+ * @return array<string, mixed>
+ */
+function _bulk_op_zone_id(array $p): array
+{
+    $input = isset($p['input']) && is_string($p['input']) ? trim($p['input']) : '';
+    if ($input === '') {
+        throw new \InvalidArgumentException('Field "input" is required.');
+    }
+    $r = parse_zone_id($input);
+    return [
+        'op'            => 'zone-id',
+        'ok'            => true,
+        'address'       => $r['address'],
+        'zone_id'       => $r['zone_id'],
+        'is_link_local' => $r['is_link_local'],
+        'warning'       => $r['warning'],
+    ];
+}
+
+/**
+ * @param array<string, mixed> $p
+ * @return array<string, mixed>
+ */
+function _bulk_op_derive(array $p): array
+{
+    $mac = isset($p['mac']) && is_string($p['mac']) ? trim($p['mac']) : '';
+    if ($mac === '') {
+        throw new \InvalidArgumentException('Field "mac" is required.');
+    }
+    $r = derive_from_mac($mac);
+    return [
+        'op'             => 'derive',
+        'ok'             => true,
+        'mac_canonical'  => $r['mac_canonical'],
+        'eui64'          => $r['eui64'],
+        'ul_bit_flipped' => $r['ul_bit_flipped'],
+        'link_local'     => $r['link_local'],
+        'solicited_node' => $r['solicited_node'],
+        'warning'        => $r['warning'],
+    ];
+}
+
+/**
+ * @param array<string, mixed> $p
+ * @return array<string, mixed>
+ */
+function _bulk_op_slaac_privacy(array $p): array
+{
+    $prefix = isset($p['prefix']) && is_string($p['prefix']) ? trim($p['prefix']) : '';
+    if ($prefix === '') {
+        throw new \InvalidArgumentException('Field "prefix" is required.');
+    }
+    $seed = null;
+    if (array_key_exists('seed', $p) && $p['seed'] !== null) {
+        if (!is_string($p['seed'])) {
+            throw new \InvalidArgumentException('Field "seed" must be a string.');
+        }
+        $seed_raw = trim($p['seed']);
+        if ($seed_raw !== '') {
+            $seed = $seed_raw;
+        }
+    }
+    $r = slaac_privacy_address($prefix, $seed);
+    return [
+        'op'                => 'slaac-privacy',
+        'ok'                => true,
+        'prefix'            => $r['prefix'],
+        'address'           => $r['address'],
+        'interface_id'      => $r['interface_id'],
+        'seed_used'         => $r['seed_used'],
+        'seed_was_provided' => $r['seed_was_provided'],
+    ];
+}
+
+/**
+ * @param array<string, mixed> $p
+ * @return array<string, mixed>
+ */
+function _bulk_op_rdns6(array $p): array
+{
+    $address = isset($p['address']) && is_string($p['address']) ? trim($p['address']) : '';
+    if ($address === '') {
+        throw new \InvalidArgumentException('Field "address" is required.');
+    }
+    $prefix = null;
+    if (array_key_exists('prefix', $p) && $p['prefix'] !== null && $p['prefix'] !== '') {
+        if (is_int($p['prefix'])) {
+            $prefix = $p['prefix'];
+        } elseif (is_string($p['prefix']) && preg_match('/^-?\d+$/', $p['prefix']) === 1) {
+            $prefix = (int)$p['prefix'];
+        } else {
+            throw new \InvalidArgumentException('Field "prefix" must be an integer 0..128 (multiple of 4).');
+        }
+    }
+    $arpa = ipv6_to_arpa($address, $prefix);
+    return [
+        'op'      => 'rdns6',
+        'ok'      => true,
+        'address' => $address,
+        'prefix'  => $prefix ?? 128,
+        'arpa'    => $arpa,
+    ];
+}
+
+/**
+ * @param array<string, mixed> $p
+ * @return array<string, mixed>
+ */
+function _bulk_op_mapped6(array $p): array
+{
+    $input = isset($p['input']) && is_string($p['input']) ? trim($p['input']) : '';
+    if ($input === '') {
+        throw new \InvalidArgumentException('Field "input" is required.');
+    }
+    $prefix = NAT64_DEFAULT_PREFIX;
+    if (array_key_exists('nat64_prefix', $p) && $p['nat64_prefix'] !== null && $p['nat64_prefix'] !== '') {
+        if (!is_string($p['nat64_prefix'])) {
+            throw new \InvalidArgumentException('Field "nat64_prefix" must be a string in /96 form.');
+        }
+        $prefix = trim($p['nat64_prefix']);
+    }
+
+    if (filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+        $v4     = $input;
+        $mapped = ipv4_to_mapped($v4);
+        $nat64  = ipv4_to_nat64($v4, $prefix);
+    } elseif (is_ipv4_mapped($input)) {
+        $v4     = mapped_to_ipv4($input);
+        $mapped = $input;
+        $nat64  = ipv4_to_nat64($v4, $prefix);
+    } elseif (is_nat64($input, $prefix)) {
+        $v4     = nat64_to_ipv4($input, $prefix);
+        $mapped = ipv4_to_mapped($v4);
+        $nat64  = $input;
+    } else {
+        throw new \InvalidArgumentException(
+            'Input is not IPv4, IPv4-mapped IPv6, or NAT64 IPv6 within the supplied prefix.'
+        );
+    }
+
+    return [
+        'op'           => 'mapped6',
+        'ok'           => true,
+        'input'        => $input,
+        'ipv4'         => $v4,
+        'ipv4_mapped'  => $mapped,
+        'nat64'        => $nat64,
+        'nat64_prefix' => $prefix,
+    ];
+}

--- a/docs/superpowers/plans/v3.4.0-living-doc.md
+++ b/docs/superpowers/plans/v3.4.0-living-doc.md
@@ -40,7 +40,7 @@ its PR opens.
 | 7 | T7 | Per-tool URL routes (`/ipv6/<tool>`) | in-review (PR #381) | `c1ba078` | T6 |
 | 8 | T8 | IPv6 reverse-DNS (rdns6) | in-review (PR #382) | `6c63844` | T7 |
 | 9 | T9 | IPv4-mapped / NAT64 (mapped6) | in-review (PR #383) | `0720b50` | T8 |
-| 10 | T10 | Bulk endpoint covers new IPv6 endpoints | pending | — | T9 |
+| 10 | T10 | Bulk endpoint covers new IPv6 endpoints | in-review (PR #384) | `0e465e1` | T9 |
 | 11 | T11 | A11y audit + fix 5 new IPv6 drawers | pending | — | T10 |
 | 12 | T12 | Release cut → tag → publish → deploy | pending | — | T11 |
 

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -2981,6 +2981,64 @@ async def test_api_bulk(page: Page) -> None:
     assert_eq("api bulk: explicit type=ipv4 item ok=true", r6[0].get("ok") if r6 else None, True)
 
 
+async def test_api_bulk_covers_new_ipv6_endpoints(page: Page) -> None:
+    section("API — bulk multi-op covers v3.3.0 + v3.4.0 IPv6 endpoints")
+    items = [
+        {"op": "range6",        "params": {"start": "2001:db8::", "end": "2001:db8::ff"}},
+        {"op": "supernet6",     "params": {"action": "find",
+                                            "cidrs": ["2001:db8:0::/48", "2001:db8:1::/48"]}},
+        {"op": "zone-id",       "params": {"input": "fe80::1%eth0"}},
+        {"op": "derive",        "params": {"mac": "00:11:22:33:44:55"}},
+        {"op": "slaac-privacy", "params": {"prefix": "2001:db8::/64",
+                                            "seed": "deadbeefcafef00d"}},
+        {"op": "rdns6",         "params": {"address": "2001:db8::1", "prefix": 64}},
+        {"op": "mapped6",       "params": {"input": "192.0.2.1"}},
+    ]
+    status, data = _api_post("bulk", {"items": items})
+    assert_eq("api bulk multi-op: HTTP 200", status, 200)
+    assert_eq("api bulk multi-op: ok=true", data.get("ok"), True)
+    results = data.get("data", {}).get("results", [])
+    assert_eq("api bulk multi-op: 7 results returned", len(results), 7)
+    expected_ops = ["range6", "supernet6", "zone-id", "derive",
+                    "slaac-privacy", "rdns6", "mapped6"]
+    for i, op in enumerate(expected_ops):
+        envelope = results[i] if i < len(results) else {}
+        assert_eq(f"api bulk multi-op: item[{i}] op={op}", envelope.get("op"), op)
+        assert_eq(f"api bulk multi-op: item[{i}] ok=true", envelope.get("ok"), True)
+    # Spot-check a couple of payloads to confirm the result fields land at the
+    # top level of the envelope (not nested under `data`).
+    rdns = results[5]
+    assert_true("api bulk multi-op: rdns6 envelope has arpa", "arpa" in rdns)
+    mapped = results[6]
+    assert_eq("api bulk multi-op: mapped6 ipv4", mapped.get("ipv4"), "192.0.2.1")
+    assert_eq("api bulk multi-op: mapped6 ipv4_mapped",
+              mapped.get("ipv4_mapped"), "::ffff:192.0.2.1")
+
+    # Mixed valid + invalid — request still succeeds; bad item carries ok=false.
+    status_mix, data_mix = _api_post("bulk", {"items": [
+        {"op": "range6", "params": {"start": "2001:db8::", "end": "2001:db8::ff"}},
+        {"op": "rdns6",  "params": {"address": "not-an-address"}},
+    ]})
+    assert_eq("api bulk multi-op mixed: HTTP 200", status_mix, 200)
+    results_mix = data_mix.get("data", {}).get("results", [])
+    assert_eq("api bulk multi-op mixed: 2 results", len(results_mix), 2)
+    assert_eq("api bulk multi-op mixed: item[0] ok=true",
+              results_mix[0].get("ok") if results_mix else None, True)
+    assert_eq("api bulk multi-op mixed: item[1] ok=false",
+              results_mix[1].get("ok") if len(results_mix) > 1 else None, False)
+    assert_true("api bulk multi-op mixed: item[1] has error",
+                "error" in results_mix[1] if len(results_mix) > 1 else False)
+
+    # Unsupported op slug → ok=false envelope, request still 200.
+    status_bad, data_bad = _api_post("bulk", {"items": [
+        {"op": "flux-capacitor", "params": {}},
+    ]})
+    assert_eq("api bulk multi-op unsupported: HTTP 200", status_bad, 200)
+    bad_results = data_bad.get("data", {}).get("results", [])
+    assert_eq("api bulk multi-op unsupported: ok=false",
+              bad_results[0].get("ok") if bad_results else None, False)
+
+
 async def test_vlsm_session_ttl_notice(page: Page) -> None:
     section("VLSM session TTL notice")
     await navigate(page, APP_URL)
@@ -7557,6 +7615,7 @@ async def main() -> None:
             await test_api_openapi_spec(page)
             await test_api_rdns(page)
             await test_api_bulk(page)
+            await test_api_bulk_covers_new_ipv6_endpoints(page)
             await test_vlsm_session_ttl_notice(page)
             await test_session_forms_spacing(page)
             await test_vlsm6_session_save_load(page)

--- a/testing/unit/BulkTest.php
+++ b/testing/unit/BulkTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the v3.4.0 multi-op bulk dispatcher (functions-bulk.php).
+ *
+ * The standalone /bulk handler also has a legacy single-op CIDR-resolution
+ * mode; that mode is exercised by the Playwright API suite. These unit tests
+ * cover the per-op dispatch logic that powers the new `items[]` request mode.
+ */
+final class BulkTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!extension_loaded('gmp')) {
+            self::markTestSkipped('Bulk dispatcher exercises IPv6 ops which require GMP.');
+        }
+    }
+
+    // ── range6 ──────────────────────────────────────────────────────────────
+
+    public function testDispatchRange6Success(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'range6', 'params' => ['start' => '2001:db8::', 'end' => '2001:db8::ff']],
+        ]);
+        $this->assertCount(1, $r);
+        $this->assertSame('range6', $r[0]['op']);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertIsArray($r[0]['cidrs']);
+        $this->assertNotEmpty($r[0]['cidrs']);
+    }
+
+    public function testDispatchRange6InvalidStart(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'range6', 'params' => ['start' => 'not-an-address', 'end' => '2001:db8::ff']],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+        $this->assertNotEmpty($r[0]['error']);
+    }
+
+    // ── supernet6 ───────────────────────────────────────────────────────────
+
+    public function testDispatchSupernet6FindSuccess(): void
+    {
+        $r = bulk_dispatch_ops([
+            [
+                'op'     => 'supernet6',
+                'params' => [
+                    'action' => 'find',
+                    'cidrs'  => ['2001:db8:0::/48', '2001:db8:1::/48'],
+                ],
+            ],
+        ]);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertArrayHasKey('supernet', $r[0]);
+        $this->assertNotSame('', $r[0]['supernet']);
+    }
+
+    public function testDispatchSupernet6EmptyCidrs(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'supernet6', 'params' => ['action' => 'find', 'cidrs' => []]],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+    }
+
+    // ── zone-id ─────────────────────────────────────────────────────────────
+
+    public function testDispatchZoneIdSuccess(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'zone-id', 'params' => ['input' => 'fe80::1%eth0']],
+        ]);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertSame('fe80::1', $r[0]['address']);
+        $this->assertSame('eth0', $r[0]['zone_id']);
+        $this->assertTrue($r[0]['is_link_local']);
+    }
+
+    public function testDispatchZoneIdInvalid(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'zone-id', 'params' => ['input' => '']],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+    }
+
+    // ── derive ──────────────────────────────────────────────────────────────
+
+    public function testDispatchDeriveSuccess(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'derive', 'params' => ['mac' => '00:11:22:33:44:55']],
+        ]);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertArrayHasKey('eui64', $r[0]);
+        $this->assertArrayHasKey('link_local', $r[0]);
+    }
+
+    public function testDispatchDeriveInvalid(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'derive', 'params' => ['mac' => 'not-a-mac']],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+    }
+
+    // ── slaac-privacy ───────────────────────────────────────────────────────
+
+    public function testDispatchSlaacPrivacySuccess(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'slaac-privacy', 'params' => ['prefix' => '2001:db8::/64', 'seed' => 'deadbeefcafef00d']],
+        ]);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertArrayHasKey('address', $r[0]);
+        $this->assertArrayHasKey('interface_id', $r[0]);
+        $this->assertTrue($r[0]['seed_was_provided']);
+    }
+
+    public function testDispatchSlaacPrivacyInvalidPrefix(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'slaac-privacy', 'params' => ['prefix' => 'nonsense']],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+    }
+
+    // ── rdns6 ───────────────────────────────────────────────────────────────
+
+    public function testDispatchRdns6Success(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'rdns6', 'params' => ['address' => '2001:db8::1', 'prefix' => 64]],
+        ]);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertSame(64, $r[0]['prefix']);
+        $this->assertStringContainsString('ip6.arpa', $r[0]['arpa']);
+    }
+
+    public function testDispatchRdns6InvalidPrefix(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'rdns6', 'params' => ['address' => '2001:db8::1', 'prefix' => 'forty-two']],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+    }
+
+    // ── mapped6 ─────────────────────────────────────────────────────────────
+
+    public function testDispatchMapped6FromIpv4(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'mapped6', 'params' => ['input' => '192.0.2.1']],
+        ]);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertSame('192.0.2.1', $r[0]['ipv4']);
+        $this->assertSame('::ffff:192.0.2.1', $r[0]['ipv4_mapped']);
+        $this->assertStringStartsWith('64:ff9b::', $r[0]['nat64']);
+    }
+
+    public function testDispatchMapped6Invalid(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'mapped6', 'params' => ['input' => '2001:db8::1']],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+    }
+
+    // ── Top-level shape errors ─────────────────────────────────────────────
+
+    public function testDispatchUnknownOp(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'flux-capacitor', 'params' => []],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+        $this->assertStringContainsString('Unsupported op', $r[0]['error']);
+    }
+
+    public function testDispatchMissingOp(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['params' => ['address' => '2001:db8::1']],
+        ]);
+        $this->assertFalse($r[0]['ok']);
+        $this->assertStringContainsString('"op" is required', $r[0]['error']);
+    }
+
+    public function testDispatchNonArrayItem(): void
+    {
+        $r = bulk_dispatch_ops(['not an object']);
+        $this->assertFalse($r[0]['ok']);
+    }
+
+    // ── Mixed batch — happy path covering all 7 ops in one call ────────────
+
+    public function testDispatchMixedBatchAllOpsSucceed(): void
+    {
+        $items = [
+            ['op' => 'range6',        'params' => ['start' => '2001:db8::', 'end' => '2001:db8::ff']],
+            ['op' => 'supernet6',     'params' => ['action' => 'find', 'cidrs' => ['2001:db8:0::/48', '2001:db8:1::/48']]],
+            ['op' => 'zone-id',       'params' => ['input' => 'fe80::1%eth0']],
+            ['op' => 'derive',        'params' => ['mac' => '00:11:22:33:44:55']],
+            ['op' => 'slaac-privacy', 'params' => ['prefix' => '2001:db8::/64', 'seed' => 'cafef00ddeadbeef']],
+            ['op' => 'rdns6',         'params' => ['address' => '2001:db8::1', 'prefix' => 64]],
+            ['op' => 'mapped6',       'params' => ['input' => '192.0.2.1']],
+        ];
+        $r = bulk_dispatch_ops($items);
+        $this->assertCount(7, $r);
+        foreach ($r as $i => $envelope) {
+            $this->assertTrue($envelope['ok'], "Item $i ({$envelope['op']}) should succeed; error: "
+                . ($envelope['error'] ?? '<none>'));
+            $this->assertSame($items[$i]['op'], $envelope['op']);
+        }
+    }
+
+    public function testDispatchMixedBatchPartialFailure(): void
+    {
+        $r = bulk_dispatch_ops([
+            ['op' => 'range6', 'params' => ['start' => '2001:db8::', 'end' => '2001:db8::ff']],
+            ['op' => 'rdns6',  'params' => ['address' => 'not-an-address']],
+        ]);
+        $this->assertCount(2, $r);
+        $this->assertTrue($r[0]['ok']);
+        $this->assertFalse($r[1]['ok']);
+        $this->assertSame('rdns6', $r[1]['op']);
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -27,3 +27,4 @@ require $base . 'functions-range6.php';
 require $base . 'functions-tree.php';
 require $base . 'functions-tree-diff.php';
 require $base . 'functions-tree-presets.php';
+require $base . 'functions-bulk.php';


### PR DESCRIPTION
## Summary
Architecture item B. Adds 7 new ops to the bulk dispatch table: `range6`, `supernet6`, `zone-id`, `derive`, `slaac-privacy` (v3.3.0) + `rdns6`, `mapped6` (v3.4.0).

Mode is selected by request body shape:
- `{"cidrs": [...], "type": "..."}` keeps the legacy single-op CIDR-resolver behaviour (unchanged).
- `{"items": [{"op": "...", "params": {...}}, ...]}` activates the new multi-op dispatcher.

Per-item error envelope on the new path: `{op, ok: false, error}`. On success: `{op, ok: true, ...result}` where `...result` matches the corresponding standalone endpoint's body. Top-level shape errors (missing `op`, unknown `op`, non-array item) are surfaced per-item with `ok: false` rather than as a 400 — matches the legacy mode's "individual failures don't abort the request" contract.

Implementation: new `includes/functions-bulk.php` exposes a pure `bulk_dispatch_ops(array $items): array`. Handler wires the new mode into `handlers/bulk.php` (existing legacy path untouched). Each per-op adapter calls the corresponding underlying pure function (`range6_to_cidrs`, `supernet6_find` / `summarise6_cidrs`, `parse_zone_id`, `derive_from_mac`, `slaac_privacy_address`, `ipv6_to_arpa`, `ipv4_to_mapped` / `nat64_to_ipv4` / etc.) — no refactoring of existing handlers required.

## Test plan
- [x] PHPUnit `BulkTest` (19 tests, 58 assertions): success + error case per op + mixed batch + unknown-op + missing-op + non-array item
- [x] Full PHPUnit suite: 516 tests / 1205 assertions (was 497 / 1147 — +19 tests added)
- [x] PHPStan L9 clean
- [x] PHPCS PSR-12 clean
- [x] Spectral OpenAPI lint clean (oneOf branch added; example payload covers all 7 ops)
- [x] Semgrep clean
- [x] npm lint clean
- [x] Playwright Docker suite: 1351/1351 passing — includes new `test_api_bulk_covers_new_ipv6_endpoints` exercising the actual HTTP path with a mixed 7-op batch + partial-failure + unsupported-op case
- [x] Backward compat: existing `test_api_bulk` (legacy `cidrs[]` mode) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)