### PR TITLE
feat(v3.5.0): 6rd address tool (RFC 5969) (#395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ as each ships.
   IPv4 (`::0:5efe:V4ADDR` for non-global, `::200:5efe:V4ADDR` for
   global) and decode them back. Auto-detects globally-unique vs
   private from the IPv4 input. (#394)
+- **6rd address tool (RFC 5969).** Service-provider 6to4 variant —
+  configurable SP IPv6 prefix and IPv4 mask length. Bidirectional
+  translation between customer IPv4 and customer-delegated IPv6
+  prefix. (#395)
 
 ## [3.4.1] - 2026-05-08
 

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -73,6 +73,8 @@ tags:
     description: Teredo address decoder (RFC 4380) — bidirectional decoding/encoding of 2001:0::/32 addresses
   - name: Isatap
     description: ISATAP interface-ID helper (RFC 5214) — bidirectional encoding/decoding of the 64-bit ISATAP IID
+  - name: SixRd
+    description: 6rd address tool (RFC 5969) — service-provider-configured IPv4 ↔ delegated IPv6 prefix translation
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -365,6 +367,7 @@ paths:
                     - "POST /api/v1/6to4"
                     - "POST /api/v1/teredo"
                     - "POST /api/v1/isatap"
+                    - "POST /api/v1/6rd"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -2410,6 +2413,163 @@ paths:
                   globally_unique: true
         "400":
           description: Missing required field, unparseable input, or non-ISATAP IID
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /6rd:
+    post:
+      operationId: sixRdConvert
+      tags: [SixRd]
+      summary: Compute customer 6rd-delegated IPv6 prefix or extract customer IPv4 (RFC 5969)
+      description: |
+        Bidirectional translation between a customer IPv4 and the
+        customer-delegated IPv6 prefix produced by a 6rd service
+        provider. 6rd is service-provider-configured; the SP IPv6
+        prefix and IPv4 mask length must be supplied by the caller
+        (out-of-band configuration, typically delivered via DHCPv6
+        OPTION_6RD).
+
+        - **`encode`** — input `sp_ipv6_prefix` (e.g. `2001:db8::/32`),
+          optional `sp_ipv4_mask_len` (0..32, default 0), and `ipv4`.
+          Output is the delegated IPv6 prefix and its length.
+        - **`decode`** — input `sp_ipv6_prefix`, optional
+          `sp_ipv4_mask_len`, and `ipv6` (any address within the SP's
+          6rd domain). Output is the customer IPv4. The masked-off
+          high bits of the v4 are treated as zero — they are SP-side
+          configuration not recoverable from the 6rd address alone.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  required: [mode, sp_ipv6_prefix, ipv4]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [encode]
+                    sp_ipv6_prefix:
+                      type: string
+                      example: "2001:db8::/32"
+                    sp_ipv4_mask_len:
+                      type: integer
+                      minimum: 0
+                      maximum: 32
+                      default: 0
+                    ipv4:
+                      type: string
+                      example: "192.0.2.1"
+                - type: object
+                  required: [mode, sp_ipv6_prefix, ipv6]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [decode]
+                    sp_ipv6_prefix:
+                      type: string
+                      example: "2001:db8::/32"
+                    sp_ipv4_mask_len:
+                      type: integer
+                      minimum: 0
+                      maximum: 32
+                      default: 0
+                    ipv6:
+                      type: string
+                      example: "2001:db8:c000:201::1"
+            examples:
+              encode:
+                summary: Encode customer IPv4 → delegated IPv6 prefix
+                value: { mode: encode, sp_ipv6_prefix: "2001:db8::/32", sp_ipv4_mask_len: 0, ipv4: "192.0.2.1" }
+              decode:
+                summary: Decode 6rd IPv6 address → customer IPv4
+                value: { mode: decode, sp_ipv6_prefix: "2001:db8::/32", sp_ipv4_mask_len: 0, ipv6: "2001:db8:c000:201::1" }
+      responses:
+        "200":
+          description: Conversion result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        oneOf:
+                          - type: object
+                            required: [mode, sp_ipv6_prefix, sp_ipv4_mask_len, ipv4, prefix, prefix_length]
+                            properties:
+                              mode:
+                                type: string
+                                enum: [encode]
+                              sp_ipv6_prefix:
+                                type: string
+                                example: "2001:db8::/32"
+                              sp_ipv4_mask_len:
+                                type: integer
+                                example: 0
+                              ipv4:
+                                type: string
+                                example: "192.0.2.1"
+                              prefix:
+                                type: string
+                                example: "2001:db8:c000:201::/64"
+                              prefix_length:
+                                type: integer
+                                example: 64
+                          - type: object
+                            required: [mode, sp_ipv6_prefix, sp_ipv4_mask_len, ipv6, ipv4]
+                            properties:
+                              mode:
+                                type: string
+                                enum: [decode]
+                              sp_ipv6_prefix:
+                                type: string
+                                example: "2001:db8::/32"
+                              sp_ipv4_mask_len:
+                                type: integer
+                                example: 0
+                              ipv6:
+                                type: string
+                                example: "2001:db8:c000:201::1"
+                              ipv4:
+                                type: string
+                                example: "192.0.2.1"
+              example:
+                ok: true
+                data:
+                  mode: encode
+                  sp_ipv6_prefix: "2001:db8::/32"
+                  sp_ipv4_mask_len: 0
+                  ipv4: "192.0.2.1"
+                  prefix: "2001:db8:c000:201::/64"
+                  prefix_length: 64
+        "400":
+          description: Missing required field, unparseable input, or address outside SP prefix
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/6rd.php
+++ b/Subnet-Calculator/api/v1/handlers/6rd.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body     = api_body();
+$raw_mode = $body['mode'] ?? 'encode';
+if (!is_string($raw_mode)) {
+    json_err('Field "mode" must be a string ("encode" or "decode").', 400);
+}
+$mode = strtolower(trim($raw_mode));
+if ($mode === '') {
+    $mode = 'encode';
+}
+if ($mode !== 'encode' && $mode !== 'decode') {
+    json_err('Field "mode" must be "encode" or "decode".', 400);
+}
+
+// Common SP parameters.
+$raw_sp_prefix = $body['sp_ipv6_prefix'] ?? null;
+if (!is_string($raw_sp_prefix) || trim($raw_sp_prefix) === '') {
+    json_err('Field "sp_ipv6_prefix" (string) is required, e.g. "2001:db8::/32".', 400);
+}
+$sp_ipv4_mask_len = 0;
+if (array_key_exists('sp_ipv4_mask_len', $body)) {
+    $raw_mask = $body['sp_ipv4_mask_len'];
+    if (!is_int($raw_mask)) {
+        json_err('Field "sp_ipv4_mask_len" must be an integer 0..32.', 400);
+    }
+    if ($raw_mask < 0 || $raw_mask > 32) {
+        json_err('Field "sp_ipv4_mask_len" must be 0..32.', 400);
+    }
+    $sp_ipv4_mask_len = $raw_mask;
+}
+
+if ($mode === 'encode') {
+    $raw_v4 = $body['ipv4'] ?? null;
+    if (!is_string($raw_v4) || trim($raw_v4) === '') {
+        json_err('Field "ipv4" (string) is required when mode=encode.', 400);
+    }
+    try {
+        $r = compute_6rd_delegation(trim($raw_sp_prefix), $sp_ipv4_mask_len, trim($raw_v4));
+    } catch (\InvalidArgumentException $e) {
+        json_err($e->getMessage(), 400);
+    }
+    json_ok([
+        'mode'             => 'encode',
+        'sp_ipv6_prefix'   => trim($raw_sp_prefix),
+        'sp_ipv4_mask_len' => $sp_ipv4_mask_len,
+        'ipv4'             => trim($raw_v4),
+        'prefix'           => $r['prefix'],
+        'prefix_length'    => $r['prefix_length'],
+    ]);
+}
+
+// mode === 'decode'
+$raw_addr = $body['ipv6'] ?? null;
+if (!is_string($raw_addr) || trim($raw_addr) === '') {
+    json_err('Field "ipv6" (string) is required when mode=decode.', 400);
+}
+try {
+    $v4 = extract_6rd_ipv4(trim($raw_sp_prefix), $sp_ipv4_mask_len, trim($raw_addr));
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+json_ok([
+    'mode'             => 'decode',
+    'sp_ipv6_prefix'   => trim($raw_sp_prefix),
+    'sp_ipv4_mask_len' => $sp_ipv4_mask_len,
+    'ipv6'             => trim($raw_addr),
+    'ipv4'             => $v4,
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -34,6 +34,9 @@ require_once $base . 'functions-teredo.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for ipv4_to_isatap_iid()/decode_isatap_iid().
 require_once $base . 'functions-isatap.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for compute_6rd_delegation()/extract_6rd_ipv4().
+require_once $base . 'functions-6rd.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -124,6 +127,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/6to4',
             'POST /api/v1/teredo',
             'POST /api/v1/isatap',
+            'POST /api/v1/6rd',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -262,6 +266,9 @@ switch ($route_key) {
         break;
     case 'POST /isatap':
         require __DIR__ . '/handlers/isatap.php';
+        break;
+    case 'POST /6rd':
+        require __DIR__ . '/handlers/6rd.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-6rd.php
+++ b/Subnet-Calculator/includes/functions-6rd.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+// 6rd delegation helper (RFC 5969) — bidirectional translation between a
+// customer IPv4 address and the customer-delegated IPv6 prefix derived
+// from a service-provider 6rd domain.
+//
+// 6rd is a service-provider-configured tunneling scheme. Unlike 6to4
+// (which uses the well-known 2002::/16 prefix and embeds the full v4),
+// 6rd uses the SP's own globally-routed IPv6 prefix and may discard
+// some leading bits of the customer v4 if the SP knows those bits are
+// constant across its v4 footprint. The customer-delegated prefix is:
+//
+//   [ SP IPv6 prefix ][ customer v4 with top mask_len bits stripped ]
+//
+// The new prefix length is sp_prefix_length + (32 - sp_ipv4_mask_len).
+// 6rd cannot be detected from an address alone — the SP parameters are
+// out-of-band configuration. This tool is therefore configurable
+// rather than auto-detecting.
+
+/**
+ * Compute the customer's delegated IPv6 prefix per RFC 5969 §4.
+ *
+ * @param string $sp_ipv6_prefix    e.g. '2001:db8::/32'
+ * @param int    $sp_ipv4_mask_len  bits of the customer IPv4 to discard from the high end
+ *                                  (typically 0 for full v4)
+ * @param string $customer_ipv4
+ *
+ * @return array{prefix: string, prefix_length: int}
+ *
+ * @throws InvalidArgumentException
+ */
+function compute_6rd_delegation(string $sp_ipv6_prefix, int $sp_ipv4_mask_len, string $customer_ipv4): array
+{
+    [$sp_address, $sp_prefix_length] = sixrd_parse_sp_prefix($sp_ipv6_prefix);
+
+    if ($sp_ipv4_mask_len < 0 || $sp_ipv4_mask_len > 32) {
+        throw new InvalidArgumentException(
+            'SP IPv4 mask length must be between 0 and 32: ' . $sp_ipv4_mask_len
+        );
+    }
+
+    $customer_bits  = 32 - $sp_ipv4_mask_len;
+    $delegated_len  = $sp_prefix_length + $customer_bits;
+    if ($delegated_len > 128) {
+        throw new InvalidArgumentException(
+            'SP prefix length plus customer bits exceeds 128: '
+            . $sp_prefix_length . ' + ' . $customer_bits
+        );
+    }
+
+    $v4 = trim($customer_ipv4);
+    if ($v4 === '') {
+        throw new InvalidArgumentException('Customer IPv4 address is required.');
+    }
+    if (filter_var($v4, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+        throw new InvalidArgumentException('Invalid customer IPv4 address: ' . $v4);
+    }
+    $v4Bin = @inet_pton($v4);
+    if ($v4Bin === false || strlen($v4Bin) !== 4) {
+        throw new InvalidArgumentException('Invalid customer IPv4 address: ' . $v4);
+    }
+
+    // Pack everything into a 128-bit GMP integer, big-endian.
+    $sp_int       = gmp_init(bin2hex($sp_address), 16);
+    $v4_int       = gmp_init(bin2hex($v4Bin), 16);
+
+    // Strip the top sp_ipv4_mask_len bits: keep only the bottom $customer_bits.
+    if ($customer_bits === 0) {
+        $customer_int = gmp_init(0);
+    } else {
+        $mask = gmp_sub(gmp_pow(2, $customer_bits), 1);
+        $customer_int = gmp_and($v4_int, $mask);
+    }
+
+    // SP prefix occupies the top $sp_prefix_length bits of the 128-bit address;
+    // the inet_pton bytes already have host bits zeroed only if the input was
+    // canonical, so mask them explicitly to be safe.
+    if ($sp_prefix_length === 0) {
+        $sp_masked = gmp_init(0);
+    } else {
+        $sp_mask  = gmp_sub(gmp_pow(2, 128), gmp_pow(2, 128 - $sp_prefix_length));
+        $sp_masked = gmp_and($sp_int, $sp_mask);
+    }
+
+    // Shift customer bits into position: [sp_prefix_length, sp_prefix_length + customer_bits)
+    $customer_shifted = gmp_mul($customer_int, gmp_pow(2, 128 - $delegated_len));
+
+    $delegated_int = gmp_or($sp_masked, $customer_shifted);
+
+    $hex   = str_pad(gmp_strval($delegated_int, 16), 32, '0', STR_PAD_LEFT);
+    $bytes = hex2bin($hex);
+    if ($bytes === false || strlen($bytes) !== 16) {
+        throw new InvalidArgumentException('Internal error packing delegated prefix.');
+    }
+    $canonical = @inet_ntop($bytes);
+    if ($canonical === false) {
+        throw new InvalidArgumentException('Internal error formatting delegated prefix.');
+    }
+
+    return [
+        'prefix'        => $canonical . '/' . $delegated_len,
+        'prefix_length' => $delegated_len,
+    ];
+}
+
+/**
+ * Reverse: extract the customer IPv4 from a 6rd address given SP parameters.
+ * The masked-off region (top sp_ipv4_mask_len bits of the v4) is treated as
+ * zero — the encoder discards it so the decoder cannot recover it without
+ * additional out-of-band information.
+ *
+ * @throws InvalidArgumentException
+ */
+function extract_6rd_ipv4(string $sp_ipv6_prefix, int $sp_ipv4_mask_len, string $rd_ipv6_address): string
+{
+    [$sp_address, $sp_prefix_length] = sixrd_parse_sp_prefix($sp_ipv6_prefix);
+
+    if ($sp_ipv4_mask_len < 0 || $sp_ipv4_mask_len > 32) {
+        throw new InvalidArgumentException(
+            'SP IPv4 mask length must be between 0 and 32: ' . $sp_ipv4_mask_len
+        );
+    }
+    $customer_bits = 32 - $sp_ipv4_mask_len;
+    $delegated_len = $sp_prefix_length + $customer_bits;
+    if ($delegated_len > 128) {
+        throw new InvalidArgumentException(
+            'SP prefix length plus customer bits exceeds 128.'
+        );
+    }
+
+    $rd = trim($rd_ipv6_address);
+    if ($rd === '') {
+        throw new InvalidArgumentException('6rd IPv6 address is required.');
+    }
+    // Strip optional /prefix on the input — accept full addresses or prefixes.
+    $slash = strpos($rd, '/');
+    if ($slash !== false) {
+        $rd = substr($rd, 0, $slash);
+    }
+    if (filter_var($rd, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
+        throw new InvalidArgumentException('Invalid 6rd IPv6 address: ' . $rd);
+    }
+    $rdBin = @inet_pton($rd);
+    if ($rdBin === false || strlen($rdBin) !== 16) {
+        throw new InvalidArgumentException('Invalid 6rd IPv6 address: ' . $rd);
+    }
+
+    $rd_int = gmp_init(bin2hex($rdBin), 16);
+    $sp_int = gmp_init(bin2hex($sp_address), 16);
+
+    // Verify the address starts with the SP prefix bits.
+    if ($sp_prefix_length > 0) {
+        $sp_mask    = gmp_sub(gmp_pow(2, 128), gmp_pow(2, 128 - $sp_prefix_length));
+        $rd_high    = gmp_and($rd_int, $sp_mask);
+        $sp_masked  = gmp_and($sp_int, $sp_mask);
+        if (gmp_cmp($rd_high, $sp_masked) !== 0) {
+            throw new InvalidArgumentException(
+                '6rd address does not start with the SP IPv6 prefix: ' . $rd
+            );
+        }
+    }
+
+    // Read bits [sp_prefix_length, sp_prefix_length + customer_bits) as the
+    // customer-contributed bits. Right-shift by (128 - delegated_len) and mask
+    // to $customer_bits.
+    $shifted = gmp_div_q($rd_int, gmp_pow(2, 128 - $delegated_len));
+    if ($customer_bits === 0) {
+        $customer_int = gmp_init(0);
+    } else {
+        $mask         = gmp_sub(gmp_pow(2, $customer_bits), 1);
+        $customer_int = gmp_and($shifted, $mask);
+    }
+
+    // The masked-off (high) region is unknown — surface as zero per RFC 5969 §4
+    // (the SP-side reconstruction step requires the SP's known v4 prefix).
+    $v4_int_full = $customer_int; // top sp_ipv4_mask_len bits already zero.
+
+    $v4Hex = str_pad(gmp_strval($v4_int_full, 16), 8, '0', STR_PAD_LEFT);
+    $v4Bin = hex2bin($v4Hex);
+    if ($v4Bin === false || strlen($v4Bin) !== 4) {
+        throw new InvalidArgumentException('Internal error packing customer IPv4.');
+    }
+    $v4 = @inet_ntop($v4Bin);
+    if ($v4 === false) {
+        throw new InvalidArgumentException('Internal error formatting customer IPv4.');
+    }
+    return $v4;
+}
+
+/**
+ * Parse an SP IPv6 prefix string ("2001:db8::/32") into the 16-byte network
+ * address and the prefix length.
+ *
+ * @return array{0: string, 1: int}
+ *
+ * @throws InvalidArgumentException
+ */
+function sixrd_parse_sp_prefix(string $sp_ipv6_prefix): array
+{
+    $raw = trim($sp_ipv6_prefix);
+    if ($raw === '') {
+        throw new InvalidArgumentException('SP IPv6 prefix is required.');
+    }
+    if (strpos($raw, '/') === false) {
+        throw new InvalidArgumentException(
+            'SP IPv6 prefix must include a length (e.g. 2001:db8::/32): ' . $raw
+        );
+    }
+    [$addr, $lenStr] = explode('/', $raw, 2);
+    if ($addr === '' || $lenStr === '' || !ctype_digit($lenStr)) {
+        throw new InvalidArgumentException('Invalid SP IPv6 prefix: ' . $raw);
+    }
+    if (filter_var($addr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
+        throw new InvalidArgumentException('Invalid SP IPv6 address: ' . $addr);
+    }
+    $len = (int) $lenStr;
+    if ($len < 0 || $len > 128) {
+        throw new InvalidArgumentException(
+            'SP IPv6 prefix length must be 0..128: ' . $len
+        );
+    }
+    $bin = @inet_pton($addr);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid SP IPv6 address: ' . $addr);
+    }
+    return [$bin, $len];
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -666,6 +666,113 @@ function sc_run_isatap(
     }
 }
 
+// ─── 6rd helper (shared by POST handler and GET shareable URL) ──────────────
+
+/**
+ * Run the 6rd tool against the supplied input. Mode is either 'encode'
+ * (customer IPv4 + SP params → delegated IPv6 prefix) or 'decode' (6rd
+ * IPv6 address + SP params → customer IPv4). Empty required input
+ * returns []. (v3.5.0 Task 6)
+ *
+ * @return array{
+ *     mode?: 'encode'|'decode',
+ *     sp_ipv6_prefix?: string,
+ *     sp_ipv4_mask_len?: int,
+ *     ipv4?: string,
+ *     ipv6?: string,
+ *     prefix?: string,
+ *     prefix_length?: int,
+ *     error?: string|null
+ * }
+ */
+function sc_run_6rd(
+    string $mode,
+    string $sp_prefix_input,
+    string $mask_len_input,
+    string $ipv4_input,
+    string $ipv6_input
+): array {
+    $mode = strtolower(trim($mode));
+    if ($mode !== 'encode' && $mode !== 'decode') {
+        $mode = 'encode';
+    }
+
+    $sp_prefix = trim($sp_prefix_input);
+    $mask_raw  = trim($mask_len_input);
+    $mask_len  = 0;
+    if ($mask_raw !== '') {
+        if (!ctype_digit($mask_raw)) {
+            return [
+                'mode'             => $mode,
+                'sp_ipv6_prefix'   => $sp_prefix,
+                'sp_ipv4_mask_len' => 0,
+                'error'            => 'SP IPv4 mask length must be an integer 0..32.',
+            ];
+        }
+        $mask_len = (int) $mask_raw;
+        if ($mask_len < 0 || $mask_len > 32) {
+            return [
+                'mode'             => $mode,
+                'sp_ipv6_prefix'   => $sp_prefix,
+                'sp_ipv4_mask_len' => $mask_len,
+                'error'            => 'SP IPv4 mask length must be 0..32.',
+            ];
+        }
+    }
+
+    if ($mode === 'encode') {
+        $v4 = trim($ipv4_input);
+        if ($sp_prefix === '' || $v4 === '') {
+            return [];
+        }
+        try {
+            $r = compute_6rd_delegation($sp_prefix, $mask_len, $v4);
+            return [
+                'mode'             => 'encode',
+                'sp_ipv6_prefix'   => $sp_prefix,
+                'sp_ipv4_mask_len' => $mask_len,
+                'ipv4'             => $v4,
+                'prefix'           => $r['prefix'],
+                'prefix_length'    => $r['prefix_length'],
+                'error'            => null,
+            ];
+        } catch (\InvalidArgumentException $e) {
+            return [
+                'mode'             => 'encode',
+                'sp_ipv6_prefix'   => $sp_prefix,
+                'sp_ipv4_mask_len' => $mask_len,
+                'ipv4'             => $v4,
+                'error'            => $e->getMessage(),
+            ];
+        }
+    }
+
+    // decode mode
+    $addr = trim($ipv6_input);
+    if ($sp_prefix === '' || $addr === '') {
+        return [];
+    }
+    try {
+        $v4 = extract_6rd_ipv4($sp_prefix, $mask_len, $addr);
+        return [
+            'mode'             => 'decode',
+            'sp_ipv6_prefix'   => $sp_prefix,
+            'sp_ipv4_mask_len' => $mask_len,
+            'ipv6'             => $addr,
+            'ipv4'             => $v4,
+            'error'            => null,
+        ];
+    } catch (\InvalidArgumentException $e) {
+        return [
+            'mode'             => 'decode',
+            'sp_ipv6_prefix'   => $sp_prefix,
+            'sp_ipv4_mask_len' => $mask_len,
+            'ipv6'             => $addr,
+            'error'            => $e->getMessage(),
+        ];
+    }
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -837,6 +944,15 @@ $isatap_globally_unique  = '';
 /** @var array{mode?: 'encode'|'decode', input?: string, ipv4?: string, iid?: string, globally_unique?: bool, error?: string|null} */
 $isatap = [];
 
+// v3.5.0 Task 6 — 6rd address tool (RFC 5969)
+$sixrd_mode             = 'encode';
+$sixrd_sp_prefix_input  = '';
+$sixrd_mask_len_input   = '';
+$sixrd_ipv4_input       = '';
+$sixrd_ipv6_input       = '';
+/** @var array{mode?: 'encode'|'decode', sp_ipv6_prefix?: string, sp_ipv4_mask_len?: int, ipv4?: string, ipv6?: string, prefix?: string, prefix_length?: int, error?: string|null} */
+$sixrd = [];
+
 $ula_global_id_input = '';
 /** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
 $ula = [];
@@ -910,6 +1026,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_isatap        = isset($_POST['isatap_mode'])
         || isset($_POST['isatap_ipv4'])
         || isset($_POST['isatap_iid']);
+    $is_sixrd         = isset($_POST['sixrd_mode'])
+        || isset($_POST['sixrd_sp_prefix'])
+        || isset($_POST['sixrd_ipv4'])
+        || isset($_POST['sixrd_ipv6']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -918,7 +1038,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_vlsm6 || $is_supernet || $is_supernet6 || $is_ula || $is_session_save || $is_range
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
         || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6 || $is_embedded_v4
-        || $is_sixtofour || $is_teredo || $is_isatap;
+        || $is_sixtofour || $is_teredo || $is_isatap || $is_sixrd;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -1385,6 +1505,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         );
     }
 
+    if ($is_sixrd && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $sixrd_mode = (string)($_POST['sixrd_mode'] ?? 'encode');
+        if ($sixrd_mode !== 'encode' && $sixrd_mode !== 'decode') {
+            $sixrd_mode = 'encode';
+        }
+        $sixrd_sp_prefix_input = trim((string)($_POST['sixrd_sp_prefix'] ?? ''));
+        $sixrd_mask_len_input  = trim((string)($_POST['sixrd_mask_len']  ?? ''));
+        $sixrd_ipv4_input      = trim((string)($_POST['sixrd_ipv4']      ?? ''));
+        $sixrd_ipv6_input      = trim((string)($_POST['sixrd_ipv6']      ?? ''));
+        $sixrd = sc_run_6rd(
+            $sixrd_mode,
+            $sixrd_sp_prefix_input,
+            $sixrd_mask_len_input,
+            $sixrd_ipv4_input,
+            $sixrd_ipv6_input
+        );
+    }
+
     if ($is_ula && !$form_blocked) {
         $ula_global_id_input = trim((string)($_POST['ula_global_id'] ?? ''));
         $ur = generate_ula_prefix($ula_global_id_input);
@@ -1843,6 +1982,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $isatap_ipv4_input,
             $isatap_iid_input,
             $isatap_globally_unique
+        );
+    }
+
+    // 6rd shareable GET URL (v3.5.0 Task 6)
+    if (
+        $active_tab === 'ipv6'
+        && (isset($_GET['sixrd_ipv4']) || isset($_GET['sixrd_ipv6']) || isset($_GET['sixrd_sp_prefix']))
+    ) {
+        $sixrd_mode = (string)($_GET['sixrd_mode'] ?? 'encode');
+        if ($sixrd_mode !== 'encode' && $sixrd_mode !== 'decode') {
+            $sixrd_mode = 'encode';
+        }
+        $sixrd_sp_prefix_input = trim((string)($_GET['sixrd_sp_prefix'] ?? ''));
+        $sixrd_mask_len_input  = trim((string)($_GET['sixrd_mask_len']  ?? ''));
+        $sixrd_ipv4_input      = trim((string)($_GET['sixrd_ipv4']      ?? ''));
+        $sixrd_ipv6_input      = trim((string)($_GET['sixrd_ipv6']      ?? ''));
+        $sixrd = sc_run_6rd(
+            $sixrd_mode,
+            $sixrd_sp_prefix_input,
+            $sixrd_mask_len_input,
+            $sixrd_ipv4_input,
+            $sixrd_ipv6_input
         );
     }
 

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -26,6 +26,9 @@ require_once __DIR__ . '/includes/functions-teredo.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for ipv4_to_isatap_iid()/decode_isatap_iid().
 require_once __DIR__ . '/includes/functions-isatap.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for compute_6rd_delegation()/extract_6rd_ipv4().
+require_once __DIR__ . '/includes/functions-6rd.php';
+// phpcs:enable PSR1.Files.SideEffects
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -768,9 +768,10 @@ if ($i < 3) {
         elseif (!empty($sixtofour)) { $open_tool_ipv6 = '6to4'; }
         elseif (!empty($teredo)) { $open_tool_ipv6 = 'teredo'; }
         elseif (!empty($isatap)) { $open_tool_ipv6 = 'isatap'; }
+        elseif (!empty($sixrd)) { $open_tool_ipv6 = '6rd'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -792,6 +793,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="6to4" aria-expanded="false">6to4</button>
             <button type="button" class="tool-trigger" data-tool="teredo" aria-expanded="false">Teredo</button>
             <button type="button" class="tool-trigger" data-tool="isatap" aria-expanded="false">ISATAP</button>
+            <button type="button" class="tool-trigger" data-tool="6rd" aria-expanded="false">6rd</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -1829,6 +1831,122 @@ if ($i < 3) {
                             <?php endif; ?>
                         </dl>
                         <p><small>ISATAP (RFC 5214) saw limited deployment outside specific enterprise transition scenarios. Provided for analysis of legacy traffic and address audits.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="6rd">
+                <div class="overlap-panel">
+                    <div class="overlap-title">6rd address tool<?= help_bubble('ipv6-6rd', 'Compute the customer IPv6 prefix delegated by a 6rd service provider per RFC 5969. Encode mode takes the SP IPv6 prefix, the SP IPv4 mask length (bits stripped from the high end of the customer v4), and the customer IPv4, and emits the delegated IPv6 prefix. Decode mode reverses: SP params + a 6rd IPv6 address → the customer IPv4 (the masked-off region is treated as zero since it is SP-side configuration).') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="sixrd_mode">Mode<?= help_bubble('6rd-mode', 'Encode: customer IPv4 → delegated IPv6 prefix. Decode: 6rd IPv6 address → customer IPv4.') ?></label>
+                                <select id="sixrd_mode" name="sixrd_mode">
+                                    <option value="encode"<?= ($sixrd_mode ?? 'encode') === 'encode' ? ' selected' : '' ?>>Encode (IPv4 → delegated prefix)</option>
+                                    <option value="decode"<?= ($sixrd_mode ?? 'encode') === 'decode' ? ' selected' : '' ?>>Decode (6rd address → IPv4)</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="sixrd_sp_prefix">SP IPv6 prefix<?= help_bubble('6rd-sp-prefix', 'The service provider\'s globally-routed 6rd IPv6 prefix in CIDR form, e.g. 2001:db8::/32. Provided by the SP via DHCPv6 OPTION_6RD or out-of-band configuration.') ?></label>
+                                <input type="text" id="sixrd_sp_prefix" name="sixrd_sp_prefix"
+                                       value="<?= htmlspecialchars($sixrd_sp_prefix_input ?? '') ?>"
+                                       placeholder="2001:db8::/32"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($sixrd['error']) ? 'aria-invalid="true" aria-describedby="sixrd-error"' : '' ?>>
+                            </div>
+                            <div class="form-group form-group--mask">
+                                <label for="sixrd_mask_len">SP IPv4 mask length<?= help_bubble('6rd-mask-len', 'How many leading bits of the customer IPv4 the SP discards before embedding (0..32). Typically 0 to embed the full v4. The remaining (32 − mask_len) bits are appended to the SP prefix.') ?></label>
+                                <input type="number" id="sixrd_mask_len" name="sixrd_mask_len"
+                                       value="<?= htmlspecialchars($sixrd_mask_len_input ?? '') ?>"
+                                       min="0" max="32" placeholder="0"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($sixrd['error']) ? 'aria-invalid="true" aria-describedby="sixrd-error"' : '' ?>>
+                            </div>
+                        </div>
+                        <?php if (($sixrd_mode ?? 'encode') === 'encode') : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="sixrd_ipv4">Customer IPv4<?= help_bubble('6rd-ipv4', 'The customer\'s WAN IPv4 address. After stripping the top mask-length bits, the remaining bits are appended to the SP prefix to form the delegated IPv6 prefix.') ?></label>
+                                    <input type="text" id="sixrd_ipv4" name="sixrd_ipv4"
+                                           value="<?= htmlspecialchars($sixrd_ipv4_input ?? '') ?>"
+                                           placeholder="192.0.2.1"
+                                           autocomplete="off" spellcheck="false"
+                                           <?= !empty($sixrd['error']) ? 'aria-invalid="true" aria-describedby="sixrd-error"' : '' ?>>
+                                </div>
+                            </div>
+                        <?php else : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="sixrd_ipv6">6rd IPv6 address<?= help_bubble('6rd-ipv6', 'Any IPv6 address (with or without /prefix) within the SP\'s 6rd domain. The decoder verifies the address starts with the SP prefix and extracts the customer-contributed bits.') ?></label>
+                                    <input type="text" id="sixrd_ipv6" name="sixrd_ipv6"
+                                           value="<?= htmlspecialchars($sixrd_ipv6_input ?? '') ?>"
+                                           placeholder="2001:db8:c000:201::1"
+                                           autocomplete="off" spellcheck="false"
+                                           <?= !empty($sixrd['error']) ? 'aria-invalid="true" aria-describedby="sixrd-error"' : '' ?>>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Convert</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($sixrd['error'])) : ?>
+                        <div class="error" id="sixrd-error"><?= htmlspecialchars((string)$sixrd['error']) ?></div>
+                    <?php elseif (!empty($sixrd) && empty($sixrd['error'])) : ?>
+                        <?php
+                        $_sixrd_history = '6rd: ' . (string)($sixrd['prefix'] ?? $sixrd['ipv4'] ?? '');
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="6rd"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_sixrd_history) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">SP IPv6 prefix</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)($sixrd['sp_ipv6_prefix'] ?? '')) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">SP IPv4 mask length</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)($sixrd['sp_ipv4_mask_len'] ?? 0)) ?></code>
+                                </dd>
+                            </div>
+                            <?php if (($sixrd['mode'] ?? 'encode') === 'encode') : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Customer IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($sixrd['ipv4'] ?? '')) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Delegated IPv6 prefix</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($sixrd['prefix'] ?? '')) ?></code>
+                                        <?= copy_button((string)($sixrd['prefix'] ?? ''), 'Copy delegated prefix') ?>
+                                    </dd>
+                                </div>
+                            <?php else : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">6rd IPv6 address</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($sixrd['ipv6'] ?? '')) ?></code>
+                                    </dd>
+                                </div>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Customer IPv4</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)($sixrd['ipv4'] ?? '')) ?></code>
+                                        <?= copy_button((string)($sixrd['ipv4'] ?? ''), 'Copy IPv4') ?>
+                                    </dd>
+                                </div>
+                            <?php endif; ?>
+                        </dl>
+                        <p><small>6rd (RFC 5969) is a service-provider-configured tunneling scheme; the SP parameters above must come from your provider. The masked-off portion of the customer IPv4 cannot be recovered from the 6rd address alone — it is treated as zero on decode.</small></p>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/6rd.md
+++ b/docs/6rd.md
@@ -1,0 +1,84 @@
+# 6rd Address Tool
+
+Compute the customer-delegated IPv6 prefix produced by a 6rd
+service-provider domain, defined by [RFC 5969][rfc5969]. The tool also
+runs the reverse: given a 6rd IPv6 address and the SP parameters, it
+extracts the customer's IPv4.
+
+!!! note "Service-provider configuration required"
+    Unlike 6to4 (which uses the well-known `2002::/16` prefix and
+    embeds the full IPv4), 6rd uses the SP's own globally-routed IPv6
+    prefix. The **SP IPv6 prefix** and **SP IPv4 mask length** are
+    out-of-band configuration — typically delivered to CPE via DHCPv6
+    OPTION_6RD. The tool cannot guess them from the address alone, so
+    this tool does not auto-detect 6rd from the embedded-v4 detector.
+
+## How a 6rd delegation is constructed
+
+The customer-delegated IPv6 prefix is the concatenation of:
+
+1. The SP IPv6 prefix (`sp_ipv6_prefix`, e.g. `2001:db8::/32`).
+2. All but the first `sp_ipv4_mask_len` bits of the customer IPv4
+   address. The masked-off bits are constant across the SP's footprint
+   and therefore not embedded.
+
+The new prefix length is `sp_prefix_length + (32 - sp_ipv4_mask_len)`.
+
+## Worked examples
+
+### Full v4 (mask length 0)
+
+| Field            | Value                  |
+| ---------------- | ---------------------- |
+| SP IPv6 prefix   | `2001:db8::/32`        |
+| SP IPv4 mask len | `0`                    |
+| Customer IPv4    | `192.0.2.1`            |
+| Delegated prefix | `2001:db8:c000:201::/64` |
+
+The full 32 bits of the customer v4 follow the /32 SP prefix, giving
+a /64 delegation.
+
+### Truncated v4 (mask length 8)
+
+| Field            | Value                |
+| ---------------- | -------------------- |
+| SP IPv6 prefix   | `2001:db8::/32`      |
+| SP IPv4 mask len | `8`                  |
+| Customer IPv4    | `192.0.2.1`          |
+| Delegated prefix | `2001:db8:2:100::/56` |
+
+The top 8 bits of the v4 (`0xC0`) are discarded; the remaining 24 bits
+(`0x000201`) are appended to the /32 SP prefix, yielding a /56 with
+the customer-contributed bits packed at IPv6 bits 32..55.
+
+## Decoding (6rd address → customer IPv4)
+
+The decoder verifies the address starts with the SP prefix bits, then
+reads the customer-contributed bits from the position immediately
+following. The masked-off region (top `sp_ipv4_mask_len` bits of the
+v4) is treated as zero — that portion is SP-side configuration and
+cannot be recovered from the address alone.
+
+## Shareable URLs
+
+The drawer state is fully captured in the URL:
+
+```
+/ipv6/6rd?sixrd_mode=encode&sixrd_sp_prefix=2001:db8::/32&sixrd_mask_len=0&sixrd_ipv4=192.0.2.1
+/ipv6/6rd?sixrd_mode=decode&sixrd_sp_prefix=2001:db8::/32&sixrd_mask_len=0&sixrd_ipv6=2001:db8:c000:201::1
+```
+
+## REST API
+
+`POST /api/v1/6rd` mirrors the UI. See the [REST API](api.md) page or
+the OpenAPI spec at `/api/openapi.yaml` for the full request/response
+schema.
+
+```bash
+curl -X POST https://example.com/api/v1/6rd \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"encode","sp_ipv6_prefix":"2001:db8::/32","sp_ipv4_mask_len":0,"ipv4":"192.0.2.1"}'
+```
+
+[rfc5969]: https://www.rfc-editor.org/rfc/rfc5969

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - 6to4 Address Tool: 6to4.md
     - Teredo Address Decoder: teredo.md
     - ISATAP Interface-ID Helper: isatap.md
+    - 6rd Address Tool: 6rd.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -3537,6 +3537,193 @@ async def test_ipv6_isatap_ui(page: Page) -> None:
                 await open_link.count() >= 1)
 
 
+async def test_api_6rd(page: Page) -> None:
+    section("API — POST /api/v1/6rd")
+
+    # Encode mode — basic case (mask=0).
+    status, data = _api_post("6rd", {
+        "mode": "encode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "sp_ipv4_mask_len": 0,
+        "ipv4": "192.0.2.1",
+    })
+    assert_eq("api 6rd encode: HTTP 200", status, 200)
+    assert_eq("api 6rd encode: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api 6rd encode: mode", d.get("mode"), "encode")
+    assert_eq("api 6rd encode: prefix", d.get("prefix"), "2001:db8:c000:201::/64")
+    assert_eq("api 6rd encode: prefix_length", d.get("prefix_length"), 64)
+
+    # Encode with mask_len=8 (SP discards top 8 bits).
+    status2, data2 = _api_post("6rd", {
+        "mode": "encode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "sp_ipv4_mask_len": 8,
+        "ipv4": "192.0.2.1",
+    })
+    assert_eq("api 6rd encode (mask=8): HTTP 200", status2, 200)
+    d2 = data2.get("data", {})
+    assert_eq("api 6rd encode (mask=8): prefix", d2.get("prefix"), "2001:db8:2:100::/56")
+    assert_eq("api 6rd encode (mask=8): prefix_length", d2.get("prefix_length"), 56)
+
+    # Encode default mask_len = 0 when omitted.
+    status3, data3 = _api_post("6rd", {
+        "mode": "encode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "ipv4": "192.0.2.1",
+    })
+    assert_eq("api 6rd encode (default mask): HTTP 200", status3, 200)
+    assert_eq("api 6rd encode (default mask): prefix",
+              data3.get("data", {}).get("prefix"), "2001:db8:c000:201::/64")
+
+    # Decode mode — round-trip.
+    status4, data4 = _api_post("6rd", {
+        "mode": "decode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "sp_ipv4_mask_len": 0,
+        "ipv6": "2001:db8:c000:201::1",
+    })
+    assert_eq("api 6rd decode: HTTP 200", status4, 200)
+    d4 = data4.get("data", {})
+    assert_eq("api 6rd decode: ipv4", d4.get("ipv4"), "192.0.2.1")
+
+    # Decode rejects address outside SP prefix.
+    status5, _ = _api_post("6rd", {
+        "mode": "decode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "ipv6": "2001:db9:c000:201::1",
+    })
+    assert_eq("api 6rd decode: outside SP prefix → 400", status5, 400)
+
+    # Encode rejects bad IPv4.
+    status6, _ = _api_post("6rd", {
+        "mode": "encode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "ipv4": "not-an-ip",
+    })
+    assert_eq("api 6rd encode: invalid IPv4 → 400", status6, 400)
+
+    # Bad SP prefix.
+    status7, _ = _api_post("6rd", {
+        "mode": "encode",
+        "sp_ipv6_prefix": "not-a-prefix",
+        "ipv4": "192.0.2.1",
+    })
+    assert_eq("api 6rd: invalid SP prefix → 400", status7, 400)
+
+    # Mask out of range.
+    status8, _ = _api_post("6rd", {
+        "mode": "encode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "sp_ipv4_mask_len": 33,
+        "ipv4": "192.0.2.1",
+    })
+    assert_eq("api 6rd: mask out of range → 400", status8, 400)
+
+    # Missing required fields.
+    status9, _ = _api_post("6rd", {"mode": "encode"})
+    assert_eq("api 6rd encode: missing sp_ipv6_prefix → 400", status9, 400)
+    status10, _ = _api_post("6rd", {
+        "mode": "encode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+    })
+    assert_eq("api 6rd encode: missing ipv4 → 400", status10, 400)
+    status11, _ = _api_post("6rd", {
+        "mode": "decode",
+        "sp_ipv6_prefix": "2001:db8::/32",
+    })
+    assert_eq("api 6rd decode: missing ipv6 → 400", status11, 400)
+
+    # Invalid mode.
+    status12, _ = _api_post("6rd", {
+        "mode": "bogus",
+        "sp_ipv6_prefix": "2001:db8::/32",
+        "ipv4": "192.0.2.1",
+    })
+    assert_eq("api 6rd: invalid mode → 400", status12, 400)
+
+
+async def test_ipv6_6rd_ui(page: Page) -> None:
+    section("IPv6 6rd tool UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # /ipv6/6rd should auto-open the drawer (per-tool URL routing).
+    await navigate(page, APP_URL + "?tab=ipv6&tool=6rd")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='6rd']")
+    assert_eq("6rd UI: panel exists", await panel.count(), 1)
+
+    # Encode — IPv4 → delegated prefix.
+    await page.select_option("#sixrd_mode", "encode")
+    await page.fill("#sixrd_sp_prefix", "2001:db8::/32")
+    await page.fill("#sixrd_mask_len", "0")
+    await page.fill("#sixrd_ipv4", "192.0.2.1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='6rd'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='6rd']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("6rd UI encode: prefix rendered",
+                "2001:db8:c000:201::/64" in body_text, f"body: {body_text!r}")
+
+    # Copy delegated prefix.
+    await panel.locator(".subnet-copy").first.click()
+    await page.wait_for_timeout(50)
+    assert_eq("6rd UI encode: copy prefix",
+              await page.evaluate("window.__lastClipboard"),
+              "2001:db8:c000:201::/64")
+
+    # Decode — 6rd address → IPv4.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=6rd")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.select_option("#sixrd_mode", "decode")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='6rd'] button.splitter-btn")
+    # After mode change the form re-rendered server-side; need to refill values.
+    await page.fill("#sixrd_sp_prefix", "2001:db8::/32")
+    await page.fill("#sixrd_mask_len", "0")
+    await page.fill("#sixrd_ipv6", "2001:db8:c000:201::1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='6rd'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='6rd']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("6rd UI decode: ipv4 rendered",
+                "192.0.2.1" in body_text, f"body: {body_text!r}")
+
+    # Error path — address outside SP prefix.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=6rd")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.select_option("#sixrd_mode", "decode")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='6rd'] button.splitter-btn")
+    await page.fill("#sixrd_sp_prefix", "2001:db8::/32")
+    await page.fill("#sixrd_mask_len", "0")
+    await page.fill("#sixrd_ipv6", "2001:db9:c000:201::1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='6rd'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='6rd']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("6rd UI: error band on address outside SP prefix",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+    # Shareable GET URL hydrates without re-submission.
+    await navigate(page,
+                   APP_URL + "?tab=ipv6&tool=6rd&sixrd_mode=encode"
+                   "&sixrd_sp_prefix=2001:db8::/32&sixrd_mask_len=0&sixrd_ipv4=192.0.2.1")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='6rd']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("6rd UI shareable URL: prefix hydrated",
+                "2001:db8:c000:201::/64" in body_text, f"body: {body_text!r}")
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -8433,6 +8620,8 @@ async def main() -> None:
             await test_api_teredo(page)
             await test_ipv6_isatap_ui(page)
             await test_api_isatap(page)
+            await test_ipv6_6rd_ui(page)
+            await test_api_6rd(page)
             await test_a11y_ipv6_drawers(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)

--- a/testing/unit/SixRdTest.php
+++ b/testing/unit/SixRdTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SixRdTest extends TestCase
+{
+    // ─── compute_6rd_delegation() ─────────────────────────────────────────────
+
+    public function test_6rd_basic(): void
+    {
+        // SP prefix 2001:db8::/32, mask 0, customer 192.0.2.1 → 2001:db8:c000:201::/64
+        $r = compute_6rd_delegation('2001:db8::/32', 0, '192.0.2.1');
+        $this->assertSame('2001:db8:c000:201::/64', $r['prefix']);
+        $this->assertSame(64, $r['prefix_length']);
+    }
+
+    public function test_6rd_with_mask(): void
+    {
+        // Discard top 8 bits of customer v4 (e.g. SP only assigns within 192.0.0.0/8).
+        // SP=32 bits + (32-8)=24 customer bits = /56. Customer remaining 24 bits: 0x000201
+        // packed at IPv6 bits [32, 56). 0x000201 << (128-56) → hex chars 8..13 = "000201".
+        // Combined: 2001:0db8:0002:0100:: → canonical "2001:db8:2:100::/56".
+        $r = compute_6rd_delegation('2001:db8::/32', 8, '192.0.2.1');
+        $this->assertSame('2001:db8:2:100::/56', $r['prefix']);
+        $this->assertSame(56, $r['prefix_length']);
+    }
+
+    public function test_6rd_extract(): void
+    {
+        $v4 = extract_6rd_ipv4('2001:db8::/32', 0, '2001:db8:c000:201::1');
+        $this->assertSame('192.0.2.1', $v4);
+    }
+
+    public function test_6rd_extract_with_mask(): void
+    {
+        // With mask 8, the masked-off region is treated as zero. Round-trip
+        // from compute_6rd_delegation('2001:db8::/32', 8, '192.0.2.1') →
+        // 2001:db8:2:100::/56 → customer bits 0x000201 → v4 0.0.2.1.
+        $v4 = extract_6rd_ipv4('2001:db8::/32', 8, '2001:db8:2:100::');
+        $this->assertSame('0.0.2.1', $v4);
+    }
+
+    public function test_6rd_round_trip(): void
+    {
+        $r = compute_6rd_delegation('2001:db8::/32', 0, '203.0.113.42');
+        $v4 = extract_6rd_ipv4('2001:db8::/32', 0, $r['prefix']);
+        $this->assertSame('203.0.113.42', $v4);
+    }
+
+    public function test_invalid_ipv4_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        compute_6rd_delegation('2001:db8::/32', 0, 'not-an-ip');
+    }
+
+    public function test_invalid_sp_prefix_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        compute_6rd_delegation('not-a-prefix', 0, '192.0.2.1');
+    }
+
+    public function test_invalid_mask_len_negative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        compute_6rd_delegation('2001:db8::/32', -1, '192.0.2.1');
+    }
+
+    public function test_invalid_mask_len_too_large(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        compute_6rd_delegation('2001:db8::/32', 33, '192.0.2.1');
+    }
+
+    public function test_invalid_sp_prefix_length_too_large(): void
+    {
+        // SP /128 + 32 customer bits would overflow 128.
+        $this->expectException(InvalidArgumentException::class);
+        compute_6rd_delegation('2001:db8::/128', 0, '192.0.2.1');
+    }
+
+    public function test_extract_rejects_address_outside_sp_prefix(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        extract_6rd_ipv4('2001:db8::/32', 0, '2001:db9:c000:201::1');
+    }
+
+    public function test_extract_rejects_invalid_sp_prefix(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        extract_6rd_ipv4('not-a-prefix', 0, '2001:db8:c000:201::1');
+    }
+
+    public function test_extract_rejects_invalid_ipv6(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        extract_6rd_ipv4('2001:db8::/32', 0, 'not-an-address');
+    }
+
+    public function test_extract_rejects_bad_mask_len(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        extract_6rd_ipv4('2001:db8::/32', 33, '2001:db8:c000:201::1');
+    }
+
+    public function test_compute_rejects_empty_inputs(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        compute_6rd_delegation('', 0, '192.0.2.1');
+    }
+
+    public function test_extract_rejects_empty_inputs(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        extract_6rd_ipv4('2001:db8::/32', 0, '');
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -25,6 +25,9 @@ require_once $base . 'functions-teredo.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for ipv4_to_isatap_iid()/decode_isatap_iid().
 require_once $base . 'functions-isatap.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for compute_6rd_delegation()/extract_6rd_ipv4().
+require_once $base . 'functions-6rd.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

- Adds the 6rd address tool (Task 6 of v3.5.0) — service-provider 6to4 variant per RFC 5969.
- Bidirectional translation between customer IPv4 and customer-delegated IPv6 prefix, with configurable SP IPv6 prefix and SP IPv4 mask length.
- `POST /api/v1/6rd` REST endpoint, IPv6 drawer (`data-tool="6rd"`), shareable GET URL, OpenAPI schema, MkDocs page.
- 16 PHPUnit cases (`SixRdTest`) and 2 Playwright groups (`test_api_6rd`, `test_ipv6_6rd_ui`).

Implements #395.

## Notes on scope

6rd cannot be auto-detected from an address alone — the SP IPv6 prefix and IPv4 mask length are out-of-band configuration (typically delivered via DHCPv6 OPTION_6RD). Per the task spec, `functions-embedded-v4.php` and `EmbeddedV4Test.php` are intentionally untouched (no per-scheme branch / `detail_route` change for 6rd).

## QA gates

- [x] `php -l` clean on all touched files
- [x] PHPUnit: 599 tests, 1341 assertions (16 new in `SixRdTest`)
- [x] PHPStan level 9: 0 errors
- [x] PHPCS PSR-12 + admin ruleset: clean
- [x] Spectral OpenAPI: 0 errors
- [x] Semgrep on new files: 0 findings
- [x] `make test-docker`: 1668/1668 Playwright assertions pass

## Test plan

- [x] PHPUnit `SixRdTest` covers basic encode, mask=8 encode, decode round-trip, error paths (bad v4, bad SP prefix, mask out of range, address outside SP prefix, empty inputs)
- [x] Playwright `test_api_6rd` covers POST encode/decode/error paths and default mask
- [x] Playwright `test_ipv6_6rd_ui` covers drawer auto-open, encode/decode, error band, copy-button, shareable URL hydration