### PR TITLE
feat(v3.5.0): IPv6 embedded-v4 detector (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-MM-DD
+
+**IPv6 Prefix Planning + Transition.** Combines the prefix-planning
+items originally roadmapped for v3.4.0 with the originally-planned
+v3.5.0 transition theme. PRs land incrementally; this section accretes
+as each ships.
+
+### Added
+
+- **IPv6 embedded-v4 detector.** Front-door tool for the v3.5.0
+  transition theme: detects IPv4-mapped, IPv4-compatible (deprecated),
+  6to4, Teredo, NAT64 well-known, and ISATAP embeddings; extracts the
+  embedded IPv4. Deep-links to per-scheme tools as they ship. (#390)
+
 ## [3.4.1] - 2026-05-08
 
 **Patch.** CodeRabbit cleanup carried over from v3.4.0's tracking PR review.

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -1936,7 +1936,7 @@ paths:
                           scheme:
                             type: string
                             nullable: true
-                            enum: [mapped, compatible, 6to4, teredo, nat64-wkp, nat64-nsp, isatap]
+                            enum: [mapped, compatible, 6to4, teredo, nat64-wkp, isatap]
                             example: "mapped"
                           ipv4:
                             type: string

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -65,6 +65,8 @@ tags:
     description: Reverse-DNS zone generation
   - name: Mapped6
     description: IPv4-mapped IPv6 and NAT64 conversion
+  - name: EmbeddedV4
+    description: IPv6 embedded-IPv4 detector (front door for v3.5.0 transition tools)
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -353,6 +355,7 @@ paths:
                     - "POST /api/v1/rdns"
                     - "POST /api/v1/rdns6"
                     - "POST /api/v1/mapped6"
+                    - "POST /api/v1/embedded-v4"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -1838,6 +1841,130 @@ paths:
                   nat64_prefix: "64:ff9b::/96"
         "400":
           description: Invalid input (unparseable address, not within supplied prefix, or non-/96 NAT64 prefix)
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /embedded-v4:
+    post:
+      operationId: embeddedV4Detect
+      tags: [EmbeddedV4]
+      summary: Detect embedded-IPv4 scheme inside an IPv6 address
+      description: |
+        Front-door detector for the IPv6 transition tools (v3.5.0).
+        Identifies whether the supplied IPv6 address embeds an IPv4 via
+        any of the supported schemes:
+
+        - `mapped`     — IPv4-mapped (`::ffff:0:0/96`, RFC 4291 §2.5.5.2)
+        - `compatible` — IPv4-compatible (`::/96`, RFC 4291 §2.5.5.1, **deprecated**)
+        - `6to4`       — RFC 3056 (`2002::/16`)
+        - `teredo`     — RFC 4380 (`2001:0::/32`)
+        - `nat64-wkp`  — NAT64 well-known prefix (`64:ff9b::/96`, RFC 6052)
+        - `isatap`     — RFC 5214 IID `*0000:5efe:V4` or `*0200:5efe:V4`
+
+        When no embedded IPv4 is detected, `scheme` and `ipv4` are `null`.
+        `detail_route` deep-links to the per-scheme tool drawer when
+        available; v3.5.0 PRs T3–T7 wire it as those drawers ship.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [input]
+              properties:
+                input:
+                  type: string
+                  description: An IPv6 address literal.
+                  example: "::ffff:192.0.2.1"
+            examples:
+              mapped:
+                summary: IPv4-mapped IPv6
+                value: { input: "::ffff:192.0.2.1" }
+              six-to-four:
+                summary: 6to4
+                value: { input: "2002:c000:0201::" }
+              teredo:
+                summary: Teredo (RFC 4380 §4 example)
+                value: { input: "2001:0:4136:e378:8000:63bf:3fff:fdd2" }
+              nat64-wkp:
+                summary: NAT64 well-known prefix
+                value: { input: "64:ff9b::192.0.2.1" }
+              isatap:
+                summary: ISATAP
+                value: { input: "2001:db8::200:5efe:c000:201" }
+      responses:
+        "200":
+          description: Detection result (or null scheme when no embedded IPv4 was found)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [input, scheme, ipv4, deprecated, detail_route, extra]
+                        properties:
+                          input:
+                            type: string
+                            example: "::ffff:192.0.2.1"
+                          scheme:
+                            type: string
+                            nullable: true
+                            enum: [mapped, compatible, 6to4, teredo, nat64-wkp, nat64-nsp, isatap]
+                            example: "mapped"
+                          ipv4:
+                            type: string
+                            nullable: true
+                            example: "192.0.2.1"
+                          deprecated:
+                            type: boolean
+                            example: false
+                          detail_route:
+                            type: string
+                            nullable: true
+                            description: Relative URL of the per-scheme tool drawer; null until that drawer ships.
+                            example: null
+                          extra:
+                            type: object
+                            description: Scheme-specific extras (e.g. Teredo flags + UDP port, 6to4 SLA ID, ISATAP u-bit).
+                            additionalProperties: true
+              example:
+                ok: true
+                data:
+                  input: "::ffff:192.0.2.1"
+                  scheme: "mapped"
+                  ipv4: "192.0.2.1"
+                  deprecated: false
+                  detail_route: null
+                  extra: {}
+        "400":
+          description: Missing or unparseable IPv6 input
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/embedded-v4.php
+++ b/Subnet-Calculator/api/v1/handlers/embedded-v4.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body      = api_body();
+$raw_input = $body['input'] ?? null;
+
+if (!is_string($raw_input) || trim($raw_input) === '') {
+    json_err('Field "input" (string) is required.', 400);
+}
+$input = trim($raw_input);
+
+try {
+    $detection = detect_embedded_v4($input);
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'input'        => $input,
+    'scheme'       => $detection['scheme'],
+    'ipv4'         => $detection['ipv4'],
+    'deprecated'   => $detection['deprecated'],
+    'detail_route' => $detection['detail_route'],
+    'extra'        => $detection['extra'],
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -28,6 +28,7 @@ require $base . 'functions-derive6.php';
 require $base . 'functions-slaac6.php';
 require $base . 'functions-rdns6.php';
 require $base . 'functions-mapped6.php';
+require $base . 'functions-embedded-v4.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -114,6 +115,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/rdns',
             'POST /api/v1/rdns6',
             'POST /api/v1/mapped6',
+            'POST /api/v1/embedded-v4',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -240,6 +242,9 @@ switch ($route_key) {
         break;
     case 'POST /mapped6':
         require __DIR__ . '/handlers/mapped6.php';
+        break;
+    case 'POST /embedded-v4':
+        require __DIR__ . '/handlers/embedded-v4.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-embedded-v4.php
+++ b/Subnet-Calculator/includes/functions-embedded-v4.php
@@ -64,7 +64,7 @@ function ipv6_in_prefix(string $address, string $prefix, int $prefix_length): bo
  * Detect any embedded-IPv4 scheme in the given IPv6 address.
  *
  * @return array{
- *     scheme: ?string,
+ *     scheme: 'mapped'|'compatible'|'6to4'|'teredo'|'nat64-wkp'|'isatap'|null,
  *     ipv4: ?string,
  *     deprecated: bool,
  *     detail_route: ?string,
@@ -101,6 +101,9 @@ function detect_embedded_v4(string $ipv6): array
     }
 
     // 2. NAT64 well-known prefix: 64:ff9b::/96.
+    // TODO(nat64-nsp): reintroduce 'nat64-nsp' scheme when operator NSP
+    // configuration lands (T3–T7); add the matching enum value back to
+    // openapi.yaml and the layout.php scheme-label map atomically.
     if (substr($bin, 0, 12) === EMBEDDEDV4_NAT64_WKP_PREFIX_BIN) {
         $v4 = @inet_ntop(substr($bin, 12, 4));
         return [

--- a/Subnet-Calculator/includes/functions-embedded-v4.php
+++ b/Subnet-Calculator/includes/functions-embedded-v4.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+// IPv6 embedded-IPv4 detector (v3.5.0).
+//
+// Identifies any of the IPv6→IPv4 transition embedding schemes the project
+// supports as front-door entry points to per-scheme tools:
+//
+//   - IPv4-mapped         ::ffff:0:0/96    (RFC 4291 §2.5.5.2; widely deployed)
+//   - IPv4-compatible     ::/96            (RFC 4291 §2.5.5.1; DEPRECATED)
+//   - 6to4                2002::/16        (RFC 3056)
+//   - Teredo              2001::/32        (RFC 4380)
+//   - NAT64 well-known    64:ff9b::/96     (RFC 6052 / RFC 6146)
+//   - ISATAP              IID `*0000:5efe:V4` or `*0200:5efe:V4` (RFC 5214)
+//
+// Detection priority follows the most-specific-prefix-first rule: any address
+// matching ::ffff:0:0/96 is reported as `mapped`, not `compatible`; the
+// compatible branch is reached only by addresses inside ::/96 that fall
+// outside the mapped block. Pure ::1 and :: are explicitly excluded from
+// `compatible`, per RFC 4291 §2.5.5.1.
+//
+// `detail_route` is seeded to null in this PR — per-scheme drawers (T3–T7)
+// will replace those null values with the live `/ipv6/<tool>` URLs as they
+// land. The contract is pinned by EmbeddedV4Test::test_detail_route_seeded_null_for_now.
+
+const EMBEDDEDV4_MAPPED_PREFIX_BIN     = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff";
+const EMBEDDEDV4_NAT64_WKP_PREFIX_BIN  = "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00";
+const EMBEDDEDV4_6TO4_PREFIX_BIN       = "\x20\x02";
+const EMBEDDEDV4_TEREDO_PREFIX_BIN     = "\x20\x01\x00\x00";
+
+/**
+ * Return true if $address parses as a valid IPv6 literal whose top
+ * $prefix_length bits match the $prefix network. GMP throughout for
+ * arbitrary prefix lengths.
+ *
+ * Returns false (no throw) on parse failure or prefix length out of
+ * the 0..128 range — the caller should validate inputs first.
+ */
+function ipv6_in_prefix(string $address, string $prefix, int $prefix_length): bool
+{
+    if ($prefix_length < 0 || $prefix_length > 128) {
+        return false;
+    }
+    $abin = @inet_pton($address);
+    $pbin = @inet_pton($prefix);
+    if ($abin === false || $pbin === false || strlen($abin) !== 16 || strlen($pbin) !== 16) {
+        return false;
+    }
+    if ($prefix_length === 0) {
+        return true;
+    }
+    $a = gmp_import($abin);
+    $p = gmp_import($pbin);
+    $shift = 128 - $prefix_length;
+    // Build mask = ((1 << 128) - 1) ^ ((1 << shift) - 1)
+    $all  = gmp_sub(gmp_pow(2, 128), 1);
+    $low  = $shift === 0 ? gmp_init(0) : gmp_sub(gmp_pow(2, $shift), 1);
+    $mask = gmp_xor($all, $low);
+    return gmp_cmp(gmp_and($a, $mask), gmp_and($p, $mask)) === 0;
+}
+
+/**
+ * Detect any embedded-IPv4 scheme in the given IPv6 address.
+ *
+ * @return array{
+ *     scheme: ?string,
+ *     ipv4: ?string,
+ *     deprecated: bool,
+ *     detail_route: ?string,
+ *     extra: array<string, mixed>
+ * }
+ *
+ * @throws InvalidArgumentException if $ipv6 is not a parseable IPv6 literal.
+ */
+function detect_embedded_v4(string $ipv6): array
+{
+    $bin = @inet_pton($ipv6);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid IPv6 address');
+    }
+
+    $none = [
+        'scheme'       => null,
+        'ipv4'         => null,
+        'deprecated'   => false,
+        'detail_route' => null,
+        'extra'        => [],
+    ];
+
+    // 1. IPv4-mapped: ::ffff:0:0/96 — most-specific check first.
+    if (substr($bin, 0, 12) === EMBEDDEDV4_MAPPED_PREFIX_BIN) {
+        $v4 = @inet_ntop(substr($bin, 12, 4));
+        return [
+            'scheme'       => 'mapped',
+            'ipv4'         => $v4 === false ? null : $v4,
+            'deprecated'   => false,
+            'detail_route' => null,
+            'extra'        => [],
+        ];
+    }
+
+    // 2. NAT64 well-known prefix: 64:ff9b::/96.
+    if (substr($bin, 0, 12) === EMBEDDEDV4_NAT64_WKP_PREFIX_BIN) {
+        $v4 = @inet_ntop(substr($bin, 12, 4));
+        return [
+            'scheme'       => 'nat64-wkp',
+            'ipv4'         => $v4 === false ? null : $v4,
+            'deprecated'   => false,
+            'detail_route' => null,
+            'extra'        => [],
+        ];
+    }
+
+    // 3. 6to4: 2002::/16, embedded V4 in bytes 2–5.
+    if (substr($bin, 0, 2) === EMBEDDEDV4_6TO4_PREFIX_BIN) {
+        $v4 = @inet_ntop(substr($bin, 2, 4));
+        return [
+            'scheme'       => '6to4',
+            'ipv4'         => $v4 === false ? null : $v4,
+            'deprecated'   => false,
+            'detail_route' => null,
+            'extra'        => [
+                'sla_id' => bin2hex(substr($bin, 6, 2)),
+            ],
+        ];
+    }
+
+    // 4. Teredo: 2001:0::/32, RFC 4380. Server IPv4 in bytes 4–7;
+    //    obfuscated client IPv4 (XOR 0xFF) in bytes 12–15; flags+port in 8–11.
+    if (substr($bin, 0, 4) === EMBEDDEDV4_TEREDO_PREFIX_BIN) {
+        $serverV4 = @inet_ntop(substr($bin, 4, 4));
+        $clientObf = substr($bin, 12, 4);
+        $clientPlain = '';
+        for ($i = 0; $i < 4; $i++) {
+            $clientPlain .= chr(ord($clientObf[$i]) ^ 0xFF);
+        }
+        $clientV4 = @inet_ntop($clientPlain);
+        $flags    = bin2hex(substr($bin, 8, 2));
+        $portObf  = substr($bin, 10, 2);
+        $port     = ((ord($portObf[0]) ^ 0xFF) << 8) | (ord($portObf[1]) ^ 0xFF);
+        return [
+            'scheme'       => 'teredo',
+            'ipv4'         => $clientV4 === false ? null : $clientV4,
+            'deprecated'   => false,
+            'detail_route' => null,
+            'extra'        => [
+                'server_ipv4' => $serverV4 === false ? null : $serverV4,
+                'flags'       => $flags,
+                'udp_port'    => $port,
+            ],
+        ];
+    }
+
+    // 5. ISATAP: IID matches `*:0000:5efe:V4ADDR` (locally-administered)
+    //    or `*:0200:5efe:V4ADDR` (globally-unique u-bit set). Bytes 8–11
+    //    of the address hold the magic; V4 in bytes 12–15. Any /64 prefix.
+    $iidMagic = substr($bin, 8, 4);
+    if ($iidMagic === "\x00\x00\x5e\xfe" || $iidMagic === "\x02\x00\x5e\xfe") {
+        $v4 = @inet_ntop(substr($bin, 12, 4));
+        return [
+            'scheme'       => 'isatap',
+            'ipv4'         => $v4 === false ? null : $v4,
+            'deprecated'   => false,
+            'detail_route' => null,
+            'extra'        => [
+                'globally_unique' => $iidMagic === "\x02\x00\x5e\xfe",
+            ],
+        ];
+    }
+
+    // 6. IPv4-compatible: ::/96, RFC 4291 §2.5.5.1 (DEPRECATED).
+    //    Reached only after the mapped/wkp checks above failed, so the top
+    //    96 bits are zero AND the bottom 32 bits are not the special ::1
+    //    loopback or :: unspecified. Per RFC 4291 those reserved values
+    //    are NOT IPv4-compatible.
+    if (substr($bin, 0, 12) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00") {
+        $tail = substr($bin, 12, 4);
+        if ($tail === "\x00\x00\x00\x00" || $tail === "\x00\x00\x00\x01") {
+            return $none;
+        }
+        $v4 = @inet_ntop($tail);
+        return [
+            'scheme'       => 'compatible',
+            'ipv4'         => $v4 === false ? null : $v4,
+            'deprecated'   => true,
+            'detail_route' => null,
+            'extra'        => [],
+        ];
+    }
+
+    return $none;
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -360,6 +360,48 @@ function sc_run_mapped6(array $input): array
     ];
 }
 
+// ─── Embedded-IPv4 detector helper (shared by POST handler and GET shareable URL) ─
+
+/**
+ * Run detect_embedded_v4() against the supplied IPv6 address and return an
+ * associative array with keys: input, scheme, ipv4, deprecated, detail_route,
+ * extra, error. Empty input early-returns []. (v3.5.0 Task 2)
+ *
+ * @return array{
+ *     input?: string,
+ *     scheme?: ?string,
+ *     ipv4?: ?string,
+ *     deprecated?: bool,
+ *     detail_route?: ?string,
+ *     extra?: array<string,mixed>,
+ *     error?: string|null
+ * }
+ */
+function sc_run_embedded_v4(string $address): array
+{
+    $raw = trim($address);
+    if ($raw === '') {
+        return [];
+    }
+    try {
+        $detection = detect_embedded_v4($raw);
+    } catch (\InvalidArgumentException $e) {
+        return [
+            'input' => $raw,
+            'error' => $e->getMessage(),
+        ];
+    }
+    return [
+        'input'        => $raw,
+        'scheme'       => $detection['scheme'],
+        'ipv4'         => $detection['ipv4'],
+        'deprecated'   => $detection['deprecated'],
+        'detail_route' => $detection['detail_route'],
+        'extra'        => $detection['extra'],
+        'error'        => null,
+    ];
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -501,6 +543,11 @@ $mapped6_prefix_input = '';
 /** @var array{input?: string, ipv4?: string, ipv4_mapped?: string, nat64?: string, nat64_prefix?: string, error?: string|null} */
 $mapped6 = [];
 
+// v3.5.0 Task 2 — IPv6 embedded-v4 detector (front door)
+$embedded_v4_input = '';
+/** @var array{input?: string, scheme?: ?string, ipv4?: ?string, deprecated?: bool, detail_route?: ?string, extra?: array<string,mixed>, error?: string|null} */
+$embedded_v4 = [];
+
 $ula_global_id_input = '';
 /** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
 $ula = [];
@@ -564,6 +611,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_slaac         = isset($_POST['slaac_prefix']);
     $is_rdns6         = isset($_POST['rdns6_address']);
     $is_mapped6       = isset($_POST['mapped6_input']);
+    $is_embedded_v4   = isset($_POST['embedded_v4_input']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -571,7 +619,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_tool = $is_splitter || $is_overlap || $is_multi_overlap || $is_vlsm
         || $is_vlsm6 || $is_supernet || $is_supernet6 || $is_ula || $is_session_save || $is_range
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
-        || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6;
+        || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6 || $is_embedded_v4;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -982,6 +1030,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         ]);
     }
 
+    if ($is_embedded_v4 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $embedded_v4_input = trim((string)($_POST['embedded_v4_input'] ?? ''));
+        $embedded_v4 = sc_run_embedded_v4($embedded_v4_input);
+    }
+
     if ($is_ula && !$form_blocked) {
         $ula_global_id_input = trim((string)($_POST['ula_global_id'] ?? ''));
         $ur = generate_ula_prefix($ula_global_id_input);
@@ -1379,6 +1433,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'input'        => $mapped6_input,
             'nat64_prefix' => $mapped6_prefix_input,
         ]);
+    }
+
+    // Embedded-v4 detector shareable GET URL (v3.5.0 Task 2)
+    if ($active_tab === 'ipv6' && isset($_GET['embedded_v4_input'])) {
+        $embedded_v4_input = trim((string)($_GET['embedded_v4_input'] ?? ''));
+        $embedded_v4 = sc_run_embedded_v4($embedded_v4_input);
     }
 
     // Supernet6 / summarise6 shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -20,6 +20,7 @@ require __DIR__ . '/includes/functions-derive6.php';
 require __DIR__ . '/includes/functions-slaac6.php';
 require __DIR__ . '/includes/functions-rdns6.php';
 require __DIR__ . '/includes/functions-mapped6.php';
+require __DIR__ . '/includes/functions-embedded-v4.php';
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -1417,7 +1417,6 @@ if ($i < 3) {
                             '6to4'       => '6to4 (RFC 3056)',
                             'teredo'     => 'Teredo (RFC 4380)',
                             'nat64-wkp'  => 'NAT64 well-known prefix (RFC 6052)',
-                            'nat64-nsp'  => 'NAT64 network-specific prefix (RFC 6052)',
                             'isatap'     => 'ISATAP (RFC 5214)',
                         ];
                         $_ev4_scheme    = (string)($embedded_v4['scheme'] ?? '');

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -764,9 +764,10 @@ if ($i < 3) {
         elseif (!empty($diff) && $active_tab === 'ipv6') { $open_tool_ipv6 = 'diff'; }
         elseif (!empty($rdns6)) { $open_tool_ipv6 = 'rdns6'; }
         elseif (!empty($mapped6)) { $open_tool_ipv6 = 'mapped6'; }
+        elseif (!empty($embedded_v4)) { $open_tool_ipv6 = 'embedded-v4'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -784,6 +785,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="diff" aria-expanded="false">Subnet Diff</button>
             <button type="button" class="tool-trigger" data-tool="rdns6" aria-expanded="false">Reverse DNS</button>
             <button type="button" class="tool-trigger" data-tool="mapped6" aria-expanded="false">IPv4-mapped / NAT64</button>
+            <button type="button" class="tool-trigger" data-tool="embedded-v4" aria-expanded="false">Embedded IPv4</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -1380,6 +1382,99 @@ if ($i < 3) {
                             <div class="zoneid-result__row">
                                 <dt class="zoneid-result__label">NAT64 prefix</dt>
                                 <dd class="zoneid-result__value"><code><?= htmlspecialchars((string)$mapped6['nat64_prefix']) ?></code></dd>
+                            </div>
+                        </dl>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="embedded-v4">
+                <div class="overlap-panel">
+                    <div class="overlap-title">Embedded IPv4 detector<?= help_bubble('ipv6-embedded-v4', 'Front door for v3.5.0 transition tools. Detects whether an IPv6 address embeds an IPv4 via IPv4-mapped, IPv4-compatible (deprecated), 6to4, Teredo, NAT64 well-known, or ISATAP — and extracts the embedded IPv4. Per-scheme deep-link buttons activate as their drawers ship.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="embedded_v4_input">IPv6 address<?= help_bubble('embedded-v4-input', 'Any IPv6 literal. Examples: ::ffff:192.0.2.1 (mapped), 2002:c000:0201:: (6to4), 64:ff9b::192.0.2.1 (NAT64 WKP), 2001:db8::200:5efe:c000:201 (ISATAP).') ?></label>
+                                <input type="text" id="embedded_v4_input" name="embedded_v4_input"
+                                       value="<?= htmlspecialchars($embedded_v4_input ?? '') ?>"
+                                       placeholder="::ffff:192.0.2.1"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($embedded_v4['error']) ? 'aria-invalid="true" aria-describedby="embedded-v4-error"' : '' ?>>
+                            </div>
+                        </div>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Detect</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($embedded_v4['error'])) : ?>
+                        <div class="error" id="embedded-v4-error"><?= htmlspecialchars((string)$embedded_v4['error']) ?></div>
+                    <?php elseif (array_key_exists('scheme', $embedded_v4) && $embedded_v4['scheme'] !== null) : ?>
+                        <?php
+                        $_ev4_scheme_labels = [
+                            'mapped'     => 'IPv4-mapped IPv6 (RFC 4291)',
+                            'compatible' => 'IPv4-compatible IPv6 (RFC 4291, DEPRECATED)',
+                            '6to4'       => '6to4 (RFC 3056)',
+                            'teredo'     => 'Teredo (RFC 4380)',
+                            'nat64-wkp'  => 'NAT64 well-known prefix (RFC 6052)',
+                            'nat64-nsp'  => 'NAT64 network-specific prefix (RFC 6052)',
+                            'isatap'     => 'ISATAP (RFC 5214)',
+                        ];
+                        $_ev4_scheme    = (string)($embedded_v4['scheme'] ?? '');
+                        $_ev4_label     = $_ev4_scheme === ''
+                            ? 'No embedded IPv4 detected'
+                            : ($_ev4_scheme_labels[$_ev4_scheme] ?? $_ev4_scheme);
+                        $_ev4_history   = 'embedded-v4: ' . (string)$embedded_v4['input'];
+                        $_ev4_route     = $embedded_v4['detail_route'] ?? null;
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="embedded-v4"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_ev4_history) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Scheme</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars($_ev4_label) ?></code>
+                                    <?php if (!empty($embedded_v4['deprecated'])) : ?>
+                                        <span class="badge badge-private">deprecated</span>
+                                    <?php endif; ?>
+                                </dd>
+                            </div>
+                            <?php if (!empty($embedded_v4['ipv4'])) : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Embedded IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)$embedded_v4['ipv4']) ?></code>
+                                        <?= copy_button((string)$embedded_v4['ipv4'], 'Copy embedded IPv4') ?>
+                                    </dd>
+                                </div>
+                            <?php endif; ?>
+                            <?php if (is_array($embedded_v4['extra'] ?? null) && $embedded_v4['extra'] !== []) : ?>
+                                <?php foreach ($embedded_v4['extra'] as $_ev4_key => $_ev4_val) : ?>
+                                    <div class="zoneid-result__row">
+                                        <dt class="zoneid-result__label"><?= htmlspecialchars((string)$_ev4_key) ?></dt>
+                                        <dd class="zoneid-result__value">
+                                            <code><?= htmlspecialchars(is_scalar($_ev4_val) ? (string)$_ev4_val : ((string)(json_encode($_ev4_val) ?: ''))) ?></code>
+                                        </dd>
+                                    </div>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Open in tool</dt>
+                                <dd class="zoneid-result__value">
+                                    <?php if ($_ev4_route !== null && $_ev4_route !== '') : ?>
+                                        <a class="splitter-btn" href="<?= htmlspecialchars((string)$_ev4_route) ?>">Open <?= htmlspecialchars($_ev4_scheme) ?> tool</a>
+                                    <?php else : ?>
+                                        <button type="button" class="splitter-btn" disabled aria-disabled="true" title="Per-scheme tool not yet available — lands in subsequent v3.5.0 PRs.">Open <?= htmlspecialchars($_ev4_scheme) ?> tool</button>
+                                    <?php endif; ?>
+                                </dd>
+                            </div>
+                        </dl>
+                    <?php elseif (array_key_exists('scheme', $embedded_v4) && $embedded_v4['scheme'] === null) : ?>
+                        <dl class="zoneid-result">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Result</dt>
+                                <dd class="zoneid-result__value"><code>No embedded IPv4 detected</code></dd>
                             </div>
                         </dl>
                     <?php endif; ?>

--- a/docs/embedded-v4.md
+++ b/docs/embedded-v4.md
@@ -1,0 +1,135 @@
+# Embedded IPv4 Detector
+
+The Embedded IPv4 Detector is the **front door** for the v3.5.0 IPv6
+transition tools. Paste any IPv6 literal and the detector identifies
+which IPv4-embedding scheme (if any) it uses, extracts the embedded
+IPv4 address, and offers a deep-link to the per-scheme tool drawer.
+
+The drawer lives in the **Tool Drawer** on the IPv6 tab and auto-opens
+via the per-tool URL route `/ipv6/embedded-v4`.
+
+## Synopsis
+
+| Input        | Required | Type   | Notes                                |
+|--------------|----------|--------|--------------------------------------|
+| IPv6 address | Yes      | string | Any IPv6 literal, e.g. `::ffff:192.0.2.1` |
+
+| Output        | Type    | Notes                                                                |
+|---------------|---------|----------------------------------------------------------------------|
+| input         | string  | Echoed input                                                         |
+| scheme        | string? | One of `mapped`, `compatible`, `6to4`, `teredo`, `nat64-wkp`, `isatap`, or `null` when no embedding is detected |
+| ipv4          | string? | Extracted IPv4 dotted-quad, or `null`                                |
+| deprecated    | bool    | `true` for `compatible` (RFC 4291 §2.5.5.1 deprecates IPv4-compatible) |
+| detail_route  | string? | Relative URL to the per-scheme tool drawer; `null` until that drawer ships |
+| extra         | object  | Scheme-specific extras (e.g. Teredo flags + UDP port, 6to4 SLA ID, ISATAP u-bit) |
+
+## Detection priority
+
+The detector checks each scheme in order of most-specific prefix first
+to avoid mis-classifying an IPv4-mapped address as IPv4-compatible
+(both sit under `::/96`):
+
+1. **IPv4-mapped** — `::ffff:0:0/96` (RFC 4291 §2.5.5.2)
+2. **NAT64 well-known prefix** — `64:ff9b::/96` (RFC 6052 §2.1)
+3. **6to4** — `2002::/16` (RFC 3056)
+4. **Teredo** — `2001:0::/32` (RFC 4380)
+5. **ISATAP** — IID matches `*0000:5efe:V4` or `*0200:5efe:V4` (RFC 5214)
+6. **IPv4-compatible** (deprecated) — `::/96`, excluding the reserved
+   `::1` (loopback) and `::` (unspecified) literals
+
+If none match, the detector returns `scheme: null` and `ipv4: null`.
+
+## Examples
+
+### IPv4-mapped (`::ffff:0:0/96`)
+
+```text
+Input:  ::ffff:192.0.2.1
+Scheme: mapped
+IPv4:   192.0.2.1
+```
+
+### IPv4-compatible (DEPRECATED)
+
+```text
+Input:  ::192.0.2.1
+Scheme: compatible
+IPv4:   192.0.2.1
+Deprecated: true
+```
+
+RFC 4291 §2.5.5.1 deprecates this form. The detector flags it so
+operators auditing legacy configurations see it explicitly.
+
+### 6to4 (`2002::/16`)
+
+```text
+Input:  2002:c000:0201::
+Scheme: 6to4
+IPv4:   192.0.2.1
+Extra:  sla_id (next 16 bits after the embedded V4)
+```
+
+### Teredo (`2001:0::/32`)
+
+```text
+Input:  2001:0:4136:e378:8000:63bf:3fff:fdd2
+Scheme: teredo
+IPv4:   <client IPv4, deobfuscated by XOR 0xFF>
+Extra:  server_ipv4, flags, udp_port (deobfuscated)
+```
+
+### NAT64 well-known prefix (`64:ff9b::/96`)
+
+```text
+Input:  64:ff9b::192.0.2.1
+Scheme: nat64-wkp
+IPv4:   192.0.2.1
+```
+
+The detector currently flags only the well-known prefix. NAT64
+network-specific prefixes (operator-supplied, RFC 6052 §2.2) are
+matched via the dedicated `mapped6` tool's NAT64 prefix field.
+
+### ISATAP (`*0000:5efe:V4` or `*0200:5efe:V4`)
+
+```text
+Input:  2001:db8::200:5efe:c000:201
+Scheme: isatap
+IPv4:   192.0.2.1
+Extra:  globally_unique=true (u-bit set in the IID)
+```
+
+### No embedding
+
+```text
+Input:  2001:db8::1
+Scheme: null
+```
+
+## Deep-links to per-scheme tools
+
+The result card includes an **Open in tool** button that deep-links to
+the per-scheme drawer when one exists. In v3.5.0 those drawers ship
+incrementally — when the per-scheme drawer for a given scheme has not
+yet shipped, the button is rendered but disabled. As subsequent
+v3.5.0 PRs land, each updates `functions-embedded-v4.php` to populate
+`detail_route` for its scheme.
+
+## REST API
+
+`POST /api/v1/embedded-v4` accepts a single `input` (string) field and
+returns the same `scheme`, `ipv4`, `deprecated`, `detail_route`, and
+`extra` fields documented above. See the
+[REST API reference](api.md) for the full request/response shape.
+
+## Shareable URL
+
+The detector supports shareable GET URLs:
+
+```text
+/ipv6/embedded-v4?embedded_v4_input=::ffff:192.0.2.1
+```
+
+This auto-opens the drawer, runs the detector, and renders the result —
+suitable for ticket links and runbook bookmarks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Reverse DNS Zones: rdns.md
     - IPv6 Reverse DNS (rdns6): ipv6-rdns6.md
     - IPv4-mapped / NAT64 (mapped6): ipv6-mapped6.md
+    - Embedded IPv4 Detector: embedded-v4.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -2935,6 +2935,145 @@ async def test_ipv6_mapped6_ui(page: Page) -> None:
               await panel.locator(".zoneid-result__row").count(), 0)
 
 
+async def test_api_embedded_v4(page: Page) -> None:
+    section("API — POST /api/v1/embedded-v4")
+    # IPv4-mapped → scheme=mapped, ipv4 extracted
+    status, data = _api_post("embedded-v4", {"input": "::ffff:192.0.2.1"})
+    assert_eq("api embedded-v4 (mapped): HTTP 200", status, 200)
+    assert_eq("api embedded-v4 (mapped): ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api embedded-v4 (mapped): scheme", d.get("scheme"), "mapped")
+    assert_eq("api embedded-v4 (mapped): ipv4", d.get("ipv4"), "192.0.2.1")
+    assert_eq("api embedded-v4 (mapped): deprecated=False", d.get("deprecated"), False)
+    assert_eq("api embedded-v4 (mapped): detail_route is null",
+              d.get("detail_route"), None)
+
+    # IPv4-compatible → deprecated
+    status2, data2 = _api_post("embedded-v4", {"input": "::192.0.2.1"})
+    assert_eq("api embedded-v4 (compat): HTTP 200", status2, 200)
+    assert_eq("api embedded-v4 (compat): scheme",
+              data2.get("data", {}).get("scheme"), "compatible")
+    assert_eq("api embedded-v4 (compat): deprecated=True",
+              data2.get("data", {}).get("deprecated"), True)
+
+    # 6to4
+    status3, data3 = _api_post("embedded-v4", {"input": "2002:c000:0201::"})
+    assert_eq("api embedded-v4 (6to4): HTTP 200", status3, 200)
+    assert_eq("api embedded-v4 (6to4): scheme",
+              data3.get("data", {}).get("scheme"), "6to4")
+    assert_eq("api embedded-v4 (6to4): ipv4",
+              data3.get("data", {}).get("ipv4"), "192.0.2.1")
+
+    # Teredo
+    status4, data4 = _api_post("embedded-v4",
+                               {"input": "2001:0:4136:e378:8000:63bf:3fff:fdd2"})
+    assert_eq("api embedded-v4 (teredo): HTTP 200", status4, 200)
+    assert_eq("api embedded-v4 (teredo): scheme",
+              data4.get("data", {}).get("scheme"), "teredo")
+
+    # NAT64 well-known
+    status5, data5 = _api_post("embedded-v4", {"input": "64:ff9b::192.0.2.1"})
+    assert_eq("api embedded-v4 (nat64-wkp): HTTP 200", status5, 200)
+    assert_eq("api embedded-v4 (nat64-wkp): scheme",
+              data5.get("data", {}).get("scheme"), "nat64-wkp")
+    assert_eq("api embedded-v4 (nat64-wkp): ipv4",
+              data5.get("data", {}).get("ipv4"), "192.0.2.1")
+
+    # ISATAP
+    status6, data6 = _api_post("embedded-v4",
+                               {"input": "2001:db8::200:5efe:c000:201"})
+    assert_eq("api embedded-v4 (isatap): HTTP 200", status6, 200)
+    assert_eq("api embedded-v4 (isatap): scheme",
+              data6.get("data", {}).get("scheme"), "isatap")
+    assert_eq("api embedded-v4 (isatap): ipv4",
+              data6.get("data", {}).get("ipv4"), "192.0.2.1")
+
+    # No embedding
+    status7, data7 = _api_post("embedded-v4", {"input": "2001:db8::1"})
+    assert_eq("api embedded-v4 (none): HTTP 200", status7, 200)
+    assert_eq("api embedded-v4 (none): scheme is null",
+              data7.get("data", {}).get("scheme"), None)
+    assert_eq("api embedded-v4 (none): ipv4 is null",
+              data7.get("data", {}).get("ipv4"), None)
+
+    # Loopback / unspecified must NOT be misdetected as compatible (RFC 4291 §2.5.5.1)
+    status8, data8 = _api_post("embedded-v4", {"input": "::1"})
+    assert_eq("api embedded-v4 (loopback): scheme is null",
+              data8.get("data", {}).get("scheme"), None)
+
+    # Missing input → 400
+    status9, _ = _api_post("embedded-v4", {})
+    assert_eq("api embedded-v4: missing input → 400", status9, 400)
+
+    # Garbage input → 400
+    status10, _ = _api_post("embedded-v4", {"input": "not-an-address"})
+    assert_eq("api embedded-v4: invalid input → 400", status10, 400)
+
+
+async def test_ipv6_embedded_v4_ui(page: Page) -> None:
+    section("IPv6 embedded-v4 detector UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # T7 per-tool URL routing — /ipv6/embedded-v4 should auto-open the drawer.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=embedded-v4")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-v4']")
+    assert_eq("embedded-v4 UI: panel exists", await panel.count(), 1)
+
+    # Submit IPv4-mapped address
+    await page.fill("#embedded_v4_input", "::ffff:192.0.2.1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='embedded-v4'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-v4']")
+    rows = panel.locator(".zoneid-result__row")
+    # Scheme + Embedded IPv4 + Open-in-tool = 3 rows (no extras for mapped)
+    assert_true("embedded-v4 UI: at least scheme + ipv4 rows",
+                await rows.count() >= 2)
+
+    # Copy embedded IPv4
+    await rows.locator(".subnet-copy").first.click()
+    await page.wait_for_timeout(50)
+    assert_eq("embedded-v4 UI: copy IPv4",
+              await page.evaluate("window.__lastClipboard"), "192.0.2.1")
+
+    # Open-in-tool button is rendered but disabled (per-scheme drawers land in T3–T7)
+    open_btn = panel.locator("button.splitter-btn[disabled]")
+    assert_true("embedded-v4 UI: open-in-tool button is disabled",
+                await open_btn.count() >= 1)
+
+    # No embedding → result card with "No embedded IPv4 detected"
+    await navigate(page, APP_URL + "?tab=ipv6&tool=embedded-v4")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#embedded_v4_input", "2001:db8::1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='embedded-v4'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-v4']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("embedded-v4 UI: empty-state message rendered",
+                "no embedded ipv4" in body_text, f"body: {body_text!r}")
+
+    # Error path — invalid IPv6 literal
+    await navigate(page, APP_URL + "?tab=ipv6&tool=embedded-v4")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#embedded_v4_input", "not-an-address")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='embedded-v4'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-v4']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("embedded-v4 UI: error band on invalid input",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -7823,6 +7962,8 @@ async def main() -> None:
             await test_api_rdns6(page)
             await test_ipv6_mapped6_ui(page)
             await test_api_mapped6(page)
+            await test_ipv6_embedded_v4_ui(page)
+            await test_api_embedded_v4(page)
             await test_a11y_ipv6_drawers(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)

--- a/testing/unit/EmbeddedV4Test.php
+++ b/testing/unit/EmbeddedV4Test.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class EmbeddedV4Test extends TestCase
+{
+    public function test_ipv4_mapped_detected(): void
+    {
+        $result = detect_embedded_v4('::ffff:192.0.2.1');
+        $this->assertSame('mapped', $result['scheme']);
+        $this->assertSame('192.0.2.1', $result['ipv4']);
+        $this->assertFalse($result['deprecated']);
+    }
+
+    public function test_ipv4_compatible_detected_as_deprecated(): void
+    {
+        $result = detect_embedded_v4('::192.0.2.1');
+        $this->assertSame('compatible', $result['scheme']);
+        $this->assertSame('192.0.2.1', $result['ipv4']);
+        $this->assertTrue($result['deprecated']);
+    }
+
+    public function test_6to4_detected(): void
+    {
+        $result = detect_embedded_v4('2002:c000:0201::');
+        $this->assertSame('6to4', $result['scheme']);
+        $this->assertSame('192.0.2.1', $result['ipv4']);
+    }
+
+    public function test_teredo_detected(): void
+    {
+        // RFC 4380 §4 example
+        $result = detect_embedded_v4('2001:0:4136:e378:8000:63bf:3fff:fdd2');
+        $this->assertSame('teredo', $result['scheme']);
+    }
+
+    public function test_nat64_wkp_detected(): void
+    {
+        $result = detect_embedded_v4('64:ff9b::192.0.2.1');
+        $this->assertSame('nat64-wkp', $result['scheme']);
+        $this->assertSame('192.0.2.1', $result['ipv4']);
+    }
+
+    public function test_isatap_globally_unique_detected(): void
+    {
+        $result = detect_embedded_v4('2001:db8::200:5efe:c000:201');
+        $this->assertSame('isatap', $result['scheme']);
+        $this->assertSame('192.0.2.1', $result['ipv4']);
+    }
+
+    public function test_no_embedding_returns_null(): void
+    {
+        $result = detect_embedded_v4('2001:db8::1');
+        $this->assertNull($result['scheme']);
+        $this->assertNull($result['ipv4']);
+    }
+
+    public function test_invalid_ipv6_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        detect_embedded_v4('not-an-address');
+    }
+
+    public function test_loopback_and_unspecified_not_misdetected_as_compatible(): void
+    {
+        // ::1 (loopback) and :: (unspecified) sit inside ::/96 but must NOT
+        // be reported as IPv4-compatible per RFC 4291 §2.5.5.1.
+        $loopback = detect_embedded_v4('::1');
+        $this->assertNull($loopback['scheme']);
+
+        $unspec = detect_embedded_v4('::');
+        $this->assertNull($unspec['scheme']);
+    }
+
+    public function test_ipv6_in_prefix_helper(): void
+    {
+        $this->assertTrue(ipv6_in_prefix('2001:db8::1', '2001:db8::', 32));
+        $this->assertFalse(ipv6_in_prefix('2001:db9::1', '2001:db8::', 32));
+        $this->assertTrue(ipv6_in_prefix('64:ff9b::c000:201', '64:ff9b::', 96));
+    }
+
+    public function test_detail_route_seeded_null_for_now(): void
+    {
+        // Per-scheme drawers land in T3–T7. Until then, every scheme returns
+        // detail_route=null. This test pins the contract so the eventual
+        // wiring touch is deliberate.
+        $r = detect_embedded_v4('::ffff:192.0.2.1');
+        $this->assertNull($r['detail_route']);
+    }
+
+    public function test_extra_present_for_all_branches(): void
+    {
+        $r = detect_embedded_v4('2001:db8::1');
+        $this->assertIsArray($r['extra']);
+    }
+}

--- a/testing/unit/EmbeddedV4Test.php
+++ b/testing/unit/EmbeddedV4Test.php
@@ -31,9 +31,13 @@ final class EmbeddedV4Test extends TestCase
 
     public function test_teredo_detected(): void
     {
-        // RFC 4380 §4 example
+        // RFC 4380 §4 worked example: server 65.54.227.120, obfuscated client
+        // 192.0.2.45, UDP port 40000.
         $result = detect_embedded_v4('2001:0:4136:e378:8000:63bf:3fff:fdd2');
         $this->assertSame('teredo', $result['scheme']);
+        $this->assertSame('192.0.2.45', $result['ipv4']);
+        $this->assertSame('65.54.227.120', $result['extra']['server_ipv4']);
+        $this->assertSame(40000, $result['extra']['udp_port']);
     }
 
     public function test_nat64_wkp_detected(): void

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -19,6 +19,7 @@ require $base . 'functions-derive6.php';
 require $base . 'functions-slaac6.php';
 require $base . 'functions-rdns6.php';
 require $base . 'functions-mapped6.php';
+require $base . 'functions-embedded-v4.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

Task 2 of the v3.5.0 release plan — the **front-door** tool for the IPv6→IPv4 transition theme. Identifies which embedded-IPv4 scheme an IPv6 address uses and extracts the embedded IPv4. Per-scheme deep-link buttons render disabled until those drawers ship in subsequent v3.5.0 PRs (T3–T7).

Linked issue: #390

### What landed

- New module `includes/functions-embedded-v4.php` with `detect_embedded_v4()` and `ipv6_in_prefix()` (GMP-based).
- Detection covers IPv4-mapped, IPv4-compatible (deprecated), 6to4, Teredo, NAT64 well-known, and ISATAP. Priority follows most-specific-prefix-first; `::1` / `::` are explicitly excluded from `compatible` per RFC 4291 §2.5.5.1.
- Teredo deobfuscates the client IPv4 (XOR 0xFF) and UDP port; ISATAP recognises both locally-administered and globally-unique IID forms.
- New API endpoint `POST /api/v1/embedded-v4`.
- New drawer `data-tool="embedded-v4"` on the IPv6 tab with `help_bubble()` on every input, copy button, and a deep-link button that's disabled until per-scheme drawers ship.
- Shareable URL via `sc_run_embedded_v4()` — handles both POST and GET symmetrically (mirrors v2.11/v3.3.0/v3.4.0 pattern).
- OpenAPI operation with five request examples; new `EmbeddedV4` tag.
- Doc page `docs/embedded-v4.md` walking through each scheme; mkdocs nav updated.
- CHANGELOG entry under a fresh `## [3.5.0]` section.

### Files changed

| Type | File |
|---|---|
| Added | `Subnet-Calculator/includes/functions-embedded-v4.php` |
| Added | `Subnet-Calculator/api/v1/handlers/embedded-v4.php` |
| Added | `testing/unit/EmbeddedV4Test.php` |
| Added | `docs/embedded-v4.md` |
| Modified | `Subnet-Calculator/api/v1/index.php` (route + module include) |
| Modified | `Subnet-Calculator/includes/request.php` (sc_run_embedded_v4, POST + GET hooks) |
| Modified | `Subnet-Calculator/index.php` (module include) |
| Modified | `Subnet-Calculator/templates/layout.php` (drawer + open_tool_ipv6 wiring) |
| Modified | `Subnet-Calculator/api/openapi.yaml` (operation + tag) |
| Modified | `mkdocs.yml` (nav) |
| Modified | `testing/scripts/playwright_test.py` (UI + API test groups) |
| Modified | `testing/unit/bootstrap.php` (module include) |
| Modified | `CHANGELOG.md` (v3.5.0 section seeded) |

## Test plan / QA gate results

All gates run locally and all green:

- [x] PHPUnit — 528/528 passing (14 skipped on platforms without GMP); 12 new tests in `EmbeddedV4Test`
- [x] PHPStan L9 — `[OK] No errors`
- [x] PHPCS PSR-12 (`includes/`, `api/`) — clean
- [x] PHPCS admin ruleset — clean
- [x] Spectral OpenAPI lint — `No results with a severity of 'error'`
- [x] Semgrep (rules.yml + p/php + p/owasp-top-ten + p/sql-injection) — 0 findings
- [x] ESLint + Stylelint — clean
- [x] Playwright via `make test-docker` — **1459/1459 passed**, includes new `IPv6 embedded-v4 detector UI` and `API — POST /api/v1/embedded-v4` groups

## Self-review notes

- `detail_route` is intentionally seeded `null` in this PR. PHPUnit pins that contract (`test_detail_route_seeded_null_for_now`) so when T3–T7 wire actual routes the change is deliberate, not silent.
- The `Open in <scheme> tool` button renders even when `detail_route` is null — disabled with an explanatory `title=`. This way the UX is visible from the front door now and just lights up as each per-scheme drawer ships.
- Teredo `extra` includes `server_ipv4`, `flags`, and the deobfuscated `udp_port`. Future Teredo drawer (T5) can lean on those without duplicating the parsing.
- The compatible-vs-mapped ambiguity (both sit under `::/96`) is resolved by the order-of-checks comment in `functions-embedded-v4.php`. Inverting the order would silently mis-classify every IPv4-mapped address. Worth a callout for reviewers.