### PR TITLE
feat(v3.5.0): IPv6 prefix-delegation planner (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ as each ships.
   (`/32`, `/40`, `/48`, `/56`, `/64`, `/96`), custom NAT64 prefix
   support, and DNS64 AAAA synthesis from A records. Existing `mapped6`
   behaviour unchanged. (#391)
+- **IPv6 prefix-delegation planner.** Slice a delegated prefix (e.g. /48)
+  into nibble-aligned child prefixes (e.g. /56) with a usage table and
+  free-space report. GMP throughout — counts that overflow signed 64
+  print as `"2^N"`. (#387)
 
 ## [3.4.1] - 2026-05-08
 

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -2775,6 +2775,11 @@ paths:
                 count:
                   type: integer
                   minimum: 1
+                  maximum: 256
+                  description: |
+                    Number of child prefixes to allocate. The default cap is 256;
+                    operators can raise it via the `$prefix_plan6_max_count`
+                    config token, up to a hard ceiling of 4096.
                   example: 4
                 start_offset:
                   type: integer

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -77,6 +77,8 @@ tags:
     description: 6rd address tool (RFC 5969) — service-provider-configured IPv4 ↔ delegated IPv6 prefix translation
   - name: Nat64
     description: NAT64 / DNS64 helper (RFC 6052 / 6147) — prefix-length-aware IPv4 ↔ NAT64 IPv6 translation and DNS64 AAAA synthesis
+  - name: PrefixPlan6
+    description: IPv6 prefix-delegation planner — slice a parent prefix into nibble-aligned child prefixes (operator math, not detection)
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -2704,6 +2706,141 @@ paths:
                           ipv6: { type: string, example: "64:ff9b::c000:221" }
         "400":
           description: Missing required field, unparseable input, or RFC 6052 §3.1 violation
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /prefix-plan6:
+    post:
+      operationId: prefixPlan6
+      tags: [PrefixPlan6]
+      summary: Slice a parent IPv6 prefix into child prefixes (operator math)
+      description: |
+        Plan an IPv6 prefix delegation. Given a parent prefix
+        (e.g. `2001:db8::/48`), a desired child prefix length
+        (e.g. `56`), and a count, returns the first `count` child
+        prefixes (optionally skipping the first `start_offset` blocks)
+        plus a free-space report.
+
+        Counts at delegation differences ≥ 64 overflow signed 64-bit
+        ints, so totals and free-remaining values are returned as
+        strings. Clean powers of two with exponent ≥ 63 are returned
+        in the `"2^N"` overflow form (consistent with
+        `/api/v1/vlsm6` and `/api/v1/range6`).
+
+        Each child carries a `contains_64s` field that surfaces the
+        block's relationship to the standard /64 LAN sizing:
+        a decimal count when the child is larger than a /64,
+        `"1"` for /64 itself, and `"subset of /64"` for anything
+        smaller.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [parent_prefix, child_length, count]
+              properties:
+                parent_prefix:
+                  type: string
+                  example: "2001:db8::/48"
+                child_length:
+                  type: integer
+                  minimum: 1
+                  maximum: 128
+                  example: 56
+                count:
+                  type: integer
+                  minimum: 1
+                  example: 4
+                start_offset:
+                  type: integer
+                  minimum: 0
+                  default: 0
+                nibble_align:
+                  type: boolean
+                  default: true
+            examples:
+              slice48Into56s:
+                summary: Slice a /48 into the first four /56s
+                value: { parent_prefix: "2001:db8::/48", child_length: 56, count: 4 }
+              huge:
+                summary: Plan a /32 → /128 (overflow path)
+                value: { parent_prefix: "2001:db8::/32", child_length: 128, count: 1, nibble_align: false }
+      responses:
+        "200":
+          description: Prefix plan
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [parent, children, free, normalized_child_length]
+                        properties:
+                          parent:
+                            type: object
+                            required: [prefix, length, total_children_str]
+                            properties:
+                              prefix: { type: string, example: "2001:db8::/48" }
+                              length: { type: integer, example: 48 }
+                              total_children_str:
+                                type: string
+                                description: Decimal string, or "2^N" overflow form when N ≥ 63.
+                                example: "256"
+                          children:
+                            type: array
+                            items:
+                              type: object
+                              required: [index, prefix, first, last, contains_64s]
+                              properties:
+                                index: { type: integer, example: 0 }
+                                prefix: { type: string, example: "2001:db8::/56" }
+                                first:  { type: string, example: "2001:db8::" }
+                                last:   { type: string, example: "2001:db8:0:ff:ffff:ffff:ffff:ffff" }
+                                contains_64s:
+                                  type: string
+                                  description: Decimal count, "1", or "subset of /64".
+                                  example: "256"
+                          free:
+                            type: object
+                            required: [remaining_str]
+                            properties:
+                              remaining_str:
+                                type: string
+                                example: "252"
+                          normalized_child_length:
+                            type: integer
+                            description: Snapped-up child length when nibble_align=true; else identical to request.
+                            example: 56
+        "400":
+          description: Missing required field, unparseable input, or out-of-range request
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/prefix-plan6.php
+++ b/Subnet-Calculator/api/v1/handlers/prefix-plan6.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body = api_body();
+
+$raw_parent = $body['parent_prefix'] ?? null;
+if (!is_string($raw_parent) || trim($raw_parent) === '') {
+    json_err('Field "parent_prefix" (string) is required, e.g. "2001:db8::/48".', 400);
+}
+
+$raw_child_len = $body['child_length'] ?? null;
+if (!is_int($raw_child_len)) {
+    json_err('Field "child_length" (integer 1..128) is required.', 400);
+}
+
+$raw_count = $body['count'] ?? null;
+if (!is_int($raw_count)) {
+    json_err('Field "count" (positive integer) is required.', 400);
+}
+
+$start_offset = 0;
+if (array_key_exists('start_offset', $body)) {
+    $raw_offset = $body['start_offset'];
+    if (!is_int($raw_offset)) {
+        json_err('Field "start_offset" must be a non-negative integer.', 400);
+    }
+    if ($raw_offset < 0) {
+        json_err('Field "start_offset" must be ≥ 0.', 400);
+    }
+    $start_offset = $raw_offset;
+}
+
+$nibble_align = true;
+if (array_key_exists('nibble_align', $body)) {
+    $raw_align = $body['nibble_align'];
+    if (!is_bool($raw_align)) {
+        json_err('Field "nibble_align" must be a boolean.', 400);
+    }
+    $nibble_align = $raw_align;
+}
+
+try {
+    $r = plan_prefix_delegation(
+        trim($raw_parent),
+        $raw_child_len,
+        $raw_count,
+        $start_offset,
+        $nibble_align
+    );
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'parent'                  => $r['parent'],
+    'children'                => $r['children'],
+    'free'                    => $r['free'],
+    'normalized_child_length' => $r['normalized_child_length'],
+]);

--- a/Subnet-Calculator/api/v1/handlers/prefix-plan6.php
+++ b/Subnet-Calculator/api/v1/handlers/prefix-plan6.php
@@ -14,13 +14,17 @@ if (!is_string($raw_parent) || trim($raw_parent) === '') {
 }
 
 $raw_child_len = $body['child_length'] ?? null;
-if (!is_int($raw_child_len)) {
+if (!is_int($raw_child_len) || $raw_child_len < 1 || $raw_child_len > 128) {
     json_err('Field "child_length" (integer 1..128) is required.', 400);
 }
 
+$prefix_plan6_max = $GLOBALS['prefix_plan6_max_count'] ?? 256;
 $raw_count = $body['count'] ?? null;
-if (!is_int($raw_count)) {
-    json_err('Field "count" (positive integer) is required.', 400);
+if (!is_int($raw_count) || $raw_count < 1 || $raw_count > $prefix_plan6_max) {
+    json_err(
+        sprintf('Field "count" (integer 1..%d) is required.', $prefix_plan6_max),
+        400
+    );
 }
 
 $start_offset = 0;

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -40,6 +40,9 @@ require_once $base . 'functions-6rd.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for nat64_embed()/nat64_extract()/dns64_synthesize().
 require_once $base . 'functions-nat64.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for plan_prefix_delegation().
+require_once $base . 'functions-prefix-plan6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -132,6 +135,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/isatap',
             'POST /api/v1/6rd',
             'POST /api/v1/nat64',
+            'POST /api/v1/prefix-plan6',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -276,6 +280,9 @@ switch ($route_key) {
         break;
     case 'POST /nat64':
         require __DIR__ . '/handlers/nat64.php';
+        break;
+    case 'POST /prefix-plan6':
+        require __DIR__ . '/handlers/prefix-plan6.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/config.php
+++ b/Subnet-Calculator/includes/config.php
@@ -14,6 +14,10 @@ $split_max_subnets    = 16;
 $lookup_max_cidrs     = 100;  // Inverse subnet lookup: max CIDRs per request
 $lookup_max_ips       = 1000; // Inverse subnet lookup: max IPs per request
 $range_max_cidrs      = 256;  // IP range → CIDR converter: max CIDRs returned (v3.3.0)
+// Maximum number of children that prefix-plan6 will allocate in one request.
+// Defaults to 256; clamped to a hard ceiling of 4096 regardless of operator
+// override. Mirrors $split_max_subnets pattern. (v3.5.0)
+$prefix_plan6_max_count = 256;
 $form_protection      = 'none';
 $turnstile_site_key   = '';
 $turnstile_secret_key = '';
@@ -111,6 +115,7 @@ $split_max_subnets = max(1, min((int)$split_max_subnets, 256));
 $lookup_max_cidrs  = max(1, min((int)$lookup_max_cidrs, 1000));
 $lookup_max_ips    = max(1, min((int)$lookup_max_ips, 10000));
 $range_max_cidrs   = max(1, min((int)$range_max_cidrs, 100000));
+$prefix_plan6_max_count = min(max((int)$prefix_plan6_max_count, 1), 4096);
 $fa = trim(preg_replace('/[\r\n]/', '', (string)$frame_ancestors));
 if (!preg_match('/^(\*|\'none\'|\'self\'|(\s*(https?:\/\/[^\s;,]+))+)$/', $fa)) {
     error_log('sc: invalid $frame_ancestors value — reset to *');

--- a/Subnet-Calculator/includes/functions-prefix-plan6.php
+++ b/Subnet-Calculator/includes/functions-prefix-plan6.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 //
 // "contains_64s" surfaces the relationship between each child block
 // and the standard /64 LAN sizing:
-//   • child_length <= 64 → "<count>" of /64s contained (decimal or "2^N").
+//   • child_length < 64  → "2^(64-child_length)" or decimal — count of /64s contained.
 //   • child_length == 64 → "1" (the block is itself a /64).
 //   • child_length > 64  → "subset of /64" (the block is smaller than a /64).
 
@@ -75,6 +75,12 @@ function plan_prefix_delegation(
 
     if ($count < 1) {
         throw new InvalidArgumentException('Count must be at least 1: ' . $count);
+    }
+    $max_count = $GLOBALS['prefix_plan6_max_count'] ?? 256;
+    if ($count > $max_count) {
+        throw new InvalidArgumentException(
+            sprintf('count must not exceed %d: %d', $max_count, $count)
+        );
     }
     if ($start_offset < 0) {
         throw new InvalidArgumentException('Start offset must be ≥ 0: ' . $start_offset);
@@ -216,7 +222,10 @@ function prefix_plan6_format_count(\GMP $count): string
 
 /**
  * Translate a child prefix length into a description of how it relates to
- * the standard /64 LAN sizing.
+ * the standard /64 LAN sizing. Three branches:
+ *   • child_length < 64  → "2^(64-child_length)" or decimal — number of /64s contained.
+ *   • child_length == 64 → "1" — the block is itself a /64.
+ *   • child_length > 64  → "subset of /64" — the block is smaller than a /64.
  */
 function prefix_plan6_contains_64s(int $child_length): string
 {

--- a/Subnet-Calculator/includes/functions-prefix-plan6.php
+++ b/Subnet-Calculator/includes/functions-prefix-plan6.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+// IPv6 prefix-delegation planner — slice a parent IPv6 prefix into
+// child prefixes (e.g. a /48 into /56s). Pure operator math, no detection.
+//
+// Counts at delegation differences ≥ 64 overflow signed 64-bit ints,
+// so the implementation uses GMP throughout and returns the overflow
+// form as the string `"2^N"` (consistent with calculate_subnet6() and
+// vlsm6_allocate()). Smaller counts are returned as decimal strings.
+//
+// "contains_64s" surfaces the relationship between each child block
+// and the standard /64 LAN sizing:
+//   • child_length <= 64 → "<count>" of /64s contained (decimal or "2^N").
+//   • child_length == 64 → "1" (the block is itself a /64).
+//   • child_length > 64  → "subset of /64" (the block is smaller than a /64).
+
+/**
+ * Slice a parent IPv6 prefix into child prefixes.
+ *
+ * @param string $parent_prefix    e.g. '2001:db8::/48'
+ * @param int    $child_length     e.g. 56 (must be > parent's prefix length, ≤ 128)
+ * @param int    $count            number of child prefixes to allocate (≥1)
+ * @param int    $start_offset     skip the first N child prefixes (≥0)
+ * @param bool   $nibble_align     snap child_length up to next nibble boundary
+ *
+ * @return array{
+ *   parent: array{prefix: string, length: int, total_children_str: string},
+ *   children: list<array{index: int, prefix: string, first: string, last: string, contains_64s: string}>,
+ *   free: array{remaining_str: string},
+ *   normalized_child_length: int,
+ * }
+ *
+ * @throws InvalidArgumentException
+ */
+function plan_prefix_delegation(
+    string $parent_prefix,
+    int $child_length,
+    int $count,
+    int $start_offset = 0,
+    bool $nibble_align = true
+): array {
+    [$parent_bin, $parent_length] = prefix_plan6_parse_parent($parent_prefix);
+
+    if ($child_length < 0 || $child_length > 128) {
+        throw new InvalidArgumentException(
+            'Child prefix length must be 0..128: ' . $child_length
+        );
+    }
+    if ($child_length <= $parent_length) {
+        throw new InvalidArgumentException(
+            'Child prefix length must be greater than parent prefix length ('
+            . $parent_length . '): ' . $child_length
+        );
+    }
+
+    // Snap up to the next nibble (multiple of 4) when requested.
+    $normalized_child_length = $child_length;
+    if ($nibble_align && ($normalized_child_length % 4) !== 0) {
+        $normalized_child_length += 4 - ($normalized_child_length % 4);
+        if ($normalized_child_length > 128) {
+            throw new InvalidArgumentException(
+                'Nibble-aligned child prefix length exceeds 128: ' . $normalized_child_length
+            );
+        }
+    }
+    if ($normalized_child_length <= $parent_length) {
+        // Possible only if $parent_length is itself non-nibble; guard anyway.
+        throw new InvalidArgumentException(
+            'Normalised child prefix length must be greater than parent prefix length ('
+            . $parent_length . '): ' . $normalized_child_length
+        );
+    }
+
+    if ($count < 1) {
+        throw new InvalidArgumentException('Count must be at least 1: ' . $count);
+    }
+    if ($start_offset < 0) {
+        throw new InvalidArgumentException('Start offset must be ≥ 0: ' . $start_offset);
+    }
+
+    $diff = $normalized_child_length - $parent_length;            // 1..128
+    $host_bits = 128 - $normalized_child_length;                  // 0..127
+    $total_children = gmp_pow(2, $diff);                          // GMP, possibly huge
+    $block_size     = gmp_pow(2, $host_bits);                     // GMP
+
+    // Validate offset + count ≤ total_children using GMP comparison.
+    $consumed = gmp_add(gmp_init((string) $start_offset, 10), gmp_init((string) $count, 10));
+    if (gmp_cmp($consumed, $total_children) > 0) {
+        throw new InvalidArgumentException(
+            'start_offset + count (' . gmp_strval($consumed) . ') exceeds total children ('
+            . prefix_plan6_format_count($total_children) . ').'
+        );
+    }
+
+    // Mask parent host bits to canonicalise.
+    $parent_int_raw = gmp_init(bin2hex($parent_bin), 16);
+    if ($parent_length === 0) {
+        $parent_int = gmp_init(0);
+    } else {
+        $parent_mask = gmp_sub(gmp_pow(2, 128), gmp_pow(2, 128 - $parent_length));
+        $parent_int  = gmp_and($parent_int_raw, $parent_mask);
+    }
+    $parent_canonical = prefix_plan6_format_address($parent_int);
+
+    // Walk children.
+    $children = [];
+    for ($i = 0; $i < $count; $i++) {
+        $idx_gmp     = gmp_add(gmp_init((string) $start_offset, 10), gmp_init((string) $i, 10));
+        $offset_int  = gmp_mul($idx_gmp, $block_size);
+        $child_first = gmp_add($parent_int, $offset_int);
+        $child_last  = gmp_sub(gmp_add($child_first, $block_size), 1);
+
+        $children[] = [
+            'index'        => (int) gmp_strval($idx_gmp),
+            'prefix'       => prefix_plan6_format_address($child_first) . '/' . $normalized_child_length,
+            'first'        => prefix_plan6_format_address($child_first),
+            'last'         => prefix_plan6_format_address($child_last),
+            'contains_64s' => prefix_plan6_contains_64s($normalized_child_length),
+        ];
+    }
+
+    // Free remaining = total_children - (start_offset + count).
+    $remaining = gmp_sub($total_children, $consumed);
+
+    return [
+        'parent' => [
+            'prefix'             => $parent_canonical . '/' . $parent_length,
+            'length'             => $parent_length,
+            'total_children_str' => prefix_plan6_format_count($total_children),
+        ],
+        'children'                => $children,
+        'free'                    => [
+            'remaining_str' => prefix_plan6_format_count($remaining),
+        ],
+        'normalized_child_length' => $normalized_child_length,
+    ];
+}
+
+/**
+ * Parse a parent prefix string ("2001:db8::/48") into the 16-byte network
+ * address and prefix length.
+ *
+ * @return array{0: string, 1: int}
+ *
+ * @throws InvalidArgumentException
+ */
+function prefix_plan6_parse_parent(string $parent_prefix): array
+{
+    $raw = trim($parent_prefix);
+    if ($raw === '') {
+        throw new InvalidArgumentException('Parent IPv6 prefix is required.');
+    }
+    if (strpos($raw, '/') === false) {
+        throw new InvalidArgumentException(
+            'Parent IPv6 prefix must include a length (e.g. 2001:db8::/48): ' . $raw
+        );
+    }
+    [$addr, $lenStr] = explode('/', $raw, 2);
+    if ($addr === '' || $lenStr === '' || !ctype_digit($lenStr)) {
+        throw new InvalidArgumentException('Invalid parent IPv6 prefix: ' . $raw);
+    }
+    if (filter_var($addr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
+        throw new InvalidArgumentException('Invalid parent IPv6 address: ' . $addr);
+    }
+    $len = (int) $lenStr;
+    if ($len < 0 || $len > 128) {
+        throw new InvalidArgumentException(
+            'Parent IPv6 prefix length must be 0..128: ' . $len
+        );
+    }
+    $bin = @inet_pton($addr);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid parent IPv6 address: ' . $addr);
+    }
+    return [$bin, $len];
+}
+
+/**
+ * Format a 128-bit GMP integer as a canonical IPv6 address.
+ */
+function prefix_plan6_format_address(\GMP $int): string
+{
+    $hex   = str_pad(gmp_strval($int, 16), 32, '0', STR_PAD_LEFT);
+    $bytes = hex2bin($hex);
+    if ($bytes === false || strlen($bytes) !== 16) {
+        throw new InvalidArgumentException('Internal error packing IPv6 address.');
+    }
+    $canonical = @inet_ntop($bytes);
+    if ($canonical === false) {
+        throw new InvalidArgumentException('Internal error formatting IPv6 address.');
+    }
+    return $canonical;
+}
+
+/**
+ * Render a GMP count as either a decimal string (when it fits comfortably)
+ * or the "2^N" overflow form for clean powers of two when N ≥ 63.
+ */
+function prefix_plan6_format_count(\GMP $count): string
+{
+    // If count is a clean power of two and the exponent is ≥ 63, surface as "2^N".
+    if (gmp_cmp($count, 0) > 0) {
+        $maybe_log = gmp_strval($count, 2);
+        // Power of two ⇔ binary form is "1" followed by zeros.
+        if ($maybe_log[0] === '1' && rtrim($maybe_log, '0') === '1') {
+            $exp = strlen($maybe_log) - 1;
+            if ($exp >= 63) {
+                return '2^' . $exp;
+            }
+        }
+    }
+    return gmp_strval($count, 10);
+}
+
+/**
+ * Translate a child prefix length into a description of how it relates to
+ * the standard /64 LAN sizing.
+ */
+function prefix_plan6_contains_64s(int $child_length): string
+{
+    if ($child_length === 64) {
+        return '1';
+    }
+    if ($child_length > 64) {
+        return 'subset of /64';
+    }
+    // child_length < 64 → contains 2^(64 - child_length) /64s.
+    $count = gmp_pow(2, 64 - $child_length);
+    return prefix_plan6_format_count($count);
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -867,6 +867,79 @@ function sc_run_6rd(
     }
 }
 
+// ─── Prefix-delegation planner helper (v3.5.0 Task 8) ──────────────────────
+
+/**
+ * Plan an IPv6 prefix-delegation slice. Empty/blank inputs early-return [].
+ * Shared by the POST handler and the GET shareable-URL hydration path.
+ *
+ * @return array{
+ *     parent_prefix?: string,
+ *     child_length_input?: string,
+ *     count_input?: string,
+ *     start_offset_input?: string,
+ *     nibble_align?: bool,
+ *     result?: array{
+ *         parent: array{prefix: string, length: int, total_children_str: string},
+ *         children: list<array{index: int, prefix: string, first: string, last: string, contains_64s: string}>,
+ *         free: array{remaining_str: string},
+ *         normalized_child_length: int,
+ *     },
+ *     error?: string|null
+ * }
+ */
+function sc_run_prefix_plan6(
+    string $parent_prefix_input,
+    string $child_length_input,
+    string $count_input,
+    string $start_offset_input,
+    bool $nibble_align
+): array {
+    $parent = trim($parent_prefix_input);
+    $clen   = trim($child_length_input);
+    $cnt    = trim($count_input);
+    $off    = trim($start_offset_input);
+
+    if ($parent === '' && $clen === '' && $cnt === '') {
+        return [];
+    }
+
+    $base = [
+        'parent_prefix'      => $parent,
+        'child_length_input' => $clen,
+        'count_input'        => $cnt,
+        'start_offset_input' => $off,
+        'nibble_align'       => $nibble_align,
+    ];
+
+    if ($parent === '' || $clen === '' || $cnt === '') {
+        return $base + ['error' => 'Parent prefix, child length, and count are all required.'];
+    }
+    if (!ctype_digit($clen)) {
+        return $base + ['error' => 'Child length must be an integer.'];
+    }
+    if (!ctype_digit($cnt)) {
+        return $base + ['error' => 'Count must be a positive integer.'];
+    }
+    if ($off !== '' && !ctype_digit($off)) {
+        return $base + ['error' => 'Start offset must be a non-negative integer.'];
+    }
+    $offset = $off === '' ? 0 : (int) $off;
+
+    try {
+        $r = plan_prefix_delegation(
+            $parent,
+            (int) $clen,
+            (int) $cnt,
+            $offset,
+            $nibble_align
+        );
+        return $base + ['result' => $r, 'error' => null];
+    } catch (\InvalidArgumentException $e) {
+        return $base + ['error' => $e->getMessage()];
+    }
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -1057,6 +1130,15 @@ $sixrd_ipv6_input       = '';
 /** @var array{mode?: 'encode'|'decode', sp_ipv6_prefix?: string, sp_ipv4_mask_len?: int, ipv4?: string, ipv6?: string, prefix?: string, prefix_length?: int, error?: string|null} */
 $sixrd = [];
 
+// v3.5.0 Task 8 — IPv6 prefix-delegation planner
+$prefix_plan6_parent_input        = '';
+$prefix_plan6_child_length_input  = '';
+$prefix_plan6_count_input         = '';
+$prefix_plan6_start_offset_input  = '';
+$prefix_plan6_nibble_align        = true;
+/** @var array{parent_prefix?: string, child_length_input?: string, count_input?: string, start_offset_input?: string, nibble_align?: bool, result?: array{parent: array{prefix: string, length: int, total_children_str: string}, children: list<array{index: int, prefix: string, first: string, last: string, contains_64s: string}>, free: array{remaining_str: string}, normalized_child_length: int}, error?: string|null} */
+$prefix_plan6 = [];
+
 $ula_global_id_input = '';
 /** @var array{result?: array{prefix?: string, global_id?: string, example_64s?: string[], available_64s?: int}, error?: string} */
 $ula = [];
@@ -1138,6 +1220,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || isset($_POST['nat64_ipv4'])
         || isset($_POST['nat64_ipv6'])
         || isset($_POST['nat64_a_record']);
+    $is_prefix_plan6  = isset($_POST['prefix_plan6_parent'])
+        || isset($_POST['prefix_plan6_child_length'])
+        || isset($_POST['prefix_plan6_count']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -1146,7 +1231,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_vlsm6 || $is_supernet || $is_supernet6 || $is_ula || $is_session_save || $is_range
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
         || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6 || $is_embedded_v4
-        || $is_sixtofour || $is_teredo || $is_isatap || $is_sixrd || $is_nat64;
+        || $is_sixtofour || $is_teredo || $is_isatap || $is_sixrd || $is_nat64
+        || $is_prefix_plan6;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -1650,6 +1736,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $nat64_ipv4_input,
             $nat64_ipv6_input,
             $nat64_a_record_input
+        );
+    }
+
+    if ($is_prefix_plan6 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $prefix_plan6_parent_input       = trim((string)($_POST['prefix_plan6_parent']       ?? ''));
+        $prefix_plan6_child_length_input = trim((string)($_POST['prefix_plan6_child_length'] ?? ''));
+        $prefix_plan6_count_input        = trim((string)($_POST['prefix_plan6_count']        ?? ''));
+        $prefix_plan6_start_offset_input = trim((string)($_POST['prefix_plan6_start_offset'] ?? ''));
+        $prefix_plan6_nibble_align       = isset($_POST['prefix_plan6_nibble_align']);
+        $prefix_plan6 = sc_run_prefix_plan6(
+            $prefix_plan6_parent_input,
+            $prefix_plan6_child_length_input,
+            $prefix_plan6_count_input,
+            $prefix_plan6_start_offset_input,
+            $prefix_plan6_nibble_align
         );
     }
 
@@ -2162,6 +2264,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $nat64_ipv4_input,
             $nat64_ipv6_input,
             $nat64_a_record_input
+        );
+    }
+
+    // Prefix-delegation planner shareable GET URL (v3.5.0 Task 8)
+    if (
+        $active_tab === 'ipv6'
+        && (
+            isset($_GET['prefix_plan6_parent'])
+            || isset($_GET['prefix_plan6_child_length'])
+            || isset($_GET['prefix_plan6_count'])
+        )
+    ) {
+        $prefix_plan6_parent_input       = trim((string)($_GET['prefix_plan6_parent']       ?? ''));
+        $prefix_plan6_child_length_input = trim((string)($_GET['prefix_plan6_child_length'] ?? ''));
+        $prefix_plan6_count_input        = trim((string)($_GET['prefix_plan6_count']        ?? ''));
+        $prefix_plan6_start_offset_input = trim((string)($_GET['prefix_plan6_start_offset'] ?? ''));
+        // GET hydration accepts an explicit `=0` to mean "off"; presence with any
+        // truthy value or no value defaults to on. This mirrors how shareable
+        // URLs serialise checkbox state across the rest of the app.
+        $prefix_plan6_nibble_align = !isset($_GET['prefix_plan6_nibble_align'])
+            || (string)$_GET['prefix_plan6_nibble_align'] !== '0';
+        $prefix_plan6 = sc_run_prefix_plan6(
+            $prefix_plan6_parent_input,
+            $prefix_plan6_child_length_input,
+            $prefix_plan6_count_input,
+            $prefix_plan6_start_offset_input,
+            $prefix_plan6_nibble_align
         );
     }
 

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -32,6 +32,9 @@ require_once __DIR__ . '/includes/functions-6rd.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for nat64_embed()/nat64_extract()/dns64_synthesize().
 require_once __DIR__ . '/includes/functions-nat64.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for plan_prefix_delegation().
+require_once __DIR__ . '/includes/functions-prefix-plan6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -769,9 +769,10 @@ if ($i < 3) {
         elseif (!empty($teredo)) { $open_tool_ipv6 = 'teredo'; }
         elseif (!empty($isatap)) { $open_tool_ipv6 = 'isatap'; }
         elseif (!empty($sixrd)) { $open_tool_ipv6 = '6rd'; }
+        elseif (!empty($prefix_plan6)) { $open_tool_ipv6 = 'prefix-plan'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -794,6 +795,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="teredo" aria-expanded="false">Teredo</button>
             <button type="button" class="tool-trigger" data-tool="isatap" aria-expanded="false">ISATAP</button>
             <button type="button" class="tool-trigger" data-tool="6rd" aria-expanded="false">6rd</button>
+            <button type="button" class="tool-trigger" data-tool="prefix-plan" aria-expanded="false">Prefix Plan</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -2054,6 +2056,124 @@ if ($i < 3) {
                             <?php endif; ?>
                         </dl>
                         <p><small>6rd (RFC 5969) is a service-provider-configured tunneling scheme; the SP parameters above must come from your provider. The masked-off portion of the customer IPv4 cannot be recovered from the 6rd address alone — it is treated as zero on decode.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+            <div class="tool-panel" data-tool="prefix-plan">
+                <div class="overlap-panel">
+                    <div class="overlap-title">IPv6 prefix-delegation planner<?= help_bubble('ipv6-prefix-plan', 'Slice a delegated parent prefix (e.g. /48) into nibble-aligned child prefixes (e.g. /56) and report how much of the parent space is left over. GMP throughout — counts that overflow signed 64-bit ints (e.g. /32 → /128) print as "2^N".') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="prefix_plan6_parent">Parent IPv6 prefix<?= help_bubble('prefix-plan-parent', 'The delegated parent prefix in CIDR form, e.g. 2001:db8::/48. Host bits are zeroed before slicing.') ?></label>
+                                <input type="text" id="prefix_plan6_parent" name="prefix_plan6_parent"
+                                       value="<?= htmlspecialchars($prefix_plan6_parent_input ?? '') ?>"
+                                       placeholder="2001:db8::/48"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($prefix_plan6['error']) ? 'aria-invalid="true" aria-describedby="prefix-plan6-error"' : '' ?>>
+                            </div>
+                            <div class="form-group form-group--mask">
+                                <label for="prefix_plan6_child_length">Child length<?= help_bubble('prefix-plan-child-length', 'Prefix length for each child block (1..128). Must be greater than the parent length. With nibble-align on, non-nibble values snap up to the next multiple of 4.') ?></label>
+                                <input type="number" id="prefix_plan6_child_length" name="prefix_plan6_child_length"
+                                       value="<?= htmlspecialchars($prefix_plan6_child_length_input ?? '') ?>"
+                                       min="1" max="128" placeholder="56"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($prefix_plan6['error']) ? 'aria-invalid="true" aria-describedby="prefix-plan6-error"' : '' ?>>
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group form-group--mask">
+                                <label for="prefix_plan6_count">Count<?= help_bubble('prefix-plan-count', 'How many child prefixes to allocate (≥ 1). Bounded by the parent: start_offset + count must not exceed the total available children.') ?></label>
+                                <input type="number" id="prefix_plan6_count" name="prefix_plan6_count"
+                                       value="<?= htmlspecialchars($prefix_plan6_count_input ?? '') ?>"
+                                       min="1" placeholder="4"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($prefix_plan6['error']) ? 'aria-invalid="true" aria-describedby="prefix-plan6-error"' : '' ?>>
+                            </div>
+                            <div class="form-group form-group--mask">
+                                <label for="prefix_plan6_start_offset">Start offset<?= help_bubble('prefix-plan-start-offset', 'Skip the first N child prefixes before allocating. Default 0. Useful for resuming an in-progress delegation plan.') ?></label>
+                                <input type="number" id="prefix_plan6_start_offset" name="prefix_plan6_start_offset"
+                                       value="<?= htmlspecialchars($prefix_plan6_start_offset_input ?? '') ?>"
+                                       min="0" placeholder="0"
+                                       autocomplete="off" spellcheck="false">
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group form-group--checkbox">
+                                <label>
+                                    <input type="checkbox" name="prefix_plan6_nibble_align" value="1"
+                                           <?= ($prefix_plan6_nibble_align ?? true) ? 'checked' : '' ?>>
+                                    Nibble-align child length<?= help_bubble('prefix-plan-nibble-align', 'When on, snap the child prefix length up to the next multiple of 4 so each child is a clean nibble boundary in the IPv6 address (easier for humans to read and DNS reverse-zones).') ?>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Plan</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($prefix_plan6['error'])) : ?>
+                        <div class="error" id="prefix-plan6-error"><?= htmlspecialchars((string)$prefix_plan6['error']) ?></div>
+                    <?php elseif (!empty($prefix_plan6['result'])) : ?>
+                        <?php
+                        $_pp = $prefix_plan6['result'];
+                        $_pp_history = 'Prefix plan: ' . (string)($_pp['parent']['prefix'] ?? '')
+                            . ' → /' . (string)($_pp['normalized_child_length'] ?? '');
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="prefix-plan6"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_pp_history) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Parent prefix</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$_pp['parent']['prefix']) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Child length</dt>
+                                <dd class="zoneid-result__value">
+                                    <code>/<?= (int)$_pp['normalized_child_length'] ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Total children</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$_pp['parent']['total_children_str']) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Free remaining</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$_pp['free']['remaining_str']) ?></code>
+                                </dd>
+                            </div>
+                        </dl>
+                        <table class="vlsm-table" data-prefix-plan6-table>
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Prefix</th>
+                                    <th>First</th>
+                                    <th>Last</th>
+                                    <th>/64s</th>
+                                    <th aria-label="Copy"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($_pp['children'] as $_child) : ?>
+                                <tr>
+                                    <td><?= (int)$_child['index'] ?></td>
+                                    <td><code><?= htmlspecialchars((string)$_child['prefix']) ?></code></td>
+                                    <td><code><?= htmlspecialchars((string)$_child['first']) ?></code></td>
+                                    <td><code><?= htmlspecialchars((string)$_child['last']) ?></code></td>
+                                    <td><?= htmlspecialchars((string)$_child['contains_64s']) ?></td>
+                                    <td><?= copy_button((string)$_child['prefix'], 'Copy child prefix') ?></td>
+                                </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                        <p><small>Prefix-delegation planning is operator math, not auto-detection. The parent prefix and child length come from your delegation policy; nibble-aligned children print cleanly and align with DNS reverse zones.</small></p>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/prefix-plan6.md
+++ b/docs/prefix-plan6.md
@@ -1,0 +1,97 @@
+# IPv6 Prefix-Delegation Planner
+
+Slice a delegated parent IPv6 prefix (e.g. a `/48` from your upstream)
+into nibble-aligned child prefixes (e.g. `/56`s for downstream sites or
+customers) and report how much of the parent space is still free.
+
+This tool is **operator math, not detection.** The parent prefix and
+desired child length come from your delegation policy; nothing is
+inferred from address structure.
+
+## When to use it
+
+- Sub-delegating a `/48` from your RIR or upstream into per-site `/56`s.
+- Carving an ISP's customer pool into per-customer `/56` or `/60` blocks.
+- Sizing a lab plan against a documentation `/48` (`2001:db8::/48`).
+- Auditing how many `/64` LANs a child block contains.
+
+## Inputs
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| Parent IPv6 prefix | yes | CIDR form, e.g. `2001:db8::/48`. Host bits are zeroed before slicing. |
+| Child length | yes | Integer 1..128. Must be greater than the parent length. |
+| Count | yes | How many child prefixes to allocate (≥ 1). |
+| Start offset | no | Skip the first N child prefixes. Useful for resuming an in-progress plan. Default 0. |
+| Nibble-align | no | When on (default), snap the child prefix length up to the next multiple of 4 so each child is a clean nibble boundary. |
+
+## Output
+
+The result is a table of child prefixes plus a parent summary:
+
+- **Parent prefix** — canonicalised CIDR (host bits zeroed, lowercase, compressed).
+- **Child length** — the *normalised* length after nibble-alignment.
+- **Total children** — `2 ** (child_length - parent_length)`. Counts that
+  overflow signed 64-bit ints (e.g. a `/32` → `/128` plan with `2^96`
+  children) print as the `"2^N"` string form.
+- **Free remaining** — total minus `(start_offset + count)`.
+
+For each child:
+
+- **#** — index within the parent (0-based; respects `start_offset`).
+- **Prefix** — child CIDR.
+- **First / Last** — the first and last IPv6 address in the block.
+- **/64s** — how the child relates to the standard `/64` LAN sizing:
+  - decimal count (or `"2^N"`) when the child is larger than a `/64`,
+  - `1` when the child is itself a `/64`,
+  - `subset of /64` when the child is smaller than a `/64`.
+- A **copy** button on each row.
+
+## Example: slice a /48 into /56s
+
+| Parent | Child len | Count | Result |
+|---|---|---|---|
+| `2001:db8::/48` | 56 | 4 | `2001:db8::/56`, `2001:db8:0:100::/56`, `2001:db8:0:200::/56`, `2001:db8:0:300::/56` |
+
+Total children: **256**. Free remaining: **252**.
+
+## Nibble alignment
+
+IPv6 addresses are written in nibbles (4-bit groups). Asking for a `/49`
+child puts the boundary mid-nibble, which is legal but ugly:
+`2001:db8::/49` and `2001:db8:0:8000::/49`. With **nibble-align on**,
+the planner snaps the requested length up to the next multiple of 4
+(`/49` → `/52`) so the children print cleanly and align with DNS reverse
+zones (`ip6.arpa` is a per-nibble hierarchy).
+
+Turn nibble-align off if your delegation policy genuinely uses non-nibble
+boundaries.
+
+## Overflow / very large counts
+
+The arithmetic is GMP throughout, so any prefix-length difference is
+supported. For clean powers of two with exponent ≥ 63, counts are
+returned in the compact `"2^N"` form rather than as huge decimal strings,
+matching the convention used by [VLSM6](vlsm.md) and
+[range6](sharing.md).
+
+## Shareable URLs
+
+The drawer's form state round-trips via GET parameters:
+
+```
+?tab=ipv6&tool=prefix-plan
+&prefix_plan6_parent=2001:db8::/48
+&prefix_plan6_child_length=56
+&prefix_plan6_count=4
+&prefix_plan6_start_offset=0
+&prefix_plan6_nibble_align=1
+```
+
+Set `prefix_plan6_nibble_align=0` to disable nibble alignment via URL.
+
+## REST API
+
+`POST /api/v1/prefix-plan6` — see [API reference](api.md). Same input
+schema as the form, returns the parent summary, child list, and
+free-space report.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
     - Teredo Address Decoder: teredo.md
     - ISATAP Interface-ID Helper: isatap.md
     - 6rd Address Tool: 6rd.md
+    - IPv6 Prefix-Delegation Planner: prefix-plan6.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -3867,6 +3867,159 @@ async def test_ipv6_6rd_ui(page: Page) -> None:
                 "2001:db8:c000:201::/64" in body_text, f"body: {body_text!r}")
 
 
+async def test_api_prefix_plan6(page: Page) -> None:
+    section("API — POST /api/v1/prefix-plan6")
+
+    # Slice /48 into the first four /56s.
+    status, data = _api_post("prefix-plan6", {
+        "parent_prefix": "2001:db8::/48",
+        "child_length": 56,
+        "count": 4,
+    })
+    assert_eq("api prefix-plan6 /48→/56: HTTP 200", status, 200)
+    assert_eq("api prefix-plan6 /48→/56: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    children = d.get("children", [])
+    assert_eq("api prefix-plan6 /48→/56: count=4", len(children), 4)
+    assert_eq("api prefix-plan6 /48→/56: first child prefix",
+              children[0].get("prefix") if children else None, "2001:db8::/56")
+    assert_eq("api prefix-plan6 /48→/56: second child prefix",
+              children[1].get("prefix") if len(children) > 1 else None, "2001:db8:0:100::/56")
+    assert_eq("api prefix-plan6 /48→/56: total_children_str",
+              d.get("parent", {}).get("total_children_str"), "256")
+    assert_eq("api prefix-plan6 /48→/56: free remaining",
+              d.get("free", {}).get("remaining_str"), "252")
+    assert_eq("api prefix-plan6 /48→/56: normalized_child_length",
+              d.get("normalized_child_length"), 56)
+    assert_eq("api prefix-plan6 /48→/56: contains_64s",
+              children[0].get("contains_64s") if children else None, "256")
+
+    # Nibble-align snaps /49 → /52.
+    status2, data2 = _api_post("prefix-plan6", {
+        "parent_prefix": "2001:db8::/48",
+        "child_length": 49,
+        "count": 1,
+        "nibble_align": True,
+    })
+    assert_eq("api prefix-plan6 nibble-align: HTTP 200", status2, 200)
+    assert_eq("api prefix-plan6 nibble-align: snaps to /52",
+              data2.get("data", {}).get("normalized_child_length"), 52)
+
+    # Overflow path — /32 → /128 ⇒ 2^96 children.
+    status3, data3 = _api_post("prefix-plan6", {
+        "parent_prefix": "2001:db8::/32",
+        "child_length": 128,
+        "count": 1,
+        "nibble_align": False,
+    })
+    assert_eq("api prefix-plan6 overflow: HTTP 200", status3, 200)
+    assert_eq("api prefix-plan6 overflow: total uses 2^N",
+              data3.get("data", {}).get("parent", {}).get("total_children_str"), "2^96")
+
+    # Start offset skips first N.
+    status4, data4 = _api_post("prefix-plan6", {
+        "parent_prefix": "2001:db8::/48",
+        "child_length": 56,
+        "count": 2,
+        "start_offset": 2,
+    })
+    assert_eq("api prefix-plan6 offset: HTTP 200", status4, 200)
+    kids = data4.get("data", {}).get("children", [])
+    assert_eq("api prefix-plan6 offset: first child index",
+              kids[0].get("index") if kids else None, 2)
+    assert_eq("api prefix-plan6 offset: first child prefix",
+              kids[0].get("prefix") if kids else None, "2001:db8:0:200::/56")
+
+    # Invalid: child_length ≤ parent_length.
+    status5, _ = _api_post("prefix-plan6", {
+        "parent_prefix": "2001:db8::/48",
+        "child_length": 32,
+        "count": 1,
+    })
+    assert_eq("api prefix-plan6 child<parent → 400", status5, 400)
+
+    # Invalid: missing required fields.
+    status6, _ = _api_post("prefix-plan6", {"parent_prefix": "2001:db8::/48"})
+    assert_eq("api prefix-plan6 missing fields → 400", status6, 400)
+
+    # Invalid: offset + count exceeds total. Disable nibble-align so /49 stays /49
+    # (only 2 children); with nibble-align on it would snap to /52 (16 children).
+    status7, _ = _api_post("prefix-plan6", {
+        "parent_prefix": "2001:db8::/48",
+        "child_length": 49,
+        "count": 2,
+        "start_offset": 1,
+        "nibble_align": False,
+    })
+    assert_eq("api prefix-plan6 offset+count overflow → 400", status7, 400)
+
+
+async def test_ipv6_prefix_plan_ui(page: Page) -> None:
+    section("IPv6 prefix-delegation planner UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # /ipv6/prefix-plan should auto-open the drawer (per-tool URL routing).
+    await navigate(page, APP_URL + "?tab=ipv6&tool=prefix-plan")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='prefix-plan']")
+    assert_eq("prefix-plan UI: panel exists", await panel.count(), 1)
+
+    # Plan a /48 → /56 slice (first 4).
+    await page.fill("#prefix_plan6_parent", "2001:db8::/48")
+    await page.fill("#prefix_plan6_child_length", "56")
+    await page.fill("#prefix_plan6_count", "4")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='prefix-plan'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='prefix-plan']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("prefix-plan UI: first child rendered",
+                "2001:db8::/56" in body_text, f"body: {body_text!r}")
+    assert_true("prefix-plan UI: fourth child rendered",
+                "2001:db8:0:300::/56" in body_text, f"body: {body_text!r}")
+
+    # Copy a child prefix.
+    await panel.locator(".subnet-copy").first.click()
+    await page.wait_for_timeout(50)
+    assert_eq("prefix-plan UI: copy child prefix",
+              await page.evaluate("window.__lastClipboard"),
+              "2001:db8::/56")
+
+    # Error path — child smaller than parent.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=prefix-plan")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#prefix_plan6_parent", "2001:db8::/48")
+    await page.fill("#prefix_plan6_child_length", "32")
+    await page.fill("#prefix_plan6_count", "1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='prefix-plan'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='prefix-plan']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("prefix-plan UI: error band when child ≤ parent",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+    # Shareable GET URL hydrates without re-submission.
+    await navigate(page,
+                   APP_URL + "?tab=ipv6&tool=prefix-plan"
+                   "&prefix_plan6_parent=2001:db8::/48"
+                   "&prefix_plan6_child_length=56"
+                   "&prefix_plan6_count=2")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='prefix-plan']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("prefix-plan UI shareable URL: hydrated",
+                "2001:db8::/56" in body_text, f"body: {body_text!r}")
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -8767,6 +8920,8 @@ async def main() -> None:
             await test_api_6rd(page)
             await test_ipv6_nat64_ui(page)
             await test_api_nat64(page)
+            await test_ipv6_prefix_plan_ui(page)
+            await test_api_prefix_plan6(page)
             await test_a11y_ipv6_drawers(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)

--- a/testing/unit/PrefixPlan6Test.php
+++ b/testing/unit/PrefixPlan6Test.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PrefixPlan6Test extends TestCase
+{
+    public function test_slice_48_into_56s(): void
+    {
+        $r = plan_prefix_delegation('2001:db8::/48', 56, 4, 0, true);
+        $this->assertCount(4, $r['children']);
+        $this->assertSame('2001:db8::/56', $r['children'][0]['prefix']);
+        $this->assertSame('2001:db8:0:100::/56', $r['children'][1]['prefix']);
+        $this->assertSame('2001:db8:0:200::/56', $r['children'][2]['prefix']);
+        $this->assertSame('2001:db8:0:300::/56', $r['children'][3]['prefix']);
+        $this->assertSame(56, $r['normalized_child_length']);
+    }
+
+    public function test_nibble_align_snaps_child_length(): void
+    {
+        // Asking for /49 with nibble-align → snaps up to /52
+        $r = plan_prefix_delegation('2001:db8::/48', 49, 1, 0, true);
+        $this->assertSame(52, $r['normalized_child_length']);
+    }
+
+    public function test_overflow_count_uses_2_n_string(): void
+    {
+        // /32 → /128 ⇒ 2^96 children
+        $r = plan_prefix_delegation('2001:db8::/32', 128, 1, 0, false);
+        $this->assertSame('2^96', $r['parent']['total_children_str']);
+    }
+
+    public function test_invalid_child_length_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::/48', 32, 1, 0, false); // smaller than parent
+    }
+
+    public function test_child_length_equal_parent_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::/48', 48, 1, 0, false);
+    }
+
+    public function test_child_length_too_large_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::/48', 129, 1, 0, false);
+    }
+
+    public function test_count_must_be_positive(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::/48', 56, 0, 0, false);
+    }
+
+    public function test_negative_offset_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::/48', 56, 1, -1, false);
+    }
+
+    public function test_offset_plus_count_exceeds_total_rejected(): void
+    {
+        // /48 → /49 ⇒ only 2 children; offset 1 + count 2 = 3 > 2.
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::/48', 49, 2, 1, false);
+    }
+
+    public function test_invalid_parent_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('not-an-address/48', 56, 1, 0, false);
+    }
+
+    public function test_parent_missing_prefix_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::', 56, 1, 0, false);
+    }
+
+    public function test_start_offset_skips_first_n(): void
+    {
+        $r = plan_prefix_delegation('2001:db8::/48', 56, 2, 2, true);
+        $this->assertCount(2, $r['children']);
+        $this->assertSame(2, $r['children'][0]['index']);
+        $this->assertSame('2001:db8:0:200::/56', $r['children'][0]['prefix']);
+        $this->assertSame('2001:db8:0:300::/56', $r['children'][1]['prefix']);
+    }
+
+    public function test_first_and_last_addresses(): void
+    {
+        $r = plan_prefix_delegation('2001:db8::/48', 56, 1, 0, true);
+        $child = $r['children'][0];
+        $this->assertSame('2001:db8::', $child['first']);
+        $this->assertSame('2001:db8:0:ff:ffff:ffff:ffff:ffff', $child['last']);
+    }
+
+    public function test_contains_64s_for_56(): void
+    {
+        // /56 contains 2^(64-56) = 256 /64s.
+        $r = plan_prefix_delegation('2001:db8::/48', 56, 1, 0, true);
+        $this->assertSame('256', $r['children'][0]['contains_64s']);
+    }
+
+    public function test_contains_64s_for_64(): void
+    {
+        // /64 contains exactly 1 /64 (itself).
+        $r = plan_prefix_delegation('2001:db8::/48', 64, 1, 0, true);
+        $this->assertSame('1', $r['children'][0]['contains_64s']);
+    }
+
+    public function test_contains_64s_for_smaller_than_64(): void
+    {
+        // /80 is a subset of a /64.
+        $r = plan_prefix_delegation('2001:db8::/48', 80, 1, 0, true);
+        $this->assertSame('subset of /64', $r['children'][0]['contains_64s']);
+    }
+
+    public function test_nibble_align_off_keeps_requested_length(): void
+    {
+        $r = plan_prefix_delegation('2001:db8::/48', 49, 2, 0, false);
+        $this->assertSame(49, $r['normalized_child_length']);
+        $this->assertCount(2, $r['children']);
+    }
+
+    public function test_total_children_str_small(): void
+    {
+        $r = plan_prefix_delegation('2001:db8::/48', 56, 4, 0, true);
+        $this->assertSame('256', $r['parent']['total_children_str']);
+    }
+
+    public function test_total_children_str_overflow_threshold(): void
+    {
+        // /48 → /128 ⇒ 2^80 children (exceeds signed 64).
+        $r = plan_prefix_delegation('2001:db8::/48', 128, 1, 0, false);
+        $this->assertSame('2^80', $r['parent']['total_children_str']);
+    }
+
+    public function test_free_remaining_str(): void
+    {
+        $r = plan_prefix_delegation('2001:db8::/48', 56, 4, 0, true);
+        $this->assertSame('252', $r['free']['remaining_str']);
+    }
+
+    public function test_free_remaining_overflow(): void
+    {
+        // /32 → /128 ⇒ 2^96 total, take 1 → 2^96 - 1 (still huge).
+        $r = plan_prefix_delegation('2001:db8::/32', 128, 1, 0, false);
+        // Free is total - 1; we surface it as decimal string when it doesn't
+        // collapse to a clean 2^N. Just check that it's a non-empty digit string.
+        $this->assertNotSame('', $r['free']['remaining_str']);
+        $this->assertMatchesRegularExpression('/^[0-9]+$/', $r['free']['remaining_str']);
+    }
+
+    public function test_child_length_128_single_address(): void
+    {
+        // /48 → /128 with count=1 ⇒ a single host address.
+        $r = plan_prefix_delegation('2001:db8::/48', 128, 1, 0, false);
+        $this->assertSame('2001:db8::/128', $r['children'][0]['prefix']);
+        $this->assertSame('2001:db8::', $r['children'][0]['first']);
+        $this->assertSame('2001:db8::', $r['children'][0]['last']);
+        $this->assertSame('subset of /64', $r['children'][0]['contains_64s']);
+    }
+
+    public function test_parent_normalised(): void
+    {
+        // Parent with non-zero host bits is canonicalised in output.
+        $r = plan_prefix_delegation('2001:db8:0:1234::/48', 56, 1, 0, true);
+        $this->assertSame('2001:db8::/48', $r['parent']['prefix']);
+        $this->assertSame(48, $r['parent']['length']);
+    }
+}

--- a/testing/unit/PrefixPlan6Test.php
+++ b/testing/unit/PrefixPlan6Test.php
@@ -171,4 +171,12 @@ final class PrefixPlan6Test extends TestCase
         $this->assertSame('2001:db8::/48', $r['parent']['prefix']);
         $this->assertSame(48, $r['parent']['length']);
     }
+
+    public function test_count_cap_rejects_excessive(): void
+    {
+        // Cap is loaded from $GLOBALS['prefix_plan6_max_count'] (default 256,
+        // hard ceiling 4096). 999999 is far above either bound and must throw.
+        $this->expectException(InvalidArgumentException::class);
+        plan_prefix_delegation('2001:db8::/48', 56, 999999);
+    }
 }

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -31,6 +31,9 @@ require_once $base . 'functions-6rd.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for nat64_embed()/nat64_extract()/dns64_synthesize().
 require_once $base . 'functions-nat64.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for plan_prefix_delegation().
+require_once $base . 'functions-prefix-plan6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

Task 8 of v3.5.0 — IPv6 prefix-delegation planner. Slice a delegated parent prefix (e.g. `/48`) into nibble-aligned child prefixes (e.g. `/56`) with a usage table and free-space report. GMP throughout — counts that overflow signed 64 print as `"2^N"`.

Closes #387.

- New helper `plan_prefix_delegation()` in `Subnet-Calculator/includes/functions-prefix-plan6.php`
- New `POST /api/v1/prefix-plan6` endpoint with full OpenAPI spec
- New IPv6 drawer (`data-tool="prefix-plan"`) with shareable GET URL hydration
- 23 PHPUnit tests (38 assertions); Playwright `test_api_prefix_plan6` + `test_ipv6_prefix_plan_ui`
- `docs/prefix-plan6.md` + mkdocs nav entry
- CHANGELOG entry under existing `## [3.5.0] / ### Added`

No changes to `functions-embedded-v4.php` or `EmbeddedV4Test.php` — prefix planning is operator math, not address detection.

## Test plan

- [x] PHPUnit: 647 tests, 1407 assertions, 14 skipped — green
- [x] PHPStan L9 (`--memory-limit=512M`): no errors
- [x] PHPCS PSR-12 (includes/, api/): clean
- [x] Spectral on openapi.yaml: no errors
- [x] semgrep (.semgrep + p/php + p/owasp-top-ten + p/sql-injection) on new files: 0 findings
- [x] `make test-docker` Playwright: 1807/1807 passing
- [x] ESLint / Stylelint: clean (only pre-existing warnings)

## Decisions

- **`child_length=128`**: handled. With nibble-align off (and counts/offsets fitting), `/N → /128` works; the helper short-circuits `host_bits=0` cases via GMP. Test `test_child_length_128_single_address` covers this.
- **Count overflow**: counts ≥ 2^63 (clean powers of two) print as `"2^N"`; smaller counts and non-power-of-two free-remaining values print as decimal strings. Same convention as `vlsm6_allocate()` and `range6_to_cidrs()`.
- **`contains_64s` semantics**: decimal count (or `"2^N"`) when child is larger than `/64`; `"1"` for `/64` itself; `"subset of /64"` for anything smaller — surfaces the right semantic per task spec.
- **Nibble-align default on**: matches operator expectation (clean DNS reverse zones); turn off via UI checkbox or `nibble_align: false` in the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)