### PR TITLE
feat(v3.5.0): Teredo address decoder (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ as each ships.
 - **6to4 address tool (RFC 3056).** Bidirectional translation between
   public IPv4 and `2002::/16` 6to4 prefixes. Help text notes RFC 7526
   deprecated status. (#392)
+- **Teredo address decoder (RFC 4380).** Decode and encode `2001:0::/32`
+  Teredo addresses (server v4, flags incl. cone bit, XOR'd UDP port,
+  XOR'd client v4). Help text notes operational status. (#393)
 
 ## [3.4.1] - 2026-05-08
 

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -69,6 +69,8 @@ tags:
     description: IPv6 embedded-IPv4 detector (front door for v3.5.0 transition tools)
   - name: SixToFour
     description: 6to4 address tool (RFC 3056) — bidirectional IPv4 ↔ 2002::/16 translation
+  - name: Teredo
+    description: Teredo address decoder (RFC 4380) — bidirectional decoding/encoding of 2001:0::/32 addresses
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -359,6 +361,7 @@ paths:
                     - "POST /api/v1/mapped6"
                     - "POST /api/v1/embedded-v4"
                     - "POST /api/v1/6to4"
+                    - "POST /api/v1/teredo"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -2102,6 +2105,171 @@ paths:
                   prefix: "2002:c000:0201::/48"
         "400":
           description: Missing required field, unparseable input, or non-public IPv4 (private / reserved / multicast)
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /teredo:
+    post:
+      operationId: teredoConvert
+      tags: [Teredo]
+      summary: Decode or encode a Teredo IPv6 address (RFC 4380)
+      description: |
+        Bidirectional conversion between Teredo IPv6 addresses (2001:0::/32)
+        and their constituent parts: server IPv4 (raw), 16-bit flags
+        (high bit 0x8000 = "cone"), de-XOR'd UDP port, and de-XOR'd
+        client IPv4. Two modes:
+
+        - **`decode`** — input `ipv6` (any address under 2001:0::/32),
+          output `server_ipv4`, `flags`, `cone`, `port`, `client_ipv4`.
+        - **`encode`** — input `server_ipv4`, `client_ipv4`, `port`
+          (0..65535), and optional `flags` (default `0x8000` for cone),
+          output `ipv6` plus the echoed parts.
+
+        Microsoft retired the public Teredo service for consumer
+        Windows in 2019. This endpoint is provided for analysis of
+        legacy traffic captures and address audits.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  required: [mode, ipv6]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [decode]
+                    ipv6:
+                      type: string
+                      description: An IPv6 literal under 2001:0::/32.
+                      example: "2001:0:4136:e378:8000:63bf:3fff:fdd2"
+                - type: object
+                  required: [mode, server_ipv4, client_ipv4, port]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [encode]
+                    server_ipv4:
+                      type: string
+                      example: "65.54.227.120"
+                    client_ipv4:
+                      type: string
+                      example: "192.0.2.45"
+                    port:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
+                      example: 40000
+                    flags:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
+                      default: 32768
+                      description: 16-bit flags field; the high bit (0x8000) is the cone-NAT indicator. Default is 0x8000.
+            examples:
+              decode:
+                summary: Decode Teredo IPv6 → parts
+                value: { mode: decode, ipv6: "2001:0:4136:e378:8000:63bf:3fff:fdd2" }
+              encode:
+                summary: Encode parts → Teredo IPv6
+                value: { mode: encode, server_ipv4: "65.54.227.120", client_ipv4: "192.0.2.45", port: 40000, flags: 32768 }
+      responses:
+        "200":
+          description: Conversion result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        oneOf:
+                          - type: object
+                            required: [mode, ipv6, server_ipv4, flags, cone, port, client_ipv4]
+                            properties:
+                              mode:
+                                type: string
+                                enum: [decode]
+                              ipv6:
+                                type: string
+                                example: "2001:0:4136:e378:8000:63bf:3fff:fdd2"
+                              server_ipv4:
+                                type: string
+                                example: "65.54.227.120"
+                              flags:
+                                type: integer
+                                example: 32768
+                              cone:
+                                type: boolean
+                                example: true
+                              port:
+                                type: integer
+                                example: 40000
+                              client_ipv4:
+                                type: string
+                                example: "192.0.2.45"
+                          - type: object
+                            required: [mode, ipv6, server_ipv4, client_ipv4, port, flags, cone]
+                            properties:
+                              mode:
+                                type: string
+                                enum: [encode]
+                              server_ipv4:
+                                type: string
+                                example: "65.54.227.120"
+                              client_ipv4:
+                                type: string
+                                example: "192.0.2.45"
+                              port:
+                                type: integer
+                                example: 40000
+                              flags:
+                                type: integer
+                                example: 32768
+                              cone:
+                                type: boolean
+                                example: true
+                              ipv6:
+                                type: string
+                                example: "2001:0:4136:e378:8000:63bf:3fff:fdd2"
+              example:
+                ok: true
+                data:
+                  mode: decode
+                  ipv6: "2001:0:4136:e378:8000:63bf:3fff:fdd2"
+                  server_ipv4: "65.54.227.120"
+                  flags: 32768
+                  cone: true
+                  port: 40000
+                  client_ipv4: "192.0.2.45"
+        "400":
+          description: Missing required field, unparseable input, or non-Teredo address
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/teredo.php
+++ b/Subnet-Calculator/api/v1/handlers/teredo.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body     = api_body();
+$raw_mode = $body['mode'] ?? 'decode';
+if (!is_string($raw_mode)) {
+    json_err('Field "mode" must be a string ("encode" or "decode").', 400);
+}
+$mode = strtolower(trim($raw_mode));
+if ($mode === '') {
+    $mode = 'decode';
+}
+if ($mode !== 'encode' && $mode !== 'decode') {
+    json_err('Field "mode" must be "encode" or "decode".', 400);
+}
+
+if ($mode === 'decode') {
+    $raw_v6 = $body['ipv6'] ?? null;
+    if (!is_string($raw_v6) || trim($raw_v6) === '') {
+        json_err('Field "ipv6" (string) is required when mode=decode.', 400);
+    }
+    try {
+        $decoded = decode_teredo(trim($raw_v6));
+    } catch (\InvalidArgumentException $e) {
+        json_err($e->getMessage(), 400);
+    }
+    json_ok([
+        'mode'        => 'decode',
+        'ipv6'        => trim($raw_v6),
+        'server_ipv4' => $decoded['server_ipv4'],
+        'flags'       => $decoded['flags'],
+        'cone'        => $decoded['cone'],
+        'port'        => $decoded['port'],
+        'client_ipv4' => $decoded['client_ipv4'],
+    ]);
+}
+
+// mode === 'encode'
+$raw_server = $body['server_ipv4'] ?? null;
+$raw_client = $body['client_ipv4'] ?? null;
+$raw_port   = $body['port']        ?? null;
+$raw_flags  = $body['flags']       ?? 0x8000;
+
+if (!is_string($raw_server) || trim($raw_server) === '') {
+    json_err('Field "server_ipv4" (string) is required when mode=encode.', 400);
+}
+if (!is_string($raw_client) || trim($raw_client) === '') {
+    json_err('Field "client_ipv4" (string) is required when mode=encode.', 400);
+}
+if (!is_int($raw_port)) {
+    json_err('Field "port" (integer 0..65535) is required when mode=encode.', 400);
+}
+if (!is_int($raw_flags)) {
+    json_err('Field "flags" must be an integer (default 0x8000).', 400);
+}
+
+try {
+    $addr = encode_teredo(trim($raw_server), trim($raw_client), $raw_port, $raw_flags);
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'mode'        => 'encode',
+    'server_ipv4' => trim($raw_server),
+    'client_ipv4' => trim($raw_client),
+    'port'        => $raw_port,
+    'flags'       => $raw_flags & 0xFFFF,
+    'cone'        => ($raw_flags & 0x8000) !== 0,
+    'ipv6'        => $addr,
+]);

--- a/Subnet-Calculator/api/v1/handlers/teredo.php
+++ b/Subnet-Calculator/api/v1/handlers/teredo.php
@@ -58,6 +58,9 @@ if (!is_int($raw_port)) {
 if (!is_int($raw_flags)) {
     json_err('Field "flags" must be an integer (default 0x8000).', 400);
 }
+if ($raw_flags < 0 || $raw_flags > 0xFFFF) {
+    json_err('Field "flags" must be in 16-bit range (0..65535).', 400);
+}
 
 try {
     $addr = encode_teredo(trim($raw_server), trim($raw_client), $raw_port, $raw_flags);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -30,6 +30,7 @@ require $base . 'functions-rdns6.php';
 require $base . 'functions-mapped6.php';
 require $base . 'functions-embedded-v4.php';
 require $base . 'functions-6to4.php';
+require $base . 'functions-teredo.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -118,6 +119,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/mapped6',
             'POST /api/v1/embedded-v4',
             'POST /api/v1/6to4',
+            'POST /api/v1/teredo',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -250,6 +252,9 @@ switch ($route_key) {
         break;
     case 'POST /6to4':
         require __DIR__ . '/handlers/6to4.php';
+        break;
+    case 'POST /teredo':
+        require __DIR__ . '/handlers/teredo.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -30,7 +30,7 @@ require $base . 'functions-rdns6.php';
 require $base . 'functions-mapped6.php';
 require $base . 'functions-embedded-v4.php';
 require $base . 'functions-6to4.php';
-require $base . 'functions-teredo.php';
+require_once $base . 'functions-teredo.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';

--- a/Subnet-Calculator/includes/functions-embedded-v4.php
+++ b/Subnet-Calculator/includes/functions-embedded-v4.php
@@ -26,6 +26,10 @@ declare(strict_types=1);
 // null until their drawers ship in T4–T7. The contract is pinned by
 // EmbeddedV4Test::test_detail_routes_per_scheme.
 
+// phpcs:disable PSR1.Files.SideEffects -- explicit dependency on decode_teredo().
+require_once __DIR__ . '/functions-teredo.php';
+// phpcs:enable PSR1.Files.SideEffects
+
 const EMBEDDEDV4_MAPPED_PREFIX_BIN     = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff";
 const EMBEDDEDV4_NAT64_WKP_PREFIX_BIN  = "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00";
 const EMBEDDEDV4_6TO4_PREFIX_BIN       = "\x20\x02";
@@ -135,30 +139,31 @@ function detect_embedded_v4(string $ipv6): array
         ];
     }
 
-    // 4. Teredo: 2001:0::/32, RFC 4380. Server IPv4 in bytes 4–7;
-    //    obfuscated client IPv4 (XOR 0xFF) in bytes 12–15; flags+port in 8–11.
+    // 4. Teredo: 2001:0::/32, RFC 4380. Delegate to decode_teredo() so the
+    //    `extra` payload shape stays in lockstep with the dedicated decoder
+    //    (server_ipv4, client_ipv4, flags(int), cone(bool), port(int)).
+    //    The prefix check above already filters non-Teredo inputs; the
+    //    try/catch is defensive in case decode_teredo() rejects a degenerate
+    //    parse that still passed the prefix sniff.
     if (substr($bin, 0, 4) === EMBEDDEDV4_TEREDO_PREFIX_BIN) {
-        $serverV4 = @inet_ntop(substr($bin, 4, 4));
-        $clientObf = substr($bin, 12, 4);
-        $clientPlain = '';
-        for ($i = 0; $i < 4; $i++) {
-            $clientPlain .= chr(ord($clientObf[$i]) ^ 0xFF);
+        try {
+            $decoded = decode_teredo($ipv6);
+            return [
+                'scheme'       => 'teredo',
+                'ipv4'         => $decoded['client_ipv4'],
+                'deprecated'   => false,
+                'detail_route' => '/ipv6/teredo',
+                'extra'        => [
+                    'server_ipv4' => $decoded['server_ipv4'],
+                    'client_ipv4' => $decoded['client_ipv4'],
+                    'flags'       => $decoded['flags'],
+                    'cone'        => $decoded['cone'],
+                    'port'        => $decoded['port'],
+                ],
+            ];
+        } catch (InvalidArgumentException $e) {
+            // Fall through to the no-match return below.
         }
-        $clientV4 = @inet_ntop($clientPlain);
-        $flags    = bin2hex(substr($bin, 8, 2));
-        $portObf  = substr($bin, 10, 2);
-        $port     = ((ord($portObf[0]) ^ 0xFF) << 8) | (ord($portObf[1]) ^ 0xFF);
-        return [
-            'scheme'       => 'teredo',
-            'ipv4'         => $clientV4 === false ? null : $clientV4,
-            'deprecated'   => false,
-            'detail_route' => '/ipv6/teredo',
-            'extra'        => [
-                'server_ipv4' => $serverV4 === false ? null : $serverV4,
-                'flags'       => $flags,
-                'udp_port'    => $port,
-            ],
-        ];
     }
 
     // 5. ISATAP: IID matches `*:0000:5efe:V4ADDR` (locally-administered)

--- a/Subnet-Calculator/includes/functions-embedded-v4.php
+++ b/Subnet-Calculator/includes/functions-embedded-v4.php
@@ -152,7 +152,7 @@ function detect_embedded_v4(string $ipv6): array
             'scheme'       => 'teredo',
             'ipv4'         => $clientV4 === false ? null : $clientV4,
             'deprecated'   => false,
-            'detail_route' => null,
+            'detail_route' => '/ipv6/teredo',
             'extra'        => [
                 'server_ipv4' => $serverV4 === false ? null : $serverV4,
                 'flags'       => $flags,

--- a/Subnet-Calculator/includes/functions-teredo.php
+++ b/Subnet-Calculator/includes/functions-teredo.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+// Teredo address tool (RFC 4380) — bidirectional decoding/encoding of
+// IPv6 addresses in the 2001:0::/32 prefix.
+//
+//   | 32 bits | 32 bits      | 16 bits | 16 bits      | 32 bits          |
+//   | 2001:0  | server IPv4  | flags   | port (XOR)   | client IPv4 (XOR)|
+//
+// The high-bit of `flags` (0x8000) is the "cone" indicator. Port and
+// client IPv4 are obfuscated by XOR-ing every bit with 1 (i.e. XOR
+// 0xFFFF for the 16-bit port, XOR 0xFFFFFFFF byte-by-byte for the
+// 32-bit client v4) so that NAT devices won't rewrite the embedded
+// values when they see them inside the IPv6 payload. Server IPv4 is
+// stored raw because Teredo servers terminate the relay tunnel and
+// don't need protection from upstream NAT mangling.
+//
+// RFC 4380 was published in 2006 and Teredo deployment has steadily
+// declined as native IPv6 has rolled out; Microsoft retired the
+// public Teredo service for consumer Windows in 2019. This tool is
+// provided for analysis of historical traffic captures and audits of
+// addresses that still appear in legacy logs.
+
+const TEREDO_PREFIX_BIN = "\x20\x01\x00\x00";
+
+/**
+ * Decode a Teredo IPv6 address per RFC 4380.
+ *
+ * @return array{
+ *     server_ipv4: string,
+ *     flags: int,
+ *     cone: bool,
+ *     port: int,
+ *     client_ipv4: string,
+ * }
+ *
+ * @throws InvalidArgumentException if the address is malformed or not
+ *         under 2001:0::/32.
+ */
+function decode_teredo(string $ipv6): array
+{
+    $raw = trim($ipv6);
+    if ($raw === '') {
+        throw new InvalidArgumentException('IPv6 address is required.');
+    }
+
+    $bin = @inet_pton($raw);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid IPv6 address: ' . $raw);
+    }
+
+    if (substr($bin, 0, 4) !== TEREDO_PREFIX_BIN) {
+        throw new InvalidArgumentException(
+            'Address is not under 2001:0::/32 (Teredo): ' . $raw
+        );
+    }
+
+    $serverV4 = @inet_ntop(substr($bin, 4, 4));
+    if ($serverV4 === false) {
+        throw new InvalidArgumentException('Internal error decoding server IPv4.');
+    }
+
+    $flags = (ord($bin[8]) << 8) | ord($bin[9]);
+    $cone  = ($flags & 0x8000) !== 0;
+
+    $port = ((ord($bin[10]) << 8) | ord($bin[11])) ^ 0xFFFF;
+
+    // Client IPv4: XOR each byte with 0xFF.
+    $clientPlain = '';
+    for ($i = 12; $i < 16; $i++) {
+        $clientPlain .= chr(ord($bin[$i]) ^ 0xFF);
+    }
+    $clientV4 = @inet_ntop($clientPlain);
+    if ($clientV4 === false) {
+        throw new InvalidArgumentException('Internal error decoding client IPv4.');
+    }
+
+    return [
+        'server_ipv4' => $serverV4,
+        'flags'       => $flags,
+        'cone'        => $cone,
+        'port'        => $port,
+        'client_ipv4' => $clientV4,
+    ];
+}
+
+/**
+ * Encode a Teredo IPv6 address from its parts.
+ *
+ * @throws InvalidArgumentException if either IPv4 is malformed or port
+ *         is outside 0..65535.
+ */
+function encode_teredo(string $server_ipv4, string $client_ipv4, int $port, int $flags = 0x8000): string
+{
+    $server = trim($server_ipv4);
+    $client = trim($client_ipv4);
+
+    if ($port < 0 || $port > 65535) {
+        throw new InvalidArgumentException('Port must be between 0 and 65535: ' . $port);
+    }
+
+    if (filter_var($server, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+        throw new InvalidArgumentException('Invalid server IPv4 address: ' . $server);
+    }
+    if (filter_var($client, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+        throw new InvalidArgumentException('Invalid client IPv4 address: ' . $client);
+    }
+
+    $serverBin = inet_pton($server);
+    $clientBin = inet_pton($client);
+    if ($serverBin === false || strlen($serverBin) !== 4) {
+        throw new InvalidArgumentException('Invalid server IPv4 address: ' . $server);
+    }
+    if ($clientBin === false || strlen($clientBin) !== 4) {
+        throw new InvalidArgumentException('Invalid client IPv4 address: ' . $client);
+    }
+
+    // XOR the client v4 byte-by-byte with 0xFF.
+    $clientObf = '';
+    for ($i = 0; $i < 4; $i++) {
+        $clientObf .= chr(ord($clientBin[$i]) ^ 0xFF);
+    }
+
+    // XOR the port with 0xFFFF (16-bit big-endian).
+    $portObf = $port ^ 0xFFFF;
+
+    // Mask flags into 16 bits — defensive; callers commonly pass 0 or 0x8000.
+    $flags &= 0xFFFF;
+
+    $packed = TEREDO_PREFIX_BIN
+        . $serverBin
+        . chr(($flags >> 8) & 0xFF) . chr($flags & 0xFF)
+        . chr(($portObf >> 8) & 0xFF) . chr($portObf & 0xFF)
+        . $clientObf;
+
+    $addr = @inet_ntop($packed);
+    if ($addr === false) {
+        throw new InvalidArgumentException('Internal error encoding Teredo address.');
+    }
+    return $addr;
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -456,6 +456,133 @@ function sc_run_6to4(string $input, string $mode): array
     }
 }
 
+// ─── Teredo helper (shared by POST handler and GET shareable URL) ──────────
+
+/**
+ * Run the Teredo tool against the supplied input. Mode is either 'decode'
+ * (Teredo IPv6 → server v4 + client v4 + port + flags) or 'encode'
+ * (server v4 + client v4 + port + flags → Teredo IPv6). Empty input
+ * returns []. (v3.5.0 Task 4)
+ *
+ * @return array{
+ *     mode?: 'encode'|'decode',
+ *     input?: string,
+ *     ipv6?: string,
+ *     server_ipv4?: string,
+ *     client_ipv4?: string,
+ *     port?: int,
+ *     flags?: int,
+ *     cone?: bool,
+ *     error?: string|null
+ * }
+ */
+function sc_run_teredo(
+    string $mode,
+    string $ipv6_input,
+    string $server_input,
+    string $client_input,
+    string $port_input,
+    string $flags_input,
+    bool $cone_flag
+): array {
+    $mode = strtolower(trim($mode));
+    if ($mode !== 'encode' && $mode !== 'decode') {
+        $mode = 'decode';
+    }
+
+    if ($mode === 'decode') {
+        $raw = trim($ipv6_input);
+        if ($raw === '') {
+            return [];
+        }
+        try {
+            $r = decode_teredo($raw);
+            return [
+                'mode'        => 'decode',
+                'input'       => $raw,
+                'ipv6'        => $raw,
+                'server_ipv4' => $r['server_ipv4'],
+                'client_ipv4' => $r['client_ipv4'],
+                'port'        => $r['port'],
+                'flags'       => $r['flags'],
+                'cone'        => $r['cone'],
+                'error'       => null,
+            ];
+        } catch (\InvalidArgumentException $e) {
+            return [
+                'mode'  => 'decode',
+                'input' => $raw,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    // Encode mode
+    $server = trim($server_input);
+    $client = trim($client_input);
+    $portRaw  = trim($port_input);
+    $flagsRaw = trim($flags_input);
+
+    // Empty-state: no parts supplied yet.
+    if ($server === '' && $client === '' && $portRaw === '') {
+        return [];
+    }
+
+    if ($portRaw === '' || !ctype_digit($portRaw)) {
+        return [
+            'mode'  => 'encode',
+            'error' => 'Port must be a non-negative integer between 0 and 65535.',
+        ];
+    }
+    $port = (int)$portRaw;
+
+    // Flags input optional. Accept decimal or 0xNNNN. Default to cone or
+    // non-cone based on the boolean toggle.
+    if ($flagsRaw === '') {
+        $flags = $cone_flag ? 0x8000 : 0x0000;
+    } else {
+        if (preg_match('/^0x[0-9a-f]{1,4}$/i', $flagsRaw)) {
+            $flags = (int)hexdec(substr($flagsRaw, 2));
+        } elseif (ctype_digit($flagsRaw)) {
+            $flags = (int)$flagsRaw;
+        } else {
+            return [
+                'mode'  => 'encode',
+                'error' => 'Flags must be a 16-bit integer (decimal or 0xNNNN).',
+            ];
+        }
+        if ($flags < 0 || $flags > 0xFFFF) {
+            return [
+                'mode'  => 'encode',
+                'error' => 'Flags must be in the 16-bit range (0..65535).',
+            ];
+        }
+    }
+
+    try {
+        $addr = encode_teredo($server, $client, $port, $flags);
+        return [
+            'mode'        => 'encode',
+            'server_ipv4' => $server,
+            'client_ipv4' => $client,
+            'port'        => $port,
+            'flags'       => $flags,
+            'cone'        => ($flags & 0x8000) !== 0,
+            'ipv6'        => $addr,
+            'error'       => null,
+        ];
+    } catch (\InvalidArgumentException $e) {
+        return [
+            'mode'        => 'encode',
+            'server_ipv4' => $server,
+            'client_ipv4' => $client,
+            'port'        => $port,
+            'flags'       => $flags,
+            'error'       => $e->getMessage(),
+        ];
+    }
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -608,6 +735,17 @@ $sixtofour_mode  = 'encode';
 /** @var array{mode?: 'encode'|'decode', input?: string, prefix?: string, ipv4?: string, subnet_id?: int, interface_id?: string, error?: string|null} */
 $sixtofour = [];
 
+// v3.5.0 Task 4 — Teredo address decoder (RFC 4380)
+$teredo_mode         = 'decode';
+$teredo_input        = '';
+$teredo_server_input = '';
+$teredo_client_input = '';
+$teredo_port_input   = '';
+$teredo_flags_input  = '';
+$teredo_cone_flag    = true;
+/** @var array{mode?: 'encode'|'decode', input?: string, ipv6?: string, server_ipv4?: string, client_ipv4?: string, port?: int, flags?: int, cone?: bool, error?: string|null} */
+$teredo = [];
+
 $ula_global_id_input = '';
 /** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
 $ula = [];
@@ -673,6 +811,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_mapped6       = isset($_POST['mapped6_input']);
     $is_embedded_v4   = isset($_POST['embedded_v4_input']);
     $is_sixtofour     = isset($_POST['sixtofour_input']);
+    $is_teredo        = isset($_POST['teredo_mode'])
+        || isset($_POST['teredo_input'])
+        || isset($_POST['teredo_server'])
+        || isset($_POST['teredo_client'])
+        || isset($_POST['teredo_port']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -681,7 +824,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_vlsm6 || $is_supernet || $is_supernet6 || $is_ula || $is_session_save || $is_range
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
         || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6 || $is_embedded_v4
-        || $is_sixtofour;
+        || $is_sixtofour || $is_teredo;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -1108,6 +1251,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $sixtofour = sc_run_6to4($sixtofour_input, $sixtofour_mode);
     }
 
+    if ($is_teredo && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $teredo_mode         = (string)($_POST['teredo_mode'] ?? 'decode');
+        if ($teredo_mode !== 'encode' && $teredo_mode !== 'decode') {
+            $teredo_mode = 'decode';
+        }
+        $teredo_input        = trim((string)($_POST['teredo_input']  ?? ''));
+        $teredo_server_input = trim((string)($_POST['teredo_server'] ?? ''));
+        $teredo_client_input = trim((string)($_POST['teredo_client'] ?? ''));
+        $teredo_port_input   = trim((string)($_POST['teredo_port']   ?? ''));
+        $teredo_flags_input  = trim((string)($_POST['teredo_flags']  ?? ''));
+        $teredo_cone_flag    = isset($_POST['teredo_cone']);
+        $teredo = sc_run_teredo(
+            $teredo_mode,
+            $teredo_input,
+            $teredo_server_input,
+            $teredo_client_input,
+            $teredo_port_input,
+            $teredo_flags_input,
+            $teredo_cone_flag
+        );
+    }
+
     if ($is_ula && !$form_blocked) {
         $ula_global_id_input = trim((string)($_POST['ula_global_id'] ?? ''));
         $ur = generate_ula_prefix($ula_global_id_input);
@@ -1521,6 +1687,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $sixtofour_mode = 'encode';
         }
         $sixtofour = sc_run_6to4($sixtofour_input, $sixtofour_mode);
+    }
+
+    // Teredo shareable GET URL (v3.5.0 Task 4)
+    if (
+        $active_tab === 'ipv6'
+        && (isset($_GET['teredo_input']) || isset($_GET['teredo_server']))
+    ) {
+        $teredo_mode = (string)($_GET['teredo_mode'] ?? 'decode');
+        if ($teredo_mode !== 'encode' && $teredo_mode !== 'decode') {
+            $teredo_mode = 'decode';
+        }
+        $teredo_input        = trim((string)($_GET['teredo_input']  ?? ''));
+        $teredo_server_input = trim((string)($_GET['teredo_server'] ?? ''));
+        $teredo_client_input = trim((string)($_GET['teredo_client'] ?? ''));
+        $teredo_port_input   = trim((string)($_GET['teredo_port']   ?? ''));
+        $teredo_flags_input  = trim((string)($_GET['teredo_flags']  ?? ''));
+        $teredo_cone_flag    = isset($_GET['teredo_cone']);
+        $teredo = sc_run_teredo(
+            $teredo_mode,
+            $teredo_input,
+            $teredo_server_input,
+            $teredo_client_input,
+            $teredo_port_input,
+            $teredo_flags_input,
+            $teredo_cone_flag
+        );
     }
 
     // Supernet6 / summarise6 shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -22,6 +22,7 @@ require __DIR__ . '/includes/functions-rdns6.php';
 require __DIR__ . '/includes/functions-mapped6.php';
 require __DIR__ . '/includes/functions-embedded-v4.php';
 require __DIR__ . '/includes/functions-6to4.php';
+require __DIR__ . '/includes/functions-teredo.php';
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -22,7 +22,7 @@ require __DIR__ . '/includes/functions-rdns6.php';
 require __DIR__ . '/includes/functions-mapped6.php';
 require __DIR__ . '/includes/functions-embedded-v4.php';
 require __DIR__ . '/includes/functions-6to4.php';
-require __DIR__ . '/includes/functions-teredo.php';
+require_once __DIR__ . '/includes/functions-teredo.php';
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -766,9 +766,10 @@ if ($i < 3) {
         elseif (!empty($mapped6)) { $open_tool_ipv6 = 'mapped6'; }
         elseif (!empty($embedded_v4)) { $open_tool_ipv6 = 'embedded-v4'; }
         elseif (!empty($sixtofour)) { $open_tool_ipv6 = '6to4'; }
+        elseif (!empty($teredo)) { $open_tool_ipv6 = 'teredo'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -788,6 +789,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="mapped6" aria-expanded="false">IPv4-mapped / NAT64</button>
             <button type="button" class="tool-trigger" data-tool="embedded-v4" aria-expanded="false">Embedded IPv4</button>
             <button type="button" class="tool-trigger" data-tool="6to4" aria-expanded="false">6to4</button>
+            <button type="button" class="tool-trigger" data-tool="teredo" aria-expanded="false">Teredo</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -1562,6 +1564,159 @@ if ($i < 3) {
                             <?php endif; ?>
                         </dl>
                         <p><small>RFC 7526 deprecated the 6to4 anycast relay (192.88.99.1) in 2015. This tool is provided for analysis and migration audits.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="teredo">
+                <div class="overlap-panel">
+                    <div class="overlap-title">Teredo address decoder<?= help_bubble('ipv6-teredo', 'Decode and encode IPv6 addresses in the 2001:0::/32 Teredo prefix (RFC 4380). Decode mode extracts the server IPv4 (raw), 16-bit flags (cone bit = 0x8000), de-XOR\'d UDP port (XOR 0xFFFF), and de-XOR\'d client IPv4 (each byte XOR 0xFF). Encode mode rebuilds the address from those parts. Microsoft retired the public Teredo service for consumer Windows in 2019; this tool is provided for analysis of legacy traffic captures and address audits.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="teredo_mode">Mode<?= help_bubble('teredo-mode', 'Decode: Teredo IPv6 → server v4, client v4, port, flags. Encode: parts → Teredo IPv6 in 2001:0::/32.') ?></label>
+                                <select id="teredo_mode" name="teredo_mode">
+                                    <option value="decode"<?= ($teredo_mode ?? 'decode') === 'decode' ? ' selected' : '' ?>>Decode (Teredo IPv6 → parts)</option>
+                                    <option value="encode"<?= ($teredo_mode ?? 'decode') === 'encode' ? ' selected' : '' ?>>Encode (parts → Teredo IPv6)</option>
+                                </select>
+                            </div>
+                        </div>
+                        <?php if (($teredo_mode ?? 'decode') === 'decode') : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="teredo_input">Teredo IPv6 address<?= help_bubble('teredo-input', 'Any IPv6 literal under 2001:0::/32. Example: 2001:0:4136:e378:8000:63bf:3fff:fdd2 (RFC 4380 §4 worked example).') ?></label>
+                                    <input type="text" id="teredo_input" name="teredo_input"
+                                           value="<?= htmlspecialchars($teredo_input ?? '') ?>"
+                                           placeholder="2001:0:4136:e378:8000:63bf:3fff:fdd2"
+                                           autocomplete="off" spellcheck="false"
+                                           <?= !empty($teredo['error']) ? 'aria-invalid="true" aria-describedby="teredo-error"' : '' ?>>
+                                </div>
+                            </div>
+                        <?php else : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="teredo_server">Server IPv4<?= help_bubble('teredo-server', 'The Teredo server\'s public IPv4 address. Stored raw in the address (no XOR obfuscation).') ?></label>
+                                    <input type="text" id="teredo_server" name="teredo_server"
+                                           value="<?= htmlspecialchars($teredo_server_input ?? '') ?>"
+                                           placeholder="65.54.227.120"
+                                           autocomplete="off" spellcheck="false">
+                                </div>
+                                <div class="form-group">
+                                    <label for="teredo_client">Client IPv4<?= help_bubble('teredo-client', 'The Teredo client\'s public IPv4 address. Obfuscated with XOR 0xFF byte-by-byte before insertion into the IPv6 address.') ?></label>
+                                    <input type="text" id="teredo_client" name="teredo_client"
+                                           value="<?= htmlspecialchars($teredo_client_input ?? '') ?>"
+                                           placeholder="192.0.2.45"
+                                           autocomplete="off" spellcheck="false">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="teredo_port">UDP port<?= help_bubble('teredo-port', 'The client\'s mapped UDP port (0..65535). Obfuscated with XOR 0xFFFF before insertion.') ?></label>
+                                    <input type="text" id="teredo_port" name="teredo_port"
+                                           value="<?= htmlspecialchars($teredo_port_input ?? '') ?>"
+                                           placeholder="40000"
+                                           inputmode="numeric"
+                                           autocomplete="off" spellcheck="false">
+                                </div>
+                                <div class="form-group">
+                                    <label for="teredo_flags">Flags<?= help_bubble('teredo-flags', '16-bit flags field. Decimal or 0xNNNN. The high bit (0x8000) is the "cone" indicator. Leave blank to use the cone toggle below.') ?></label>
+                                    <input type="text" id="teredo_flags" name="teredo_flags"
+                                           value="<?= htmlspecialchars($teredo_flags_input ?? '') ?>"
+                                           placeholder="0x8000"
+                                           autocomplete="off" spellcheck="false">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label><input type="checkbox" name="teredo_cone" value="1"<?= !empty($teredo_cone_flag) ? ' checked' : '' ?>> Cone NAT<?= help_bubble('teredo-cone', 'When set, the Teredo client is behind a cone NAT (flags = 0x8000). When unset, flags = 0x0000. Ignored if you supply a flags value above.') ?></label>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Convert</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($teredo['error'])) : ?>
+                        <div class="error" id="teredo-error"><?= htmlspecialchars((string)$teredo['error']) ?></div>
+                    <?php elseif (!empty($teredo) && empty($teredo['error'])) : ?>
+                        <?php
+                        $_teredo_history = 'teredo: ' . (string)($teredo['ipv6'] ?? $teredo['input'] ?? '');
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="teredo"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_teredo_history) ?>">
+                            <?php if (($teredo['mode'] ?? 'decode') === 'decode') : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Input IPv6</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($teredo['input'] ?? '')) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Server IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($teredo['server_ipv4'] ?? '')) ?></code>
+                                        <?= copy_button((string)($teredo['server_ipv4'] ?? ''), 'Copy server IPv4') ?>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Client IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($teredo['client_ipv4'] ?? '')) ?></code>
+                                        <?= copy_button((string)($teredo['client_ipv4'] ?? ''), 'Copy client IPv4') ?>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">UDP port</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)(int)($teredo['port'] ?? 0)) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Flags</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars(sprintf('0x%04x', (int)($teredo['flags'] ?? 0))) ?></code>
+                                        <?= !empty($teredo['cone']) ? ' <span class="badge">cone</span>' : '' ?>
+                                    </dd>
+                                </div>
+                            <?php else : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Server IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($teredo['server_ipv4'] ?? '')) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Client IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($teredo['client_ipv4'] ?? '')) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">UDP port</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)(int)($teredo['port'] ?? 0)) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Flags</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars(sprintf('0x%04x', (int)($teredo['flags'] ?? 0))) ?></code>
+                                        <?= !empty($teredo['cone']) ? ' <span class="badge">cone</span>' : '' ?>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Teredo IPv6</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($teredo['ipv6'] ?? '')) ?></code>
+                                        <?= copy_button((string)($teredo['ipv6'] ?? ''), 'Copy Teredo IPv6') ?>
+                                    </dd>
+                                </div>
+                            <?php endif; ?>
+                        </dl>
+                        <p><small>Microsoft retired the public Teredo service for consumer Windows in 2019. This tool is provided for analysis of legacy traffic captures and address audits.</small></p>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/teredo.md
+++ b/docs/teredo.md
@@ -1,0 +1,114 @@
+# Teredo Address Decoder
+
+Decode and encode IPv6 addresses in the `2001:0::/32` Teredo prefix
+defined by [RFC 4380][rfc4380].
+
+!!! warning "Legacy transition mechanism"
+    Microsoft retired the public Teredo service for consumer Windows
+    in 2019. Native IPv6 connectivity has displaced Teredo across the
+    public internet. This tool is provided for analysis of historical
+    traffic captures and audits of addresses that still appear in
+    legacy logs.
+
+## How Teredo addresses are structured
+
+A Teredo address packs four pieces of information into 128 bits:
+
+```
+| 32 bits | 32 bits      | 16 bits | 16 bits      | 32 bits          |
+| 2001:0  | server IPv4  | flags   | port (XOR)   | client IPv4 (XOR)|
+```
+
+- The **server IPv4** is the public address of the Teredo server that
+  terminates the relay tunnel for the client. Stored raw, with no
+  obfuscation, because it does not need to traverse a NAT in plain
+  view.
+- The **flags** field is a 16-bit value whose high bit (`0x8000`) is
+  the **cone** indicator. Set to `0x8000` when the client is behind a
+  cone NAT (any inbound packet from any source can reach the mapped
+  port); cleared (`0x0000`) for restricted / port-restricted NATs.
+- The **UDP port** is the client's mapped port at its NAT, XOR-ed with
+  `0xFFFF` so that NAT devices on the wire don't rewrite it when they
+  see what looks like a port number embedded in an IPv6 address.
+- The **client IPv4** is the client's mapped public IPv4 address,
+  XOR-ed byte-by-byte with `0xFF` for the same reason.
+
+## RFC 4380 §4 worked example
+
+```
+server  = 65.54.227.120
+client  = 192.0.2.45
+port    = 40000
+flags   = 0x8000   (cone NAT)
+
+Teredo address: 2001:0:4136:e378:8000:63bf:3fff:fdd2
+```
+
+The decoder reverses the XOR obfuscation on the port and client v4 to
+recover their plain values; the encoder applies it.
+
+## Decoding (Teredo IPv6 → parts)
+
+| Field        | Value                          |
+| ------------ | ------------------------------ |
+| Server IPv4  | `65.54.227.120` (raw)          |
+| Flags        | `0x8000` (cone)                |
+| UDP port     | `40000` (XOR'd `0x63bf`)       |
+| Client IPv4  | `192.0.2.45` (XOR'd `3fff:fdd2`) |
+
+The decoder rejects any address that does not start with the
+`2001:0::/32` prefix. Use the
+[Embedded IPv4 Detector](embedded-v4.md) as the front door if you do
+not yet know whether an address is Teredo, 6to4, NAT64, ISATAP, or
+something else.
+
+## Encoding (parts → Teredo IPv6)
+
+Provide the four parts; the encoder packs them into the canonical form:
+
+- Server IPv4 → bytes 4–7 (raw).
+- Flags → bytes 8–9 (big-endian uint16). Default `0x8000` (cone).
+- Port XOR `0xFFFF` → bytes 10–11.
+- Client IPv4 XOR `0xFF` byte-by-byte → bytes 12–15.
+
+The encoder rejects malformed IPv4 addresses and out-of-range ports.
+
+## REST API
+
+`POST /api/v1/teredo` with one of two request bodies:
+
+```json
+{ "mode": "decode", "ipv6": "2001:0:4136:e378:8000:63bf:3fff:fdd2" }
+```
+
+```json
+{
+  "mode": "encode",
+  "server_ipv4": "65.54.227.120",
+  "client_ipv4": "192.0.2.45",
+  "port": 40000,
+  "flags": 32768
+}
+```
+
+See [REST API → Teredo](api.md) and the OpenAPI spec for the complete
+response schemas and error envelopes.
+
+## Shareable URL
+
+Direct-link to a pre-filled decode:
+
+```
+?tab=ipv6&tool=teredo&teredo_mode=decode&teredo_input=2001:0:4136:e378:8000:63bf:3fff:fdd2
+```
+
+Or an encode:
+
+```
+?tab=ipv6&tool=teredo&teredo_mode=encode&teredo_server=65.54.227.120&teredo_client=192.0.2.45&teredo_port=40000&teredo_cone=1
+```
+
+The `/ipv6/teredo` per-tool route accepts the same query parameters
+and auto-opens the drawer with the result rendered.
+
+[rfc4380]: https://datatracker.ietf.org/doc/html/rfc4380

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
     - IPv4-mapped / NAT64 (mapped6): ipv6-mapped6.md
     - Embedded IPv4 Detector: embedded-v4.md
     - 6to4 Address Tool: 6to4.md
+    - Teredo Address Decoder: teredo.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -3226,6 +3226,162 @@ async def test_ipv6_6to4_ui(page: Page) -> None:
                 await open_link.count() >= 1)
 
 
+async def test_api_teredo(page: Page) -> None:
+    section("API — POST /api/v1/teredo")
+
+    # Decode mode — RFC 4380 §4 worked example.
+    status, data = _api_post("teredo", {
+        "mode": "decode",
+        "ipv6": "2001:0:4136:e378:8000:63bf:3fff:fdd2",
+    })
+    assert_eq("api teredo decode: HTTP 200", status, 200)
+    assert_eq("api teredo decode: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api teredo decode: mode", d.get("mode"), "decode")
+    assert_eq("api teredo decode: server_ipv4", d.get("server_ipv4"), "65.54.227.120")
+    assert_eq("api teredo decode: client_ipv4", d.get("client_ipv4"), "192.0.2.45")
+    assert_eq("api teredo decode: port", d.get("port"), 40000)
+    assert_eq("api teredo decode: flags", d.get("flags"), 0x8000)
+    assert_eq("api teredo decode: cone", d.get("cone"), True)
+
+    # Encode mode — round-trip.
+    status2, data2 = _api_post("teredo", {
+        "mode": "encode",
+        "server_ipv4": "65.54.227.120",
+        "client_ipv4": "192.0.2.45",
+        "port": 40000,
+        "flags": 0x8000,
+    })
+    assert_eq("api teredo encode: HTTP 200", status2, 200)
+    d2 = data2.get("data", {})
+    assert_eq("api teredo encode: ipv6",
+              d2.get("ipv6"), "2001:0:4136:e378:8000:63bf:3fff:fdd2")
+    assert_eq("api teredo encode: cone", d2.get("cone"), True)
+
+    # Decode rejects non-Teredo addresses.
+    status3, _ = _api_post("teredo", {"mode": "decode", "ipv6": "2001:db8::1"})
+    assert_eq("api teredo decode: non-Teredo → 400", status3, 400)
+
+    # Decode rejects garbage.
+    status4, _ = _api_post("teredo", {"mode": "decode", "ipv6": "not-an-address"})
+    assert_eq("api teredo decode: garbage → 400", status4, 400)
+
+    # Encode rejects bad IPv4.
+    status5, _ = _api_post("teredo", {
+        "mode": "encode",
+        "server_ipv4": "not-an-ip",
+        "client_ipv4": "192.0.2.45",
+        "port": 40000,
+    })
+    assert_eq("api teredo encode: invalid server IPv4 → 400", status5, 400)
+
+    # Encode rejects out-of-range port.
+    status6, _ = _api_post("teredo", {
+        "mode": "encode",
+        "server_ipv4": "65.54.227.120",
+        "client_ipv4": "192.0.2.45",
+        "port": 70000,
+    })
+    assert_eq("api teredo encode: port out of range → 400", status6, 400)
+
+    # Missing required field on decode.
+    status7, _ = _api_post("teredo", {"mode": "decode"})
+    assert_eq("api teredo decode: missing ipv6 → 400", status7, 400)
+
+    # Missing required fields on encode.
+    status8, _ = _api_post("teredo", {"mode": "encode"})
+    assert_eq("api teredo encode: missing parts → 400", status8, 400)
+
+    # Invalid mode.
+    status9, _ = _api_post("teredo", {"mode": "bogus", "ipv6": "2001:0::1"})
+    assert_eq("api teredo: invalid mode → 400", status9, 400)
+
+    # embedded-v4 detector now deep-links Teredo to /ipv6/teredo (T4 contract).
+    status10, data10 = _api_post("embedded-v4",
+                                 {"input": "2001:0:4136:e378:8000:63bf:3fff:fdd2"})
+    assert_eq("api embedded-v4 (teredo): HTTP 200", status10, 200)
+    assert_eq("api embedded-v4 (teredo): detail_route is /ipv6/teredo",
+              data10.get("data", {}).get("detail_route"), "/ipv6/teredo")
+
+
+async def test_ipv6_teredo_ui(page: Page) -> None:
+    section("IPv6 Teredo tool UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # /ipv6/teredo should auto-open the drawer (per-tool URL routing).
+    await navigate(page, APP_URL + "?tab=ipv6&tool=teredo")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='teredo']")
+    assert_eq("teredo UI: panel exists", await panel.count(), 1)
+
+    # Decode — Teredo IPv6 → parts.
+    await page.select_option("#teredo_mode", "decode")
+    await page.fill("#teredo_input", "2001:0:4136:e378:8000:63bf:3fff:fdd2")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='teredo'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='teredo']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("teredo UI decode: server v4 rendered",
+                "65.54.227.120" in body_text, f"body: {body_text!r}")
+    assert_true("teredo UI decode: client v4 rendered",
+                "192.0.2.45" in body_text, f"body: {body_text!r}")
+    assert_true("teredo UI decode: port rendered",
+                "40000" in body_text, f"body: {body_text!r}")
+    assert_true("teredo UI decode: flags rendered",
+                "0x8000" in body_text, f"body: {body_text!r}")
+
+    # Copy server IPv4.
+    await panel.locator(".subnet-copy").first.click()
+    await page.wait_for_timeout(50)
+    assert_eq("teredo UI decode: copy server IPv4",
+              await page.evaluate("window.__lastClipboard"),
+              "65.54.227.120")
+
+    # Error path — non-Teredo address.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=teredo")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.select_option("#teredo_mode", "decode")
+    await page.fill("#teredo_input", "2001:db8::1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='teredo'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='teredo']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("teredo UI: error band on non-Teredo address",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+    # Shareable GET URL hydrates without re-submission.
+    await navigate(page,
+                   APP_URL + "?tab=ipv6&tool=teredo&teredo_mode=decode&teredo_input=2001:0:4136:e378:8000:63bf:3fff:fdd2")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='teredo']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("teredo UI shareable URL: server v4 hydrated",
+                "65.54.227.120" in body_text, f"body: {body_text!r}")
+    assert_true("teredo UI shareable URL: client v4 hydrated",
+                "192.0.2.45" in body_text, f"body: {body_text!r}")
+
+    # embedded-v4 detector now deep-links Teredo to /ipv6/teredo. Render
+    # the embedded-v4 drawer with a Teredo input and verify the
+    # Open-in-tool button is enabled (anchor element).
+    await navigate(page,
+                   APP_URL + "?tab=ipv6&tool=embedded-v4&embedded_v4_input=2001:0:4136:e378:8000:63bf:3fff:fdd2")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    ev4_panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-v4']")
+    open_link = ev4_panel.locator("a.splitter-btn[href='/ipv6/teredo']")
+    assert_true("embedded-v4 → teredo deep-link: anchor present",
+                await open_link.count() >= 1)
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -8118,6 +8274,8 @@ async def main() -> None:
             await test_api_embedded_v4(page)
             await test_ipv6_6to4_ui(page)
             await test_api_6to4(page)
+            await test_ipv6_teredo_ui(page)
+            await test_api_teredo(page)
             await test_a11y_ipv6_drawers(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)

--- a/testing/unit/EmbeddedV4Test.php
+++ b/testing/unit/EmbeddedV4Test.php
@@ -37,7 +37,10 @@ final class EmbeddedV4Test extends TestCase
         $this->assertSame('teredo', $result['scheme']);
         $this->assertSame('192.0.2.45', $result['ipv4']);
         $this->assertSame('65.54.227.120', $result['extra']['server_ipv4']);
-        $this->assertSame(40000, $result['extra']['udp_port']);
+        $this->assertSame('192.0.2.45', $result['extra']['client_ipv4']);
+        $this->assertSame(40000, $result['extra']['port']);
+        $this->assertSame(0x8000, $result['extra']['flags']);
+        $this->assertTrue($result['extra']['cone']);
     }
 
     public function test_nat64_wkp_detected(): void

--- a/testing/unit/EmbeddedV4Test.php
+++ b/testing/unit/EmbeddedV4Test.php
@@ -87,9 +87,9 @@ final class EmbeddedV4Test extends TestCase
 
     public function test_detail_routes_per_scheme(): void
     {
-        // Per-scheme drawers land incrementally across v3.5.0. As of T3
-        // (#392) only 6to4 has shipped; mapped/compatible/teredo/nat64-wkp/
-        // isatap detail_routes stay null until T4–T7. This test pins the
+        // Per-scheme drawers land incrementally across v3.5.0. As of T4
+        // (#393) 6to4 and Teredo have shipped; mapped/compatible/nat64-wkp/
+        // isatap detail_routes stay null until T5–T7. This test pins the
         // contract so each future wiring touch is deliberate.
         $sixToFour = detect_embedded_v4('2002:c000:0201::');
         $this->assertSame('/ipv6/6to4', $sixToFour['detail_route']);
@@ -101,7 +101,7 @@ final class EmbeddedV4Test extends TestCase
         $this->assertNull($compatible['detail_route']);
 
         $teredo = detect_embedded_v4('2001:0:4136:e378:8000:63bf:3fff:fdd2');
-        $this->assertNull($teredo['detail_route']);
+        $this->assertSame('/ipv6/teredo', $teredo['detail_route']);
 
         $nat64Wkp = detect_embedded_v4('64:ff9b::192.0.2.1');
         $this->assertNull($nat64Wkp['detail_route']);

--- a/testing/unit/TeredoTest.php
+++ b/testing/unit/TeredoTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class TeredoTest extends TestCase
+{
+    // ─── decode_teredo() ───────────────────────────────────────────────────────
+
+    public function test_decode_rfc4380_example(): void
+    {
+        // RFC 4380 §4 worked example:
+        //   server = 65.54.227.120
+        //   client = 192.0.2.45 (post-XOR)
+        //   port   = 40000      (post-XOR)
+        //   flags  = 0x8000 (cone)
+        // Encoded address: 2001:0:4136:e378:8000:63bf:3fff:fdd2
+        $r = decode_teredo('2001:0:4136:e378:8000:63bf:3fff:fdd2');
+        $this->assertSame('65.54.227.120', $r['server_ipv4']);
+        $this->assertSame(40000, $r['port']);
+        $this->assertSame('192.0.2.45', $r['client_ipv4']);
+        $this->assertTrue($r['cone']);
+        $this->assertSame(0x8000, $r['flags']);
+    }
+
+    public function test_decode_non_cone_flag(): void
+    {
+        // Same address but flags=0x0000 → non-cone client.
+        $r = decode_teredo('2001:0:4136:e378:0:63bf:3fff:fdd2');
+        $this->assertFalse($r['cone']);
+        $this->assertSame(0, $r['flags']);
+        $this->assertSame('192.0.2.45', $r['client_ipv4']);
+        $this->assertSame(40000, $r['port']);
+    }
+
+    public function test_decode_rejects_non_teredo(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_teredo('2001:db8::1');
+    }
+
+    public function test_decode_rejects_6to4(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_teredo('2002:c000:0201::1');
+    }
+
+    public function test_decode_rejects_garbage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_teredo('not-an-address');
+    }
+
+    public function test_decode_rejects_ipv4(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_teredo('192.0.2.1');
+    }
+
+    public function test_decode_rejects_empty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_teredo('');
+    }
+
+    // ─── encode_teredo() ───────────────────────────────────────────────────────
+
+    public function test_encode_round_trip(): void
+    {
+        $addr = encode_teredo('65.54.227.120', '192.0.2.45', 40000, 0x8000);
+        $this->assertSame('2001:0:4136:e378:8000:63bf:3fff:fdd2', $addr);
+    }
+
+    public function test_encode_default_flags_cone(): void
+    {
+        // Default flags arg = 0x8000 (cone).
+        $addr = encode_teredo('65.54.227.120', '192.0.2.45', 40000);
+        $this->assertSame('2001:0:4136:e378:8000:63bf:3fff:fdd2', $addr);
+    }
+
+    public function test_encode_zero_flags(): void
+    {
+        $addr = encode_teredo('65.54.227.120', '192.0.2.45', 40000, 0);
+        $this->assertSame('2001:0:4136:e378:0:63bf:3fff:fdd2', $addr);
+    }
+
+    public function test_encode_rejects_invalid_server_ipv4(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        encode_teredo('not-an-ip', '192.0.2.45', 40000);
+    }
+
+    public function test_encode_rejects_invalid_client_ipv4(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        encode_teredo('65.54.227.120', 'not-an-ip', 40000);
+    }
+
+    public function test_encode_rejects_port_out_of_range_high(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        encode_teredo('65.54.227.120', '192.0.2.45', 70000);
+    }
+
+    public function test_encode_rejects_port_out_of_range_negative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        encode_teredo('65.54.227.120', '192.0.2.45', -1);
+    }
+
+    public function test_encode_rejects_ipv6_as_v4(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        encode_teredo('::ffff:192.0.2.1', '192.0.2.45', 40000);
+    }
+
+    // ─── round-trip ────────────────────────────────────────────────────────────
+
+    public function test_decode_encode_round_trip(): void
+    {
+        $original = '2001:0:4136:e378:8000:63bf:3fff:fdd2';
+        $r = decode_teredo($original);
+        $rebuilt = encode_teredo($r['server_ipv4'], $r['client_ipv4'], $r['port'], $r['flags']);
+        $this->assertSame($original, $rebuilt);
+    }
+}

--- a/testing/unit/TeredoTest.php
+++ b/testing/unit/TeredoTest.php
@@ -124,4 +124,33 @@ final class TeredoTest extends TestCase
         $rebuilt = encode_teredo($r['server_ipv4'], $r['client_ipv4'], $r['port'], $r['flags']);
         $this->assertSame($original, $rebuilt);
     }
+
+    public function test_encode_decode_roundtrip_port_zero(): void
+    {
+        $addr = encode_teredo('65.54.227.120', '192.0.2.45', 0, 0x8000);
+        $r = decode_teredo($addr);
+        $this->assertSame(0, $r['port']);
+        $this->assertSame('65.54.227.120', $r['server_ipv4']);
+        $this->assertSame('192.0.2.45', $r['client_ipv4']);
+    }
+
+    public function test_encode_decode_roundtrip_client_zero(): void
+    {
+        $addr = encode_teredo('65.54.227.120', '0.0.0.0', 40000, 0x8000);
+        $r = decode_teredo($addr);
+        $this->assertSame('0.0.0.0', $r['client_ipv4']);
+        $this->assertSame('65.54.227.120', $r['server_ipv4']);
+        $this->assertSame(40000, $r['port']);
+    }
+
+    public function test_decode_2001_double_colon_1_succeeds(): void
+    {
+        // 2001::1 sits inside 2001:0::/32 — decode is intentionally permissive
+        // and treats it as a degenerate Teredo address. Server is all-zero and
+        // flags is 0 (non-cone). Pins this permissive behaviour as intentional.
+        $r = decode_teredo('2001::1');
+        $this->assertSame('0.0.0.0', $r['server_ipv4']);
+        $this->assertSame(0, $r['flags']);
+        $this->assertFalse($r['cone']);
+    }
 }

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -21,6 +21,7 @@ require $base . 'functions-rdns6.php';
 require $base . 'functions-mapped6.php';
 require $base . 'functions-embedded-v4.php';
 require $base . 'functions-6to4.php';
+require $base . 'functions-teredo.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -21,7 +21,7 @@ require $base . 'functions-rdns6.php';
 require $base . 'functions-mapped6.php';
 require $base . 'functions-embedded-v4.php';
 require $base . 'functions-6to4.php';
-require $base . 'functions-teredo.php';
+require_once $base . 'functions-teredo.php';
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

Task 4 of the v3.5.0 transition release: Teredo (RFC 4380) address
decoder/encoder. Adds a dedicated drawer in the IPv6 toolbar, REST
endpoint `POST /api/v1/teredo`, shareable URL (`/ipv6/teredo` and
`?teredo_*=…`), MkDocs page, and CHANGELOG entry. Closes #393.

- **Decode**: 2001:0::/32 IPv6 → server v4 (raw), flags (cone bit
  0x8000), de-XOR'd UDP port (XOR 0xFFFF), de-XOR'd client v4
  (per-byte XOR 0xFF).
- **Encode**: parts → canonical Teredo IPv6. Default flags `0x8000`
  (cone). Round-trips RFC 4380 §4 worked example
  (`2001:0:4136:e378:8000:63bf:3fff:fdd2`).
- **Embedded-v4 deep-link**: T2's detector now returns
  `detail_route='/ipv6/teredo'` for Teredo detections; pinned by
  `EmbeddedV4Test::test_detail_routes_per_scheme`.

## Test plan

- [x] PHPUnit: 564 tests, 1288 assertions (16 new in `TeredoTest`)
- [x] PHPStan level 9 (`--memory-limit=512M`): no errors
- [x] PHPCS PSR-12 over `includes/` and `api/`: clean
- [x] Spectral OpenAPI lint: no errors
- [x] semgrep (rules + p/php + p/owasp-top-ten + p/sql-injection): 0 findings
- [x] ESLint + Stylelint: no errors
- [x] Playwright: 1557/1557 via `make test-docker` (adds
      `test_api_teredo` + `test_ipv6_teredo_ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)