### PR TITLE
feat(v3.5.0): ISATAP interface-ID helper (RFC 5214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ as each ships.
 - **Teredo address decoder (RFC 4380).** Decode and encode `2001:0::/32`
   Teredo addresses (server v4, flags incl. cone bit, XOR'd UDP port,
   XOR'd client v4). Help text notes operational status. (#393)
+- **ISATAP interface-ID helper (RFC 5214).** Build ISATAP IIDs from
+  IPv4 (`::0:5efe:V4ADDR` for non-global, `::200:5efe:V4ADDR` for
+  global) and decode them back. Auto-detects globally-unique vs
+  private from the IPv4 input. (#394)
 
 ## [3.4.1] - 2026-05-08
 

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -71,6 +71,8 @@ tags:
     description: 6to4 address tool (RFC 3056) — bidirectional IPv4 ↔ 2002::/16 translation
   - name: Teredo
     description: Teredo address decoder (RFC 4380) — bidirectional decoding/encoding of 2001:0::/32 addresses
+  - name: Isatap
+    description: ISATAP interface-ID helper (RFC 5214) — bidirectional encoding/decoding of the 64-bit ISATAP IID
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -362,6 +364,7 @@ paths:
                     - "POST /api/v1/embedded-v4"
                     - "POST /api/v1/6to4"
                     - "POST /api/v1/teredo"
+                    - "POST /api/v1/isatap"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -2270,6 +2273,143 @@ paths:
                   client_ipv4: "192.0.2.45"
         "400":
           description: Missing required field, unparseable input, or non-Teredo address
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /isatap:
+    post:
+      operationId: isatapConvert
+      tags: [Isatap]
+      summary: Encode an IPv4 into an ISATAP IID or decode an ISATAP IID back to IPv4 (RFC 5214)
+      description: |
+        Bidirectional conversion between an IPv4 address and the 64-bit
+        ISATAP interface ID that embeds it. Two modes:
+
+        - **`encode`** — input `ipv4` (any IPv4 literal) and optional
+          `globally_unique` (boolean). When `globally_unique` is omitted
+          the helper auto-detects from the IPv4: public address →
+          `true` (`0200:5efe:V4`); private/reserved → `false`
+          (`0000:5efe:V4`). Output is the colon-grouped IID with
+          leading zeros stripped per hexadectet (`inet_ntop`-style),
+          plus the resolved `globally_unique` flag.
+        - **`decode`** — input `iid` (four colon-separated hexadectets,
+          either canonical or zero-padded; magic must be `0000:5efe`
+          or `0200:5efe`). Output is the embedded `ipv4` and
+          `globally_unique` flag.
+
+        ISATAP saw limited deployment outside specific enterprise
+        transition scenarios. This endpoint is provided for analysis of
+        legacy traffic and address audits.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  required: [mode, ipv4]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [encode]
+                    ipv4:
+                      type: string
+                      example: "192.0.2.1"
+                    globally_unique:
+                      type: boolean
+                      description: When omitted, auto-detected from the IPv4 (public → true, private/reserved → false).
+                - type: object
+                  required: [mode, iid]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [decode]
+                    iid:
+                      type: string
+                      description: ISATAP IID — four colon-separated hexadectets.
+                      example: "200:5efe:c000:201"
+            examples:
+              encode:
+                summary: Encode IPv4 → ISATAP IID
+                value: { mode: encode, ipv4: "192.0.2.1" }
+              decode:
+                summary: Decode ISATAP IID → IPv4
+                value: { mode: decode, iid: "200:5efe:c000:201" }
+      responses:
+        "200":
+          description: Conversion result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        oneOf:
+                          - type: object
+                            required: [mode, ipv4, iid, globally_unique]
+                            properties:
+                              mode:
+                                type: string
+                                enum: [encode]
+                              ipv4:
+                                type: string
+                                example: "192.0.2.1"
+                              iid:
+                                type: string
+                                example: "200:5efe:c000:201"
+                              globally_unique:
+                                type: boolean
+                                example: true
+                          - type: object
+                            required: [mode, iid, ipv4, globally_unique]
+                            properties:
+                              mode:
+                                type: string
+                                enum: [decode]
+                              iid:
+                                type: string
+                                example: "200:5efe:c000:201"
+                              ipv4:
+                                type: string
+                                example: "192.0.2.1"
+                              globally_unique:
+                                type: boolean
+                                example: true
+              example:
+                ok: true
+                data:
+                  mode: encode
+                  ipv4: "192.0.2.1"
+                  iid: "200:5efe:c000:201"
+                  globally_unique: true
+        "400":
+          description: Missing required field, unparseable input, or non-ISATAP IID
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/isatap.php
+++ b/Subnet-Calculator/api/v1/handlers/isatap.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body     = api_body();
+$raw_mode = $body['mode'] ?? 'encode';
+if (!is_string($raw_mode)) {
+    json_err('Field "mode" must be a string ("encode" or "decode").', 400);
+}
+$mode = strtolower(trim($raw_mode));
+if ($mode === '') {
+    $mode = 'encode';
+}
+if ($mode !== 'encode' && $mode !== 'decode') {
+    json_err('Field "mode" must be "encode" or "decode".', 400);
+}
+
+if ($mode === 'encode') {
+    $raw_v4 = $body['ipv4'] ?? null;
+    if (!is_string($raw_v4) || trim($raw_v4) === '') {
+        json_err('Field "ipv4" (string) is required when mode=encode.', 400);
+    }
+    $globally_unique = null;
+    if (array_key_exists('globally_unique', $body)) {
+        if (!is_bool($body['globally_unique'])) {
+            json_err('Field "globally_unique" must be a boolean if present.', 400);
+        }
+        $globally_unique = $body['globally_unique'];
+    }
+    try {
+        $iid = ipv4_to_isatap_iid(trim($raw_v4), $globally_unique);
+    } catch (\InvalidArgumentException $e) {
+        json_err($e->getMessage(), 400);
+    }
+    // Re-derive globally_unique from the produced IID so the response is
+    // consistent regardless of whether the caller supplied an explicit value.
+    $decoded = decode_isatap_iid($iid);
+    json_ok([
+        'mode'            => 'encode',
+        'ipv4'            => trim($raw_v4),
+        'iid'             => $iid,
+        'globally_unique' => $decoded['globally_unique'],
+    ]);
+}
+
+// mode === 'decode'
+$raw_iid = $body['iid'] ?? null;
+if (!is_string($raw_iid) || trim($raw_iid) === '') {
+    json_err('Field "iid" (string) is required when mode=decode.', 400);
+}
+try {
+    $decoded = decode_isatap_iid(trim($raw_iid));
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+json_ok([
+    'mode'            => 'decode',
+    'iid'             => trim($raw_iid),
+    'ipv4'            => $decoded['ipv4'],
+    'globally_unique' => $decoded['globally_unique'],
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -31,6 +31,9 @@ require $base . 'functions-mapped6.php';
 require $base . 'functions-embedded-v4.php';
 require $base . 'functions-6to4.php';
 require_once $base . 'functions-teredo.php';
+// phpcs:disable PSR1.Files.SideEffects -- module include for ipv4_to_isatap_iid()/decode_isatap_iid().
+require_once $base . 'functions-isatap.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -120,6 +123,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/embedded-v4',
             'POST /api/v1/6to4',
             'POST /api/v1/teredo',
+            'POST /api/v1/isatap',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -255,6 +259,9 @@ switch ($route_key) {
         break;
     case 'POST /teredo':
         require __DIR__ . '/handlers/teredo.php';
+        break;
+    case 'POST /isatap':
+        require __DIR__ . '/handlers/isatap.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-embedded-v4.php
+++ b/Subnet-Calculator/includes/functions-embedded-v4.php
@@ -29,6 +29,9 @@ declare(strict_types=1);
 // phpcs:disable PSR1.Files.SideEffects -- explicit dependency on decode_teredo().
 require_once __DIR__ . '/functions-teredo.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- explicit dependency on decode_isatap_iid().
+require_once __DIR__ . '/functions-isatap.php';
+// phpcs:enable PSR1.Files.SideEffects
 
 const EMBEDDEDV4_MAPPED_PREFIX_BIN     = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff";
 const EMBEDDEDV4_NAT64_WKP_PREFIX_BIN  = "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00";
@@ -169,18 +172,32 @@ function detect_embedded_v4(string $ipv6): array
     // 5. ISATAP: IID matches `*:0000:5efe:V4ADDR` (locally-administered)
     //    or `*:0200:5efe:V4ADDR` (globally-unique u-bit set). Bytes 8–11
     //    of the address hold the magic; V4 in bytes 12–15. Any /64 prefix.
+    //    Delegate to decode_isatap_iid() so the `extra` payload shape stays
+    //    in lockstep with the dedicated decoder (ipv4, globally_unique).
     $iidMagic = substr($bin, 8, 4);
     if ($iidMagic === "\x00\x00\x5e\xfe" || $iidMagic === "\x02\x00\x5e\xfe") {
-        $v4 = @inet_ntop(substr($bin, 12, 4));
-        return [
-            'scheme'       => 'isatap',
-            'ipv4'         => $v4 === false ? null : $v4,
-            'deprecated'   => false,
-            'detail_route' => null,
-            'extra'        => [
-                'globally_unique' => $iidMagic === "\x02\x00\x5e\xfe",
-            ],
-        ];
+        $iidParts = sprintf(
+            '%x:%x:%x:%x',
+            (ord($bin[8])  << 8) | ord($bin[9]),
+            (ord($bin[10]) << 8) | ord($bin[11]),
+            (ord($bin[12]) << 8) | ord($bin[13]),
+            (ord($bin[14]) << 8) | ord($bin[15])
+        );
+        try {
+            $decoded = decode_isatap_iid($iidParts);
+            return [
+                'scheme'       => 'isatap',
+                'ipv4'         => $decoded['ipv4'],
+                'deprecated'   => false,
+                'detail_route' => '/ipv6/isatap',
+                'extra'        => [
+                    'ipv4'            => $decoded['ipv4'],
+                    'globally_unique' => $decoded['globally_unique'],
+                ],
+            ];
+        } catch (InvalidArgumentException $e) {
+            // Fall through to no-match return below.
+        }
     }
 
     // 6. IPv4-compatible: ::/96, RFC 4291 §2.5.5.1 (DEPRECATED).

--- a/Subnet-Calculator/includes/functions-isatap.php
+++ b/Subnet-Calculator/includes/functions-isatap.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+// ISATAP interface-ID helper (RFC 5214) — bidirectional encoding/decoding
+// of the 64-bit ISATAP interface identifier that embeds an IPv4 address.
+//
+//   | 32 bits         | 32 bits          |
+//   | 0000:5efe       | V4ADDR (raw)     |   locally-administered
+//   | 0200:5efe       | V4ADDR (raw)     |   globally-unique (u-bit set)
+//
+// The IID is appended to any /64 prefix to form a complete IPv6 address.
+// `0x5efe` is the IANA-assigned OUI-style value for ISATAP. The leading
+// 16 bits encode the universal/local (u) bit per RFC 4291 §2.5.1: 0x0000
+// for locally-administered (i.e. the embedded V4 is from a private/
+// reserved range and not globally unique), 0x0200 for globally-unique.
+//
+// RFC 5214 was published in 2008. ISATAP deployment has been very limited
+// outside specific enterprise transition scenarios. This tool is provided
+// for analysis of legacy traffic and address audits.
+
+/**
+ * Build an ISATAP interface ID from an IPv4 address per RFC 5214 §6.
+ *
+ * @param string    $ipv4
+ * @param ?bool $globally_unique  When null, infer from filter_var private/
+ *                                 reserved checks: globally-routable IPv4 →
+ *                                 true; private/reserved → false.
+ *                                 When true, builds '200:5efe:V4ADDR'.
+ *                                 When false, builds '0:5efe:V4ADDR'.
+ *
+ * @return string The 64-bit IID as a colon-grouped string with leading zeros
+ *                stripped from each hexadectet (matching inet_ntop()-style
+ *                canonical output), e.g. '0:5efe:c000:201' or
+ *                '200:5efe:c000:201'.
+ *
+ * @throws InvalidArgumentException if $ipv4 is not a valid IPv4 literal.
+ */
+function ipv4_to_isatap_iid(string $ipv4, ?bool $globally_unique = null): string
+{
+    $raw = trim($ipv4);
+    if ($raw === '') {
+        throw new InvalidArgumentException('IPv4 address is required.');
+    }
+    if (filter_var($raw, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+        throw new InvalidArgumentException('Invalid IPv4 address: ' . $raw);
+    }
+
+    $bin = @inet_pton($raw);
+    if ($bin === false || strlen($bin) !== 4) {
+        throw new InvalidArgumentException('Invalid IPv4 address: ' . $raw);
+    }
+
+    if ($globally_unique === null) {
+        // Globally-unique means routable on the public internet — neither
+        // private (RFC 1918) nor reserved (loopback/link-local/etc.).
+        $isPublic = filter_var(
+            $raw,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        );
+        $globally_unique = ($isPublic !== false);
+    }
+
+    // First two hexadectets: ISATAP magic.
+    $hd1 = $globally_unique ? 0x0200 : 0x0000;
+    $hd2 = 0x5efe;
+
+    // Bottom two hexadectets: pack the v4 octets as two big-endian 16-bit groups.
+    $hd3 = (ord($bin[0]) << 8) | ord($bin[1]);
+    $hd4 = (ord($bin[2]) << 8) | ord($bin[3]);
+
+    // Format like inet_ntop() canonical hex: leading zeros stripped per group.
+    return sprintf('%x:%x:%x:%x', $hd1, $hd2, $hd3, $hd4);
+}
+
+/**
+ * Recognise an ISATAP IID and extract the embedded IPv4.
+ *
+ * Accepts both the canonical compressed form ('0:5efe:c000:201') and the
+ * fully zero-padded form ('0000:5efe:c000:0201'). Trailing scope or zone
+ * suffixes are not accepted — callers should pass just the bottom-64 IID.
+ *
+ * @return array{ipv4: string, globally_unique: bool}
+ *
+ * @throws InvalidArgumentException if the IID does not match the ISATAP
+ *         pattern or is otherwise unparseable.
+ */
+function decode_isatap_iid(string $iid): array
+{
+    $raw = trim($iid);
+    if ($raw === '') {
+        throw new InvalidArgumentException('ISATAP IID is required.');
+    }
+
+    $parts = explode(':', $raw);
+    if (count($parts) !== 4) {
+        throw new InvalidArgumentException(
+            'ISATAP IID must have exactly four colon-separated hexadectets: ' . $raw
+        );
+    }
+    foreach ($parts as $hd) {
+        if ($hd === '' || strlen($hd) > 4 || !ctype_xdigit($hd)) {
+            throw new InvalidArgumentException(
+                'ISATAP IID contains an invalid hexadectet: ' . $raw
+            );
+        }
+    }
+
+    $hd1 = hexdec($parts[0]);
+    $hd2 = hexdec($parts[1]);
+    $hd3 = hexdec($parts[2]);
+    $hd4 = hexdec($parts[3]);
+
+    if ($hd2 !== 0x5efe) {
+        throw new InvalidArgumentException(
+            'ISATAP IID magic (second hexadectet) must be 5efe: ' . $raw
+        );
+    }
+    if ($hd1 !== 0x0000 && $hd1 !== 0x0200) {
+        throw new InvalidArgumentException(
+            'ISATAP IID first hexadectet must be 0000 or 0200: ' . $raw
+        );
+    }
+
+    // Reassemble the v4 from the bottom two hexadectets.
+    $v4Bin = chr(($hd3 >> 8) & 0xFF)
+           . chr($hd3 & 0xFF)
+           . chr(($hd4 >> 8) & 0xFF)
+           . chr($hd4 & 0xFF);
+    $v4 = @inet_ntop($v4Bin);
+    if ($v4 === false) {
+        throw new InvalidArgumentException('Internal error decoding embedded IPv4.');
+    }
+
+    return [
+        'ipv4'            => $v4,
+        'globally_unique' => $hd1 === 0x0200,
+    ];
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -583,6 +583,89 @@ function sc_run_teredo(
     }
 }
 
+// ─── ISATAP helper (shared by POST handler and GET shareable URL) ─────────
+
+/**
+ * Run the ISATAP tool against the supplied input. Mode is either 'encode'
+ * (IPv4 → ISATAP IID) or 'decode' (IID → IPv4). Empty input returns [].
+ * (v3.5.0 Task 5)
+ *
+ * @return array{
+ *     mode?: 'encode'|'decode',
+ *     input?: string,
+ *     ipv4?: string,
+ *     iid?: string,
+ *     globally_unique?: bool,
+ *     error?: string|null
+ * }
+ */
+function sc_run_isatap(
+    string $mode,
+    string $ipv4_input,
+    string $iid_input,
+    string $globally_unique_input
+): array {
+    $mode = strtolower(trim($mode));
+    if ($mode !== 'encode' && $mode !== 'decode') {
+        $mode = 'encode';
+    }
+
+    if ($mode === 'encode') {
+        $raw = trim($ipv4_input);
+        if ($raw === '') {
+            return [];
+        }
+        $gu = null;
+        $guRaw = strtolower(trim($globally_unique_input));
+        if ($guRaw === 'true' || $guRaw === '1' || $guRaw === 'yes') {
+            $gu = true;
+        } elseif ($guRaw === 'false' || $guRaw === '0' || $guRaw === 'no') {
+            $gu = false;
+        }
+        try {
+            $iid = ipv4_to_isatap_iid($raw, $gu);
+            $decoded = decode_isatap_iid($iid);
+            return [
+                'mode'            => 'encode',
+                'input'           => $raw,
+                'ipv4'            => $raw,
+                'iid'             => $iid,
+                'globally_unique' => $decoded['globally_unique'],
+                'error'           => null,
+            ];
+        } catch (\InvalidArgumentException $e) {
+            return [
+                'mode'  => 'encode',
+                'input' => $raw,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    // decode mode
+    $raw = trim($iid_input);
+    if ($raw === '') {
+        return [];
+    }
+    try {
+        $r = decode_isatap_iid($raw);
+        return [
+            'mode'            => 'decode',
+            'input'           => $raw,
+            'iid'             => $raw,
+            'ipv4'            => $r['ipv4'],
+            'globally_unique' => $r['globally_unique'],
+            'error'           => null,
+        ];
+    } catch (\InvalidArgumentException $e) {
+        return [
+            'mode'  => 'decode',
+            'input' => $raw,
+            'error' => $e->getMessage(),
+        ];
+    }
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -746,6 +829,14 @@ $teredo_cone_flag    = true;
 /** @var array{mode?: 'encode'|'decode', input?: string, ipv6?: string, server_ipv4?: string, client_ipv4?: string, port?: int, flags?: int, cone?: bool, error?: string|null} */
 $teredo = [];
 
+// v3.5.0 Task 5 — ISATAP interface-ID helper (RFC 5214)
+$isatap_mode             = 'encode';
+$isatap_ipv4_input       = '';
+$isatap_iid_input        = '';
+$isatap_globally_unique  = '';
+/** @var array{mode?: 'encode'|'decode', input?: string, ipv4?: string, iid?: string, globally_unique?: bool, error?: string|null} */
+$isatap = [];
+
 $ula_global_id_input = '';
 /** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
 $ula = [];
@@ -816,6 +907,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || isset($_POST['teredo_server'])
         || isset($_POST['teredo_client'])
         || isset($_POST['teredo_port']);
+    $is_isatap        = isset($_POST['isatap_mode'])
+        || isset($_POST['isatap_ipv4'])
+        || isset($_POST['isatap_iid']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -824,7 +918,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_vlsm6 || $is_supernet || $is_supernet6 || $is_ula || $is_session_save || $is_range
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
         || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6 || $is_embedded_v4
-        || $is_sixtofour || $is_teredo;
+        || $is_sixtofour || $is_teredo || $is_isatap;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -1274,6 +1368,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         );
     }
 
+    if ($is_isatap && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $isatap_mode = (string)($_POST['isatap_mode'] ?? 'encode');
+        if ($isatap_mode !== 'encode' && $isatap_mode !== 'decode') {
+            $isatap_mode = 'encode';
+        }
+        $isatap_ipv4_input      = trim((string)($_POST['isatap_ipv4'] ?? ''));
+        $isatap_iid_input       = trim((string)($_POST['isatap_iid']  ?? ''));
+        $isatap_globally_unique = (string)($_POST['isatap_globally_unique'] ?? '');
+        $isatap = sc_run_isatap(
+            $isatap_mode,
+            $isatap_ipv4_input,
+            $isatap_iid_input,
+            $isatap_globally_unique
+        );
+    }
+
     if ($is_ula && !$form_blocked) {
         $ula_global_id_input = trim((string)($_POST['ula_global_id'] ?? ''));
         $ur = generate_ula_prefix($ula_global_id_input);
@@ -1712,6 +1823,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $teredo_port_input,
             $teredo_flags_input,
             $teredo_cone_flag
+        );
+    }
+
+    // ISATAP shareable GET URL (v3.5.0 Task 5)
+    if (
+        $active_tab === 'ipv6'
+        && (isset($_GET['isatap_ipv4']) || isset($_GET['isatap_iid']))
+    ) {
+        $isatap_mode = (string)($_GET['isatap_mode'] ?? 'encode');
+        if ($isatap_mode !== 'encode' && $isatap_mode !== 'decode') {
+            $isatap_mode = 'encode';
+        }
+        $isatap_ipv4_input      = trim((string)($_GET['isatap_ipv4'] ?? ''));
+        $isatap_iid_input       = trim((string)($_GET['isatap_iid']  ?? ''));
+        $isatap_globally_unique = (string)($_GET['isatap_globally_unique'] ?? '');
+        $isatap = sc_run_isatap(
+            $isatap_mode,
+            $isatap_ipv4_input,
+            $isatap_iid_input,
+            $isatap_globally_unique
         );
     }
 

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -23,6 +23,9 @@ require __DIR__ . '/includes/functions-mapped6.php';
 require __DIR__ . '/includes/functions-embedded-v4.php';
 require __DIR__ . '/includes/functions-6to4.php';
 require_once __DIR__ . '/includes/functions-teredo.php';
+// phpcs:disable PSR1.Files.SideEffects -- module include for ipv4_to_isatap_iid()/decode_isatap_iid().
+require_once __DIR__ . '/includes/functions-isatap.php';
+// phpcs:enable PSR1.Files.SideEffects
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -767,9 +767,10 @@ if ($i < 3) {
         elseif (!empty($embedded_v4)) { $open_tool_ipv6 = 'embedded-v4'; }
         elseif (!empty($sixtofour)) { $open_tool_ipv6 = '6to4'; }
         elseif (!empty($teredo)) { $open_tool_ipv6 = 'teredo'; }
+        elseif (!empty($isatap)) { $open_tool_ipv6 = 'isatap'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -790,6 +791,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="embedded-v4" aria-expanded="false">Embedded IPv4</button>
             <button type="button" class="tool-trigger" data-tool="6to4" aria-expanded="false">6to4</button>
             <button type="button" class="tool-trigger" data-tool="teredo" aria-expanded="false">Teredo</button>
+            <button type="button" class="tool-trigger" data-tool="isatap" aria-expanded="false">ISATAP</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -1717,6 +1719,116 @@ if ($i < 3) {
                             <?php endif; ?>
                         </dl>
                         <p><small>Microsoft retired the public Teredo service for consumer Windows in 2019. This tool is provided for analysis of legacy traffic captures and address audits.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="isatap">
+                <div class="overlap-panel">
+                    <div class="overlap-title">ISATAP interface-ID helper<?= help_bubble('ipv6-isatap', 'Build and decode the 64-bit ISATAP interface ID (RFC 5214). Encode mode wraps an IPv4 in `0:5efe:V4` (locally-administered) or `200:5efe:V4` (globally-unique, u-bit set); the universal/local bit is auto-detected from the IPv4 (private/reserved → local; public → global) but you can force either side. Decode mode recognises both forms and pulls the embedded IPv4 back out. Append the resulting IID to any /64 prefix to get a complete IPv6 address.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="isatap_mode">Mode<?= help_bubble('isatap-mode', 'Encode: IPv4 → ISATAP IID. Decode: IID → IPv4 + globally-unique flag.') ?></label>
+                                <select id="isatap_mode" name="isatap_mode">
+                                    <option value="encode"<?= ($isatap_mode ?? 'encode') === 'encode' ? ' selected' : '' ?>>Encode (IPv4 → ISATAP IID)</option>
+                                    <option value="decode"<?= ($isatap_mode ?? 'encode') === 'decode' ? ' selected' : '' ?>>Decode (IID → IPv4)</option>
+                                </select>
+                            </div>
+                        </div>
+                        <?php if (($isatap_mode ?? 'encode') === 'encode') : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="isatap_ipv4">IPv4 address<?= help_bubble('isatap-ipv4', 'Any IPv4 literal. The encoder packs it into the bottom 32 bits of the IID.') ?></label>
+                                    <input type="text" id="isatap_ipv4" name="isatap_ipv4"
+                                           value="<?= htmlspecialchars($isatap_ipv4_input ?? '') ?>"
+                                           placeholder="192.0.2.1"
+                                           autocomplete="off" spellcheck="false"
+                                           <?= !empty($isatap['error']) ? 'aria-invalid="true" aria-describedby="isatap-error"' : '' ?>>
+                                </div>
+                                <div class="form-group">
+                                    <label for="isatap_globally_unique">Universal/local bit<?= help_bubble('isatap-gu', 'Auto: infer from the IPv4 (public → globally-unique, private/reserved → local). True: force globally-unique (200:5efe). False: force local (0:5efe).') ?></label>
+                                    <select id="isatap_globally_unique" name="isatap_globally_unique">
+                                        <option value=""<?= ($isatap_globally_unique ?? '') === '' ? ' selected' : '' ?>>Auto-detect</option>
+                                        <option value="true"<?= ($isatap_globally_unique ?? '') === 'true' ? ' selected' : '' ?>>Force globally-unique (0200:5efe)</option>
+                                        <option value="false"<?= ($isatap_globally_unique ?? '') === 'false' ? ' selected' : '' ?>>Force locally-administered (0000:5efe)</option>
+                                    </select>
+                                </div>
+                            </div>
+                        <?php else : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="isatap_iid">ISATAP IID<?= help_bubble('isatap-iid', 'Four colon-separated hexadectets. Magic must be 0000:5efe (locally-administered) or 0200:5efe (globally-unique). Examples: 0:5efe:c000:201, 200:5efe:c000:201.') ?></label>
+                                    <input type="text" id="isatap_iid" name="isatap_iid"
+                                           value="<?= htmlspecialchars($isatap_iid_input ?? '') ?>"
+                                           placeholder="200:5efe:c000:201"
+                                           autocomplete="off" spellcheck="false"
+                                           <?= !empty($isatap['error']) ? 'aria-invalid="true" aria-describedby="isatap-error"' : '' ?>>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Convert</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($isatap['error'])) : ?>
+                        <div class="error" id="isatap-error"><?= htmlspecialchars((string)$isatap['error']) ?></div>
+                    <?php elseif (!empty($isatap) && empty($isatap['error'])) : ?>
+                        <?php
+                        $_isatap_history = 'isatap: ' . (string)($isatap['iid'] ?? $isatap['ipv4'] ?? $isatap['input'] ?? '');
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="isatap"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_isatap_history) ?>">
+                            <?php if (($isatap['mode'] ?? 'encode') === 'encode') : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($isatap['ipv4'] ?? '')) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">ISATAP IID</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code>::<?= htmlspecialchars((string)($isatap['iid'] ?? '')) ?></code>
+                                        <?= copy_button('::' . (string)($isatap['iid'] ?? ''), 'Copy ISATAP IID') ?>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Universal/local bit</dt>
+                                    <dd class="zoneid-result__value">
+                                        <?= !empty($isatap['globally_unique'])
+                                            ? '<span class="badge">globally-unique</span>'
+                                            : '<span class="badge">locally-administered</span>' ?>
+                                    </dd>
+                                </div>
+                            <?php else : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Input IID</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($isatap['iid'] ?? $isatap['input'] ?? '')) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Embedded IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($isatap['ipv4'] ?? '')) ?></code>
+                                        <?= copy_button((string)($isatap['ipv4'] ?? ''), 'Copy IPv4') ?>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Universal/local bit</dt>
+                                    <dd class="zoneid-result__value">
+                                        <?= !empty($isatap['globally_unique'])
+                                            ? '<span class="badge">globally-unique</span>'
+                                            : '<span class="badge">locally-administered</span>' ?>
+                                    </dd>
+                                </div>
+                            <?php endif; ?>
+                        </dl>
+                        <p><small>ISATAP (RFC 5214) saw limited deployment outside specific enterprise transition scenarios. Provided for analysis of legacy traffic and address audits.</small></p>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/isatap.md
+++ b/docs/isatap.md
@@ -1,0 +1,85 @@
+# ISATAP Interface-ID Helper
+
+Build and decode the 64-bit ISATAP interface ID defined by
+[RFC 5214][rfc5214].
+
+!!! warning "Limited deployment"
+    ISATAP saw limited deployment outside specific enterprise
+    transition scenarios. Native IPv6 connectivity has displaced it
+    across the public internet. This tool is provided for analysis of
+    legacy traffic captures and audits of addresses that still appear
+    in old configuration files and route tables.
+
+## How an ISATAP IID is structured
+
+The 64-bit interface ID packs the embedded IPv4 plus a 2-bit "is
+globally unique?" indicator into four 16-bit hexadectets:
+
+```
+| 32 bits     | 32 bits          |
+| 0000:5efe   | V4ADDR (raw)     |   locally-administered
+| 0200:5efe   | V4ADDR (raw)     |   globally-unique (u-bit set)
+```
+
+- The **`5efe`** magic in the second hexadectet is the IANA-assigned
+  OUI-style value that identifies this IID as ISATAP.
+- The **first hexadectet** carries the universal/local (u) bit per
+  RFC 4291 §2.5.1: `0x0000` for locally-administered (the embedded
+  IPv4 is from a private/reserved range), `0x0200` for
+  globally-unique (the embedded IPv4 is publicly routable).
+- The **bottom 32 bits** are the IPv4 address, stored raw with no
+  obfuscation.
+
+The IID is appended to any /64 prefix to form a complete IPv6 address.
+
+## Encoding (IPv4 → ISATAP IID)
+
+The encoder accepts any IPv4 literal and produces the colon-grouped
+IID with leading zeros stripped per hexadectet (`inet_ntop`-style
+canonical form):
+
+| IPv4          | Mode             | IID                     |
+| ------------- | ---------------- | ----------------------- |
+| `192.0.2.1`   | globally-unique  | `200:5efe:c000:201`     |
+| `192.0.2.1`   | locally-admin    | `0:5efe:c000:201`       |
+| `10.0.0.1`    | auto (private)   | `0:5efe:a00:1`          |
+
+When the universal/local bit is set to **Auto-detect**, the helper
+classifies the IPv4 by `filter_var` private/reserved checks: public
+addresses become globally-unique; private (RFC 1918) and reserved
+(loopback, link-local, etc.) become locally-administered. You can
+override either way explicitly via the **Force** options.
+
+## Decoding (ISATAP IID → IPv4)
+
+The decoder accepts both the canonical compressed form
+(`0:5efe:c000:201`) and the fully zero-padded form
+(`0000:5efe:c000:0201`). It pulls the embedded IPv4 back out and
+reports the universal/local bit as a `globally_unique` boolean.
+
+The decoder rejects any IID whose magic is not `0000:5efe` or
+`0200:5efe`. It does **not** accept full 128-bit IPv6 addresses —
+pass just the bottom-64 IID.
+
+## Shareable URLs
+
+The drawer state is fully captured in the URL:
+
+```
+/ipv6/isatap?isatap_mode=encode&isatap_ipv4=192.0.2.1
+/ipv6/isatap?isatap_mode=decode&isatap_iid=200:5efe:c000:201
+```
+
+## Embedded-v4 detector deep link
+
+The [Embedded IPv4 Detector](embedded-v4.md) recognises ISATAP
+addresses (`*0000:5efe:V4` or `*0200:5efe:V4`) and deep-links into
+this tool with the IID pre-filled.
+
+## REST API
+
+`POST /api/v1/isatap` — see the [API reference](api.md) and
+[OpenAPI spec][openapi] for the full request/response shape.
+
+[rfc5214]: https://datatracker.ietf.org/doc/html/rfc5214
+[openapi]: https://github.com/seanmousseau/Subnet-Calculator/blob/main/Subnet-Calculator/api/openapi.yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Embedded IPv4 Detector: embedded-v4.md
     - 6to4 Address Tool: 6to4.md
     - Teredo Address Decoder: teredo.md
+    - ISATAP Interface-ID Helper: isatap.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -3382,6 +3382,161 @@ async def test_ipv6_teredo_ui(page: Page) -> None:
                 await open_link.count() >= 1)
 
 
+async def test_api_isatap(page: Page) -> None:
+    section("API — POST /api/v1/isatap")
+
+    # Encode mode — public IPv4 → globally-unique IID auto-detect.
+    status, data = _api_post("isatap", {"mode": "encode", "ipv4": "192.0.2.1"})
+    assert_eq("api isatap encode: HTTP 200", status, 200)
+    assert_eq("api isatap encode: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api isatap encode: mode", d.get("mode"), "encode")
+    assert_eq("api isatap encode: iid", d.get("iid"), "200:5efe:c000:201")
+    assert_eq("api isatap encode: globally_unique=true", d.get("globally_unique"), True)
+
+    # Encode mode — private IPv4 → locally-administered.
+    status2, data2 = _api_post("isatap", {"mode": "encode", "ipv4": "10.0.0.1"})
+    assert_eq("api isatap encode (private): HTTP 200", status2, 200)
+    d2 = data2.get("data", {})
+    assert_eq("api isatap encode (private): iid", d2.get("iid"), "0:5efe:a00:1")
+    assert_eq("api isatap encode (private): globally_unique=false",
+              d2.get("globally_unique"), False)
+
+    # Encode with explicit globally_unique=false override.
+    status3, data3 = _api_post("isatap", {
+        "mode": "encode", "ipv4": "192.0.2.1", "globally_unique": False,
+    })
+    assert_eq("api isatap encode (forced local): HTTP 200", status3, 200)
+    assert_eq("api isatap encode (forced local): iid",
+              data3.get("data", {}).get("iid"), "0:5efe:c000:201")
+
+    # Decode mode — round-trip.
+    status4, data4 = _api_post("isatap", {"mode": "decode", "iid": "200:5efe:c000:201"})
+    assert_eq("api isatap decode: HTTP 200", status4, 200)
+    d4 = data4.get("data", {})
+    assert_eq("api isatap decode: ipv4", d4.get("ipv4"), "192.0.2.1")
+    assert_eq("api isatap decode: globally_unique", d4.get("globally_unique"), True)
+
+    # Decode rejects non-ISATAP IID.
+    status5, _ = _api_post("isatap", {"mode": "decode", "iid": "feed:beef:cafe:1"})
+    assert_eq("api isatap decode: non-ISATAP → 400", status5, 400)
+
+    # Decode rejects garbage.
+    status6, _ = _api_post("isatap", {"mode": "decode", "iid": "not-an-iid"})
+    assert_eq("api isatap decode: garbage → 400", status6, 400)
+
+    # Encode rejects bad IPv4.
+    status7, _ = _api_post("isatap", {"mode": "encode", "ipv4": "not-an-ip"})
+    assert_eq("api isatap encode: invalid IPv4 → 400", status7, 400)
+
+    # Missing required fields.
+    status8, _ = _api_post("isatap", {"mode": "encode"})
+    assert_eq("api isatap encode: missing ipv4 → 400", status8, 400)
+    status9, _ = _api_post("isatap", {"mode": "decode"})
+    assert_eq("api isatap decode: missing iid → 400", status9, 400)
+
+    # Invalid mode.
+    status10, _ = _api_post("isatap", {"mode": "bogus", "ipv4": "192.0.2.1"})
+    assert_eq("api isatap: invalid mode → 400", status10, 400)
+
+    # embedded-v4 detector now deep-links ISATAP to /ipv6/isatap (T5 contract).
+    status11, data11 = _api_post("embedded-v4",
+                                 {"input": "2001:db8::200:5efe:c000:201"})
+    assert_eq("api embedded-v4 (isatap): HTTP 200", status11, 200)
+    ev4 = data11.get("data", {})
+    assert_eq("api embedded-v4 (isatap): detail_route is /ipv6/isatap",
+              ev4.get("detail_route"), "/ipv6/isatap")
+    assert_eq("api embedded-v4 (isatap): extra.ipv4 from decoder",
+              ev4.get("extra", {}).get("ipv4"), "192.0.2.1")
+    assert_eq("api embedded-v4 (isatap): extra.globally_unique from decoder",
+              ev4.get("extra", {}).get("globally_unique"), True)
+
+
+async def test_ipv6_isatap_ui(page: Page) -> None:
+    section("IPv6 ISATAP tool UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # /ipv6/isatap should auto-open the drawer (per-tool URL routing).
+    await navigate(page, APP_URL + "?tab=ipv6&tool=isatap")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='isatap']")
+    assert_eq("isatap UI: panel exists", await panel.count(), 1)
+
+    # Encode — IPv4 → IID.
+    await page.select_option("#isatap_mode", "encode")
+    await page.fill("#isatap_ipv4", "192.0.2.1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='isatap'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='isatap']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("isatap UI encode: IID rendered",
+                "200:5efe:c000:201" in body_text, f"body: {body_text!r}")
+    assert_true("isatap UI encode: globally-unique badge",
+                "globally-unique" in body_text, f"body: {body_text!r}")
+
+    # Copy IID.
+    await panel.locator(".subnet-copy").first.click()
+    await page.wait_for_timeout(50)
+    assert_eq("isatap UI encode: copy IID",
+              await page.evaluate("window.__lastClipboard"),
+              "::200:5efe:c000:201")
+
+    # Decode — IID → IPv4.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=isatap")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.select_option("#isatap_mode", "decode")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='isatap'] button.splitter-btn")
+    # After mode change the form re-rendered server-side; need to refill iid.
+    await page.fill("#isatap_iid", "200:5efe:c000:201")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='isatap'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='isatap']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("isatap UI decode: ipv4 rendered",
+                "192.0.2.1" in body_text, f"body: {body_text!r}")
+
+    # Error path — non-ISATAP IID.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=isatap")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.select_option("#isatap_mode", "decode")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='isatap'] button.splitter-btn")
+    await page.fill("#isatap_iid", "feed:beef:cafe:1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='isatap'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='isatap']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("isatap UI: error band on non-ISATAP IID",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+    # Shareable GET URL hydrates without re-submission.
+    await navigate(page,
+                   APP_URL + "?tab=ipv6&tool=isatap&isatap_mode=encode&isatap_ipv4=192.0.2.1")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='isatap']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("isatap UI shareable URL: IID hydrated",
+                "200:5efe:c000:201" in body_text, f"body: {body_text!r}")
+
+    # embedded-v4 detector now deep-links ISATAP to /ipv6/isatap.
+    await navigate(page,
+                   APP_URL + "?tab=ipv6&tool=embedded-v4&embedded_v4_input=2001:db8::200:5efe:c000:201")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    ev4_panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-v4']")
+    open_link = ev4_panel.locator("a.splitter-btn[href='/ipv6/isatap']")
+    assert_true("embedded-v4 → isatap deep-link: anchor present",
+                await open_link.count() >= 1)
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -8276,6 +8431,8 @@ async def main() -> None:
             await test_api_6to4(page)
             await test_ipv6_teredo_ui(page)
             await test_api_teredo(page)
+            await test_ipv6_isatap_ui(page)
+            await test_api_isatap(page)
             await test_a11y_ipv6_drawers(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)

--- a/testing/unit/EmbeddedV4Test.php
+++ b/testing/unit/EmbeddedV4Test.php
@@ -90,10 +90,10 @@ final class EmbeddedV4Test extends TestCase
 
     public function test_detail_routes_per_scheme(): void
     {
-        // Per-scheme drawers land incrementally across v3.5.0. As of T4
-        // (#393) 6to4 and Teredo have shipped; mapped/compatible/nat64-wkp/
-        // isatap detail_routes stay null until T5–T7. This test pins the
-        // contract so each future wiring touch is deliberate.
+        // Per-scheme drawers land incrementally across v3.5.0. As of T5
+        // (#394) 6to4, Teredo, and ISATAP have shipped; mapped/compatible/
+        // nat64-wkp detail_routes stay null until T6–T7. This test pins
+        // the contract so each future wiring touch is deliberate.
         $sixToFour = detect_embedded_v4('2002:c000:0201::');
         $this->assertSame('/ipv6/6to4', $sixToFour['detail_route']);
 
@@ -110,7 +110,9 @@ final class EmbeddedV4Test extends TestCase
         $this->assertNull($nat64Wkp['detail_route']);
 
         $isatap = detect_embedded_v4('2001:db8::200:5efe:c000:201');
-        $this->assertNull($isatap['detail_route']);
+        $this->assertSame('/ipv6/isatap', $isatap['detail_route']);
+        $this->assertSame('192.0.2.1', $isatap['extra']['ipv4']);
+        $this->assertTrue($isatap['extra']['globally_unique']);
     }
 
     public function test_extra_present_for_all_branches(): void

--- a/testing/unit/IsatapTest.php
+++ b/testing/unit/IsatapTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class IsatapTest extends TestCase
+{
+    // ─── ipv4_to_isatap_iid() ──────────────────────────────────────────────────
+
+    public function test_private_ipv4_to_iid(): void
+    {
+        // Explicit globally_unique=false → '0:5efe:V4'.
+        $this->assertSame('0:5efe:c000:201', ipv4_to_isatap_iid('192.0.2.1', false));
+    }
+
+    public function test_global_ipv4_to_iid(): void
+    {
+        // Explicit globally_unique=true → '200:5efe:V4'.
+        $this->assertSame('200:5efe:c000:201', ipv4_to_isatap_iid('192.0.2.1', true));
+    }
+
+    public function test_auto_globally_unique_decision(): void
+    {
+        // 192.0.2.1 is documentation/global → globally_unique=true by default.
+        $this->assertSame('200:5efe:c000:201', ipv4_to_isatap_iid('192.0.2.1'));
+
+        // 10.0.0.1 is private → globally_unique=false.
+        $this->assertSame('0:5efe:a00:1', ipv4_to_isatap_iid('10.0.0.1'));
+    }
+
+    public function test_encode_zero_address(): void
+    {
+        $this->assertSame('0:5efe:0:0', ipv4_to_isatap_iid('0.0.0.0', false));
+    }
+
+    public function test_encode_max_address(): void
+    {
+        $this->assertSame('200:5efe:ffff:ffff', ipv4_to_isatap_iid('255.255.255.255', true));
+    }
+
+    public function test_encode_rejects_invalid_ipv4(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv4_to_isatap_iid('not-an-ip');
+    }
+
+    public function test_encode_rejects_ipv6(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv4_to_isatap_iid('::1');
+    }
+
+    public function test_encode_rejects_empty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ipv4_to_isatap_iid('');
+    }
+
+    // ─── decode_isatap_iid() ───────────────────────────────────────────────────
+
+    public function test_decode_iid_round_trip_global(): void
+    {
+        $r = decode_isatap_iid('200:5efe:c000:201');
+        $this->assertSame('192.0.2.1', $r['ipv4']);
+        $this->assertTrue($r['globally_unique']);
+    }
+
+    public function test_decode_iid_round_trip_private(): void
+    {
+        $r = decode_isatap_iid('0:5efe:a00:1');
+        $this->assertSame('10.0.0.1', $r['ipv4']);
+        $this->assertFalse($r['globally_unique']);
+    }
+
+    public function test_decode_accepts_zero_padded_form(): void
+    {
+        // Also accept the un-compressed form.
+        $r = decode_isatap_iid('0000:5efe:c000:0201');
+        $this->assertSame('192.0.2.1', $r['ipv4']);
+        $this->assertFalse($r['globally_unique']);
+    }
+
+    public function test_decode_rejects_non_isatap(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_isatap_iid('feed:beef:cafe:1');
+    }
+
+    public function test_decode_rejects_garbage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_isatap_iid('not-an-iid');
+    }
+
+    public function test_decode_rejects_empty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_isatap_iid('');
+    }
+
+    public function test_decode_rejects_wrong_magic(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        // Magic must be 0000:5efe or 0200:5efe — not 0100:5efe.
+        decode_isatap_iid('100:5efe:c000:201');
+    }
+
+    public function test_round_trip_preserves_value(): void
+    {
+        $iid = ipv4_to_isatap_iid('203.0.113.42', true);
+        $r = decode_isatap_iid($iid);
+        $this->assertSame('203.0.113.42', $r['ipv4']);
+        $this->assertTrue($r['globally_unique']);
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -22,6 +22,9 @@ require $base . 'functions-mapped6.php';
 require $base . 'functions-embedded-v4.php';
 require $base . 'functions-6to4.php';
 require_once $base . 'functions-teredo.php';
+// phpcs:disable PSR1.Files.SideEffects -- module include for ipv4_to_isatap_iid()/decode_isatap_iid().
+require_once $base . 'functions-isatap.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

Closes Task 5 of the v3.5.0 release plan (#394).

- **New module** `functions-isatap.php` with `ipv4_to_isatap_iid()` and `decode_isatap_iid()`. Auto-detects globally-unique vs locally-administered (`u`-bit) from the IPv4 via `filter_var` private/reserved checks; callers can force either side.
- **POST /api/v1/isatap** endpoint with encode/decode modes, full OpenAPI operation, meta-endpoint list updated, and `Isatap` tag.
- **IPv6 drawer** `data-tool="isatap"` with shareable GET URL hydration via the new `sc_run_isatap()` helper in `request.php` (handles POST + GET via the same code path, mirroring T4's `sc_run_teredo`).
- **Embedded-v4 detector** ISATAP branch delegates to `decode_isatap_iid()` (T4 deduplication pattern) — surfaces `ipv4` and `globally_unique` in `extra`, deep-links to `/ipv6/isatap`. `EmbeddedV4Test::test_detail_routes_per_scheme` updated to pin the new contract.
- **Module includes** wired into `index.php`, `api/v1/index.php`, and `testing/unit/bootstrap.php` with `require_once` + `phpcs:disable PSR1.Files.SideEffects` markers.
- **Tests:** 16 PHPUnit cases in `IsatapTest`, 2 Playwright groups (`test_api_isatap`, `test_ipv6_isatap_ui`).
- **Docs:** `docs/isatap.md` + nav entry + `CHANGELOG.md` entry under `## [3.5.0]` `### Added`.

## Test plan

- [x] PHPUnit: 583 tests, 1323 assertions, 14 skipped (clean).
- [x] PHPStan level 9 (`--memory-limit=512M`): 0 errors.
- [x] PHPCS PSR-12 on `includes/` and `api/`: clean.
- [x] Spectral lint of `openapi.yaml`: clean.
- [x] Semgrep on new files: 0 findings.
- [x] `make test-docker` Playwright suite: 1612/1612 passed.
- [x] `npm run lint`: only pre-existing warnings.