### PR TITLE
feat(v3.5.0): IPv6 nibble-boundary helper (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ as each ships.
   into nibble-aligned child prefixes (e.g. /56) with a usage table and
   free-space report. GMP throughout — counts that overflow signed 64
   print as `"2^N"`. (#387)
+- **IPv6 nibble-boundary helper.** Show nibble-aligned neighbours
+  (above and below) for any IPv6 prefix. Helps with reverse-zone
+  delegation planning. (#388)
 
 ## [3.4.1] - 2026-05-08
 

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -79,6 +79,8 @@ tags:
     description: NAT64 / DNS64 helper (RFC 6052 / 6147) — prefix-length-aware IPv4 ↔ NAT64 IPv6 translation and DNS64 AAAA synthesis
   - name: PrefixPlan6
     description: IPv6 prefix-delegation planner — slice a parent prefix into nibble-aligned child prefixes (operator math, not detection)
+  - name: Nibble6
+    description: IPv6 nibble-boundary helper — surface the nibble-aligned neighbours (above and below) of any IPv6 prefix
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -2846,6 +2848,113 @@ paths:
                             example: 56
         "400":
           description: Missing required field, unparseable input, or out-of-range request
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /nibble6:
+    post:
+      operationId: nibble6
+      tags: [Nibble6]
+      summary: Surface the nibble-aligned neighbours of an IPv6 prefix
+      description: |
+        Given any IPv6 prefix (e.g. `2001:db8::/49`), return the
+        nibble-aligned neighbours: `above` (the nearest nibble boundary
+        at-or-shorter than the input length) and `below` (the nearest
+        nibble boundary at-or-longer than the input length, capped at
+        /128).
+
+        Both neighbour prefixes are emitted in canonical form: address
+        bits beyond the neighbour's prefix length are zeroed. Each
+        carries a `contains_64s` field with the same semantics as
+        `/api/v1/prefix-plan6` (decimal count, `"1"`, or `"subset of /64"`).
+
+        Useful for reverse-zone (`ip6.arpa`) delegation planning, where
+        non-nibble prefix lengths require explicit operator decisions
+        about which nibble boundary to delegate against.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [prefix]
+              properties:
+                prefix:
+                  type: string
+                  example: "2001:db8::/49"
+            examples:
+              forty_nine:
+                summary: A /49 sits between /48 and /52
+                value: { prefix: "2001:db8::/49" }
+              already_aligned:
+                summary: A /48 is already nibble-aligned
+                value: { prefix: "2001:db8::/48" }
+      responses:
+        "200":
+          description: Nibble-aligned neighbours
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [input, above, below]
+                        properties:
+                          input:
+                            type: object
+                            required: [prefix, length]
+                            properties:
+                              prefix: { type: string, example: "2001:db8::/49" }
+                              length: { type: integer, example: 49 }
+                          above:
+                            type: object
+                            required: [length, prefix, contains_64s]
+                            properties:
+                              length: { type: integer, example: 48 }
+                              prefix: { type: string, example: "2001:db8::/48" }
+                              contains_64s:
+                                type: string
+                                description: Decimal count, "1", or "subset of /64".
+                                example: "65536"
+                          below:
+                            type: object
+                            required: [length, prefix, contains_64s]
+                            properties:
+                              length: { type: integer, example: 52 }
+                              prefix: { type: string, example: "2001:db8::/52" }
+                              contains_64s:
+                                type: string
+                                description: Decimal count, "1", or "subset of /64".
+                                example: "4096"
+        "400":
+          description: Missing required field or unparseable input
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/nibble6.php
+++ b/Subnet-Calculator/api/v1/handlers/nibble6.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body = api_body();
+
+$raw_prefix = $body['prefix'] ?? null;
+if (!is_string($raw_prefix) || trim($raw_prefix) === '') {
+    json_err('Field "prefix" (string) is required, e.g. "2001:db8::/49".', 400);
+}
+
+try {
+    $r = nibble_neighbours(trim($raw_prefix));
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'input' => $r['input'],
+    'above' => $r['above'],
+    'below' => $r['below'],
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -136,6 +136,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/6rd',
             'POST /api/v1/nat64',
             'POST /api/v1/prefix-plan6',
+            'POST /api/v1/nibble6',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -283,6 +284,9 @@ switch ($route_key) {
         break;
     case 'POST /prefix-plan6':
         require __DIR__ . '/handlers/prefix-plan6.php';
+        break;
+    case 'POST /nibble6':
+        require __DIR__ . '/handlers/nibble6.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-prefix-plan6.php
+++ b/Subnet-Calculator/includes/functions-prefix-plan6.php
@@ -221,6 +221,100 @@ function prefix_plan6_format_count(\GMP $count): string
 }
 
 /**
+ * Given an arbitrary IPv6 prefix, return the nibble-aligned neighbours.
+ *
+ * "above" = aligned and ≤ input length (less specific, a higher-up nibble
+ * boundary in the tree). "below" = aligned and ≥ input length (more
+ * specific, a lower nibble boundary). For an input `/49`: above=`/48`,
+ * below=`/52`.
+ *
+ * Edge cases:
+ *   • Input length is already nibble-aligned → above stays at the input
+ *     length; below moves to the next deeper nibble (input + 4), capped
+ *     at /128.
+ *   • Input length is /128 → both above and below collapse to /128
+ *     (no further refinement is possible).
+ *   • Input length 0..3 → above snaps down to /0; below = /4.
+ *   • Input length 125..127 → below caps at /128.
+ *
+ * Both neighbour prefixes are emitted in canonical form: address bits
+ * beyond the neighbour's prefix length are zeroed via GMP masking, then
+ * formatted with inet_ntop() (lowercase, compressed).
+ *
+ * `contains_64s` reuses prefix_plan6_contains_64s() so the field's
+ * formatting matches the prefix-delegation planner exactly.
+ *
+ * @return array{
+ *   input: array{prefix: string, length: int},
+ *   above: array{length: int, prefix: string, contains_64s: string},
+ *   below: array{length: int, prefix: string, contains_64s: string},
+ * }
+ *
+ * @throws InvalidArgumentException
+ */
+function nibble_neighbours(string $prefix): array
+{
+    [$bin, $length] = prefix_plan6_parse_parent($prefix);
+
+    // Snap-down to nearest nibble boundary at-or-below the input length.
+    $above_length = $length - ($length % 4);
+    // Snap-up to nearest nibble boundary at-or-above the input length,
+    // capped at 128. When the input is already aligned, advance to the
+    // next deeper nibble. /128 is its own floor.
+    if ($length >= 128) {
+        $below_length = 128;
+    } elseif (($length % 4) === 0) {
+        $below_length = min(128, $length + 4);
+    } else {
+        $below_length = $length + (4 - ($length % 4));
+        if ($below_length > 128) {
+            $below_length = 128;
+        }
+    }
+
+    $addr_int = gmp_init(bin2hex($bin), 16);
+
+    return [
+        'input' => [
+            'prefix' => prefix_plan6_format_address(
+                nibble6_mask_to_length($addr_int, $length)
+            ) . '/' . $length,
+            'length' => $length,
+        ],
+        'above' => [
+            'length'       => $above_length,
+            'prefix'       => prefix_plan6_format_address(
+                nibble6_mask_to_length($addr_int, $above_length)
+            ) . '/' . $above_length,
+            'contains_64s' => prefix_plan6_contains_64s($above_length),
+        ],
+        'below' => [
+            'length'       => $below_length,
+            'prefix'       => prefix_plan6_format_address(
+                nibble6_mask_to_length($addr_int, $below_length)
+            ) . '/' . $below_length,
+            'contains_64s' => prefix_plan6_contains_64s($below_length),
+        ],
+    ];
+}
+
+/**
+ * Mask a 128-bit GMP integer to the given prefix length (zero host bits).
+ * Length 0 returns 0; length 128 returns the address unchanged.
+ */
+function nibble6_mask_to_length(\GMP $addr_int, int $length): \GMP
+{
+    if ($length <= 0) {
+        return gmp_init(0);
+    }
+    if ($length >= 128) {
+        return $addr_int;
+    }
+    $mask = gmp_sub(gmp_pow(2, 128), gmp_pow(2, 128 - $length));
+    return gmp_and($addr_int, $mask);
+}
+
+/**
  * Translate a child prefix length into a description of how it relates to
  * the standard /64 LAN sizing. Three branches:
  *   • child_length < 64  → "2^(64-child_length)" or decimal — number of /64s contained.

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -940,6 +940,39 @@ function sc_run_prefix_plan6(
     }
 }
 
+// ─── Nibble6 helper (shared by POST handler and GET shareable URL) ──────────
+
+/**
+ * Run nibble_neighbours() against a single user-supplied prefix and return
+ * an associative array mirroring sc_run_prefix_plan6(): empty on no input,
+ * `error` on failure, `result` on success. Shared by the POST handler and
+ * the GET shareable-URL hydration path. (v3.5.0 Task 9)
+ *
+ * @return array{
+ *     prefix_input?: string,
+ *     result?: array{
+ *         input: array{prefix: string, length: int},
+ *         above: array{length: int, prefix: string, contains_64s: string},
+ *         below: array{length: int, prefix: string, contains_64s: string},
+ *     },
+ *     error?: string|null
+ * }
+ */
+function sc_run_nibble6(string $prefix_input): array
+{
+    $prefix = trim($prefix_input);
+    if ($prefix === '') {
+        return [];
+    }
+    $base = ['prefix_input' => $prefix];
+    try {
+        $r = nibble_neighbours($prefix);
+        return $base + ['result' => $r, 'error' => null];
+    } catch (\InvalidArgumentException $e) {
+        return $base + ['error' => $e->getMessage()];
+    }
+}
+
 // ─── Diff helper (shared by POST handler and GET shareable URL) ──────────────
 
 /**
@@ -1130,6 +1163,11 @@ $sixrd_ipv6_input       = '';
 /** @var array{mode?: 'encode'|'decode', sp_ipv6_prefix?: string, sp_ipv4_mask_len?: int, ipv4?: string, ipv6?: string, prefix?: string, prefix_length?: int, error?: string|null} */
 $sixrd = [];
 
+// v3.5.0 Task 9 — IPv6 nibble-boundary helper
+$nibble6_prefix_input = '';
+/** @var array{prefix_input?: string, result?: array{input: array{prefix: string, length: int}, above: array{length: int, prefix: string, contains_64s: string}, below: array{length: int, prefix: string, contains_64s: string}}, error?: string|null} */
+$nibble6 = [];
+
 // v3.5.0 Task 8 — IPv6 prefix-delegation planner
 $prefix_plan6_parent_input        = '';
 $prefix_plan6_child_length_input  = '';
@@ -1223,6 +1261,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_prefix_plan6  = isset($_POST['prefix_plan6_parent'])
         || isset($_POST['prefix_plan6_child_length'])
         || isset($_POST['prefix_plan6_count']);
+    $is_nibble6       = isset($_POST['nibble6_prefix']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -1232,7 +1271,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_range6 || $is_tree || $is_wildcard || $is_lookup || $is_diff || $is_zoneid
         || $is_derive || $is_slaac || $is_rdns6 || $is_mapped6 || $is_embedded_v4
         || $is_sixtofour || $is_teredo || $is_isatap || $is_sixrd || $is_nat64
-        || $is_prefix_plan6;
+        || $is_prefix_plan6
+        || $is_nibble6;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -1737,6 +1777,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $nat64_ipv6_input,
             $nat64_a_record_input
         );
+    }
+
+    if ($is_nibble6 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $nibble6_prefix_input = trim((string)($_POST['nibble6_prefix'] ?? ''));
+        $nibble6              = sc_run_nibble6($nibble6_prefix_input);
     }
 
     if ($is_prefix_plan6 && !$form_blocked) {
@@ -2292,6 +2338,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $prefix_plan6_start_offset_input,
             $prefix_plan6_nibble_align
         );
+    }
+
+    // Nibble-boundary helper shareable GET URL (v3.5.0 Task 9)
+    if ($active_tab === 'ipv6' && isset($_GET['nibble6_prefix'])) {
+        $nibble6_prefix_input = trim((string)($_GET['nibble6_prefix'] ?? ''));
+        $nibble6              = sc_run_nibble6($nibble6_prefix_input);
     }
 
     // Supernet6 / summarise6 shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -770,9 +770,10 @@ if ($i < 3) {
         elseif (!empty($isatap)) { $open_tool_ipv6 = 'isatap'; }
         elseif (!empty($sixrd)) { $open_tool_ipv6 = '6rd'; }
         elseif (!empty($prefix_plan6)) { $open_tool_ipv6 = 'prefix-plan'; }
+        elseif (!empty($nibble6)) { $open_tool_ipv6 = 'nibble'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan','nibble'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -796,6 +797,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="isatap" aria-expanded="false">ISATAP</button>
             <button type="button" class="tool-trigger" data-tool="6rd" aria-expanded="false">6rd</button>
             <button type="button" class="tool-trigger" data-tool="prefix-plan" aria-expanded="false">Prefix Plan</button>
+            <button type="button" class="tool-trigger" data-tool="nibble" aria-expanded="false">Nibble Neighbours</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -2174,6 +2176,60 @@ if ($i < 3) {
                             </tbody>
                         </table>
                         <p><small>Prefix-delegation planning is operator math, not auto-detection. The parent prefix and child length come from your delegation policy; nibble-aligned children print cleanly and align with DNS reverse zones.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+            <div class="tool-panel" data-tool="nibble">
+                <div class="overlap-panel">
+                    <div class="overlap-title">IPv6 nibble-boundary helper<?= help_bubble('ipv6-nibble', 'For any IPv6 prefix, surface the nibble-aligned neighbours: above (≤ input length, less specific) and below (≥ input length, more specific). Useful for ip6.arpa reverse-zone delegation planning where non-nibble lengths require an explicit nibble-boundary decision.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="nibble6_prefix">IPv6 prefix<?= help_bubble('nibble-prefix', 'Any IPv6 prefix in CIDR form, e.g. 2001:db8::/49. Host bits beyond the prefix length are zeroed before the neighbours are computed.') ?></label>
+                                <input type="text" id="nibble6_prefix" name="nibble6_prefix"
+                                       value="<?= htmlspecialchars($nibble6_prefix_input ?? '') ?>"
+                                       placeholder="2001:db8::/49"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($nibble6['error']) ? 'aria-invalid="true" aria-describedby="nibble6-error"' : '' ?>>
+                            </div>
+                        </div>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Find neighbours</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($nibble6['error'])) : ?>
+                        <div class="error" id="nibble6-error"><?= htmlspecialchars((string)$nibble6['error']) ?></div>
+                    <?php elseif (!empty($nibble6['result'])) : ?>
+                        <?php $_n = $nibble6['result']; ?>
+                        <dl class="zoneid-result"
+                            data-history-source="nibble6"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars('Nibble neighbours: ' . (string)$_n['input']['prefix']) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Input prefix</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$_n['input']['prefix']) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Above (less specific)</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$_n['above']['prefix']) ?></code>
+                                    <?= copy_button((string)$_n['above']['prefix'], 'Copy above prefix') ?>
+                                    <small>contains <?= htmlspecialchars((string)$_n['above']['contains_64s']) ?> /64s</small>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Below (more specific)</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)$_n['below']['prefix']) ?></code>
+                                    <?= copy_button((string)$_n['below']['prefix'], 'Copy below prefix') ?>
+                                    <small>contains <?= htmlspecialchars((string)$_n['below']['contains_64s']) ?> /64s</small>
+                                </dd>
+                            </div>
+                        </dl>
+                        <p><small>Nibble boundaries (multiples of 4) align with the per-nibble <code>ip6.arpa</code> reverse-DNS hierarchy. <em>Above</em> is the nearest nibble at-or-shorter than your input; <em>below</em> is the nearest nibble at-or-longer (capped at /128).</small></p>
                     <?php endif; ?>
                 </div>
             </div>

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -2217,7 +2217,16 @@ if ($i < 3) {
                                 <dd class="zoneid-result__value">
                                     <code><?= htmlspecialchars((string)$_n['above']['prefix']) ?></code>
                                     <?= copy_button((string)$_n['above']['prefix'], 'Copy above prefix') ?>
-                                    <small>contains <?= htmlspecialchars((string)$_n['above']['contains_64s']) ?> /64s</small>
+                                    <?php $_c = (string)$_n['above']['contains_64s']; ?>
+                                    <small><?php
+                                        if ($_c === '1') {
+                                            echo 'is itself a /64';
+                                        } elseif ($_c === 'subset of /64') {
+                                            echo 'smaller than a /64';
+                                        } else {
+                                            echo 'contains ' . htmlspecialchars($_c, ENT_QUOTES, 'UTF-8') . ' /64s';
+                                        }
+                                    ?></small>
                                 </dd>
                             </div>
                             <div class="zoneid-result__row">
@@ -2225,7 +2234,16 @@ if ($i < 3) {
                                 <dd class="zoneid-result__value">
                                     <code><?= htmlspecialchars((string)$_n['below']['prefix']) ?></code>
                                     <?= copy_button((string)$_n['below']['prefix'], 'Copy below prefix') ?>
-                                    <small>contains <?= htmlspecialchars((string)$_n['below']['contains_64s']) ?> /64s</small>
+                                    <?php $_c = (string)$_n['below']['contains_64s']; ?>
+                                    <small><?php
+                                        if ($_c === '1') {
+                                            echo 'is itself a /64';
+                                        } elseif ($_c === 'subset of /64') {
+                                            echo 'smaller than a /64';
+                                        } else {
+                                            echo 'contains ' . htmlspecialchars($_c, ENT_QUOTES, 'UTF-8') . ' /64s';
+                                        }
+                                    ?></small>
                                 </dd>
                             </div>
                         </dl>

--- a/docs/nibble6.md
+++ b/docs/nibble6.md
@@ -1,0 +1,73 @@
+# IPv6 Nibble-Boundary Helper
+
+For any IPv6 prefix, surface the **nibble-aligned neighbours**: the
+nearest nibble boundary at-or-shorter than the input length (*above*,
+less specific) and the nearest nibble boundary at-or-longer than the
+input length (*below*, more specific).
+
+Useful for `ip6.arpa` reverse-zone delegation planning, where non-nibble
+prefix lengths require an explicit operator decision about which nibble
+boundary to delegate against.
+
+## When to use it
+
+- Planning reverse-DNS delegation against a non-nibble allocation
+  (e.g. you were delegated a `/49` and need to decide whether to
+  delegate the `/48` zone or split it into two `/52` zones).
+- Auditing whether a delegation policy keeps prefixes on clean nibble
+  boundaries.
+- Quick sanity-check of how much address space is gained or lost when
+  rounding to the nearest nibble.
+
+## Inputs
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| IPv6 prefix | yes | CIDR form, e.g. `2001:db8::/49`. Host bits beyond the prefix length are zeroed before the neighbours are computed. |
+
+## Output
+
+- **Input prefix** — your input, canonicalised (host bits zeroed,
+  lowercase, compressed).
+- **Above** — the nearest nibble boundary at-or-shorter than the input
+  length. For an aligned input, *above* equals the input length.
+- **Below** — the nearest nibble boundary at-or-longer than the input
+  length, capped at `/128`. For an aligned input, *below* moves to the
+  next deeper nibble (input + 4).
+- Each neighbour carries a `contains_64s` count (decimal, `1`, or
+  `subset of /64`) matching the [prefix-delegation
+  planner](prefix-plan6.md) field of the same name.
+
+## Examples
+
+| Input | Above | Below |
+|-------|-------|-------|
+| `2001:db8::/49` | `/48` | `/52` |
+| `2001:db8::/48` | `/48` | `/52` |
+| `2001:db8::/63` | `/60` | `/64` |
+| `2001:db8::/127` | `/124` | `/128` |
+| `2001:db8::1/128` | `/128` | `/128` |
+| `::/0` | `/0` | `/4` |
+
+## Why nibble boundaries matter
+
+IPv6 reverse DNS lives in `ip6.arpa`, a per-nibble hierarchy: each label
+is a single hex digit. A delegation that lands mid-nibble (e.g. a `/49`)
+cannot be cleanly cut at a single zone boundary — it spans half of one
+nibble's child zones. The two adjacent nibble-aligned prefixes (`/48`
+and `/52` for a `/49`) are the only choices that yield clean reverse-zone
+delegations.
+
+## Shareable URLs
+
+The drawer's form state round-trips via a single GET parameter:
+
+```
+?tab=ipv6&tool=nibble&nibble6_prefix=2001:db8::/49
+```
+
+## REST API
+
+`POST /api/v1/nibble6` — see [API reference](api.md). Same input as the
+form, returns the canonicalised input, plus the *above* and *below*
+neighbour prefixes with their `contains_64s` counts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
     - ISATAP Interface-ID Helper: isatap.md
     - 6rd Address Tool: 6rd.md
     - IPv6 Prefix-Delegation Planner: prefix-plan6.md
+    - IPv6 Nibble-Boundary Helper: nibble6.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -4020,6 +4020,113 @@ async def test_ipv6_prefix_plan_ui(page: Page) -> None:
                 "2001:db8::/56" in body_text, f"body: {body_text!r}")
 
 
+async def test_api_nibble6(page: Page) -> None:
+    section("API — POST /api/v1/nibble6")
+
+    # /49 → above=/48, below=/52.
+    status, data = _api_post("nibble6", {"prefix": "2001:db8::/49"})
+    assert_eq("api nibble6 /49: HTTP 200", status, 200)
+    assert_eq("api nibble6 /49: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api nibble6 /49: input length",
+              d.get("input", {}).get("length"), 49)
+    assert_eq("api nibble6 /49: above length",
+              d.get("above", {}).get("length"), 48)
+    assert_eq("api nibble6 /49: below length",
+              d.get("below", {}).get("length"), 52)
+    assert_eq("api nibble6 /49: above prefix",
+              d.get("above", {}).get("prefix"), "2001:db8::/48")
+    assert_eq("api nibble6 /49: below prefix",
+              d.get("below", {}).get("prefix"), "2001:db8::/52")
+    assert_eq("api nibble6 /49: above contains_64s",
+              d.get("above", {}).get("contains_64s"), "65536")
+    assert_eq("api nibble6 /49: below contains_64s",
+              d.get("below", {}).get("contains_64s"), "4096")
+
+    # Already-aligned input — /48 stays /48 above, advances to /52 below.
+    status2, data2 = _api_post("nibble6", {"prefix": "2001:db8::/48"})
+    assert_eq("api nibble6 /48: HTTP 200", status2, 200)
+    assert_eq("api nibble6 /48: above stays at /48",
+              data2.get("data", {}).get("above", {}).get("prefix"), "2001:db8::/48")
+    assert_eq("api nibble6 /48: below = /52",
+              data2.get("data", {}).get("below", {}).get("prefix"), "2001:db8::/52")
+
+    # /128 — both collapse.
+    status3, data3 = _api_post("nibble6", {"prefix": "2001:db8::1/128"})
+    assert_eq("api nibble6 /128: HTTP 200", status3, 200)
+    assert_eq("api nibble6 /128: below caps at /128",
+              data3.get("data", {}).get("below", {}).get("length"), 128)
+
+    # Invalid: missing field.
+    status4, _ = _api_post("nibble6", {})
+    assert_eq("api nibble6 missing field → 400", status4, 400)
+
+    # Invalid: unparseable address.
+    status5, _ = _api_post("nibble6", {"prefix": "not-an-address/48"})
+    assert_eq("api nibble6 invalid address → 400", status5, 400)
+
+
+async def test_ipv6_nibble_ui(page: Page) -> None:
+    section("IPv6 nibble-boundary helper UI")
+
+    # Install clipboard intercept (docker test harness serves over insecure HTTP).
+    await page.add_init_script("""
+        (() => {
+            window.__lastClipboard = null;
+            const stub = { writeText: (text) => { window.__lastClipboard = text; return Promise.resolve(); } };
+            try { Object.defineProperty(navigator, 'clipboard', { value: stub, configurable: true }); }
+            catch (e) { navigator.clipboard = stub; }
+        })();
+    """)
+
+    # /ipv6/nibble should auto-open the drawer (per-tool URL routing).
+    await navigate(page, APP_URL + "?tab=ipv6&tool=nibble")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='nibble']")
+    assert_eq("nibble UI: panel exists", await panel.count(), 1)
+
+    # Compute neighbours of /49.
+    await page.fill("#nibble6_prefix", "2001:db8::/49")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='nibble'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='nibble']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("nibble UI: above /48 rendered",
+                "2001:db8::/48" in body_text, f"body: {body_text!r}")
+    assert_true("nibble UI: below /52 rendered",
+                "2001:db8::/52" in body_text, f"body: {body_text!r}")
+
+    # Copy the above prefix.
+    await panel.locator(".subnet-copy").first.click()
+    await page.wait_for_timeout(50)
+    assert_eq("nibble UI: copy above prefix",
+              await page.evaluate("window.__lastClipboard"),
+              "2001:db8::/48")
+
+    # Error path — missing prefix length.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=nibble")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#nibble6_prefix", "2001:db8::")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='nibble'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='nibble']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("nibble UI: error band on missing length",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+    # Shareable GET URL hydrates without re-submission.
+    await navigate(page,
+                   APP_URL + "?tab=ipv6&tool=nibble"
+                   "&nibble6_prefix=2001:db8::/49")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='nibble']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("nibble UI shareable URL: hydrated",
+                "2001:db8::/48" in body_text and "2001:db8::/52" in body_text,
+                f"body: {body_text!r}")
+
+
 async def test_api_bulk(page: Page) -> None:
     section("API — bulk calculation")
     # Two valid IPv4 CIDRs
@@ -8922,6 +9029,8 @@ async def main() -> None:
             await test_api_nat64(page)
             await test_ipv6_prefix_plan_ui(page)
             await test_api_prefix_plan6(page)
+            await test_ipv6_nibble_ui(page)
+            await test_api_nibble6(page)
             await test_a11y_ipv6_drawers(page)
             await test_api_tree(page)
             await test_tooltips_visual_polish(page)

--- a/testing/unit/Nibble6Test.php
+++ b/testing/unit/Nibble6Test.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class Nibble6Test extends TestCase
+{
+    public function test_49_neighbours(): void
+    {
+        $r = nibble_neighbours('2001:db8::/49');
+        $this->assertSame(48, $r['above']['length']);
+        $this->assertSame(52, $r['below']['length']);
+        $this->assertSame('2001:db8::/48', $r['above']['prefix']);
+        $this->assertSame('2001:db8::/52', $r['below']['prefix']);
+    }
+
+    public function test_aligned_input_returns_self(): void
+    {
+        // /48 is already nibble-aligned: above stays at /48, below is the next
+        // deeper nibble (/52).
+        $r = nibble_neighbours('2001:db8::/48');
+        $this->assertSame(48, $r['above']['length']);
+        $this->assertSame(52, $r['below']['length']);
+        $this->assertSame('2001:db8::/48', $r['above']['prefix']);
+        $this->assertSame('2001:db8::/52', $r['below']['prefix']);
+    }
+
+    public function test_boundary_at_128(): void
+    {
+        // /128 has no further refinement — below collapses to /128 itself.
+        $r = nibble_neighbours('2001:db8::1/128');
+        $this->assertSame(128, $r['below']['length']);
+        $this->assertSame(128, $r['above']['length']);
+    }
+
+    public function test_input_zero_prefix(): void
+    {
+        $r = nibble_neighbours('::/0');
+        $this->assertSame(0, $r['above']['length']);
+        $this->assertSame(4, $r['below']['length']);
+        $this->assertSame('::/0', $r['above']['prefix']);
+        $this->assertSame('::/4', $r['below']['prefix']);
+    }
+
+    public function test_input_127_below_caps_at_128(): void
+    {
+        // /127 → above=/124, below=/128 (cap).
+        $r = nibble_neighbours('2001:db8::/127');
+        $this->assertSame(124, $r['above']['length']);
+        $this->assertSame(128, $r['below']['length']);
+        $this->assertSame('2001:db8::/124', $r['above']['prefix']);
+    }
+
+    public function test_input_1(): void
+    {
+        // /1 → above=/0, below=/4.
+        $r = nibble_neighbours('::/1');
+        $this->assertSame(0, $r['above']['length']);
+        $this->assertSame(4, $r['below']['length']);
+        $this->assertSame('::/0', $r['above']['prefix']);
+        $this->assertSame('::/4', $r['below']['prefix']);
+    }
+
+    public function test_input_3(): void
+    {
+        // /3 → above=/0, below=/4.
+        $r = nibble_neighbours('2000::/3');
+        $this->assertSame(0, $r['above']['length']);
+        $this->assertSame(4, $r['below']['length']);
+        // 2000::/3 above-snapped to /0 zeroes all bits.
+        $this->assertSame('::/0', $r['above']['prefix']);
+        $this->assertSame('2000::/4', $r['below']['prefix']);
+    }
+
+    public function test_input_125(): void
+    {
+        // /125 → above=/124, below=/128.
+        $r = nibble_neighbours('2001:db8::/125');
+        $this->assertSame(124, $r['above']['length']);
+        $this->assertSame(128, $r['below']['length']);
+    }
+
+    public function test_input_carries_input_metadata(): void
+    {
+        $r = nibble_neighbours('2001:db8::/49');
+        $this->assertSame(49, $r['input']['length']);
+        // Input prefix is canonicalised (host bits zeroed beyond input length).
+        $this->assertSame('2001:db8::/49', $r['input']['prefix']);
+    }
+
+    public function test_host_bits_canonicalised_above(): void
+    {
+        // /49 with host bits set in the input — above (/48) zeroes them.
+        $r = nibble_neighbours('2001:db8:0:abcd::/49');
+        // The /49 boundary keeps the high bit of the 4th hextet (a=1010 → bit 0
+        // of the top nibble keeps with /49; rest is zeroed within the /49).
+        // Above is /48 — zero all of hextet 4 onwards.
+        $this->assertSame('2001:db8::/48', $r['above']['prefix']);
+    }
+
+    public function test_contains_64s_above_below(): void
+    {
+        $r = nibble_neighbours('2001:db8::/49');
+        // /48 contains 2^16 /64s = 65536.
+        $this->assertSame('65536', $r['above']['contains_64s']);
+        // /52 contains 2^12 /64s = 4096.
+        $this->assertSame('4096', $r['below']['contains_64s']);
+    }
+
+    public function test_contains_64s_at_64_boundary(): void
+    {
+        // Input /63 → above=/60, below=/64.
+        $r = nibble_neighbours('2001:db8::/63');
+        $this->assertSame(60, $r['above']['length']);
+        $this->assertSame(64, $r['below']['length']);
+        // /60 contains 2^4 = 16 /64s.
+        $this->assertSame('16', $r['above']['contains_64s']);
+        // /64 is exactly itself.
+        $this->assertSame('1', $r['below']['contains_64s']);
+    }
+
+    public function test_contains_64s_smaller_than_64(): void
+    {
+        // /67 → above=/64, below=/68.
+        $r = nibble_neighbours('2001:db8::/67');
+        $this->assertSame('1', $r['above']['contains_64s']);
+        $this->assertSame('subset of /64', $r['below']['contains_64s']);
+    }
+
+    public function test_invalid_missing_prefix_length(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        nibble_neighbours('2001:db8::');
+    }
+
+    public function test_invalid_address(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        nibble_neighbours('not-an-address/48');
+    }
+
+    public function test_invalid_length_negative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        nibble_neighbours('2001:db8::/-1');
+    }
+
+    public function test_invalid_length_too_large(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        nibble_neighbours('2001:db8::/129');
+    }
+
+    public function test_empty_input_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        nibble_neighbours('');
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `nibble_neighbours()` to `functions-prefix-plan6.php` (T8's module — same nibble math).
- Surfaces the nibble-aligned neighbours (above ≤ input length, below ≥ input length, capped at /128) of any IPv6 prefix.
- Useful for `ip6.arpa` reverse-zone delegation planning where non-nibble lengths require an explicit nibble-boundary decision.

Refs #388. Task 9 of the v3.5.0 release.

## Files

- **Modify** `Subnet-Calculator/includes/functions-prefix-plan6.php` — `nibble_neighbours()` + private `nibble6_mask_to_length()` helper.
- **Create** `Subnet-Calculator/api/v1/handlers/nibble6.php` — separate handler (one input: `prefix`).
- **Modify** `Subnet-Calculator/api/v1/index.php` — meta listing + route case.
- **Modify** `Subnet-Calculator/api/openapi.yaml` — new `Nibble6` tag + `/nibble6` operation.
- **Modify** `Subnet-Calculator/includes/request.php` — `sc_run_nibble6()` helper + POST trigger + GET shareable URL.
- **Modify** `Subnet-Calculator/templates/layout.php` — drawer with `data-tool="nibble"`.
- **Create** `testing/unit/Nibble6Test.php` — 18 tests (separate file, kept clean from T8 suite).
- **Modify** `testing/scripts/playwright_test.py` — `test_api_nibble6` + `test_ipv6_nibble_ui`.
- **Create** `docs/nibble6.md`; **Modify** `mkdocs.yml`.
- **Modify** `CHANGELOG.md` — entry under `[3.5.0]` → `Added`.

## Test plan

- [x] PHPUnit: 666 tests, 1451 assertions (T8's PrefixPlan6Test still passes unchanged).
- [x] PHPStan L9: clean.
- [x] PHPCS PSR-12: clean.
- [x] Spectral OpenAPI lint: 0 errors.
- [x] ESLint/Stylelint: clean (no new warnings).
- [x] Semgrep: 0 findings.
- [x] Playwright via `make test-docker`: 1841/1841 passed.
- [x] T8's `plan_prefix_delegation` and `PrefixPlan6Test` unchanged.
- [x] `functions-embedded-v4.php` and `EmbeddedV4Test.php` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)