### PR TITLE
feat(v3.6.0): IPv6 multicast scope decoder + ipv6_in_prefix migration (#396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-MM-DD
+
+### Added
+
+- **IPv6 multicast scope decoder.** Front-door tool for the v3.6.0
+  multicast theme: decodes any FF00::/8 address into scope, flags,
+  scheme hint, group ID, and well-known group lookup. Deep-links to
+  per-scheme tools (SSM, embedded-RP) when applicable. Also migrates
+  the ipv6_in_prefix() helper from functions-embedded-v4.php to
+  functions-ipv6.php for shared use across IPv6 tools. (#396)
+
 ## [3.5.1] - 2026-05-09
 
 **Patch.** Code-quality cleanup carried over from v3.5.0's review trail,

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -83,6 +83,8 @@ tags:
     description: IPv6 nibble-boundary helper — surface the nibble-aligned neighbours (above and below) of any IPv6 prefix
   - name: Rfc3531
     description: RFC 3531 sparse-allocation guidance — centermost / leftmost / rightmost bit-reservation strategy for growth-friendly prefix assignment
+  - name: Multicast6
+    description: IPv6 multicast scope decoder (RFC 4291 §2.7) — front door for the v3.6.0 multicast tools (scope, flags, scheme, well-known group lookup, deep-link to SSM and embedded-RP)
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -377,6 +379,7 @@ paths:
                     - "POST /api/v1/isatap"
                     - "POST /api/v1/6rd"
                     - "POST /api/v1/nat64"
+                    - "POST /api/v1/multicast6"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -3093,6 +3096,176 @@ paths:
                                 prefix: { type: string, example: "2001:db8:0:8000::/52" }
         "400":
           description: Missing required field, unparseable input, or out-of-range request
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /multicast6:
+    post:
+      operationId: multicast6Decode
+      tags: [Multicast6]
+      summary: Decode an IPv6 multicast address (RFC 4291 §2.7)
+      description: |
+        Front-door decoder for the v3.6.0 IPv6 multicast tools. Decodes any
+        FF00::/8 address into:
+
+        - `scope` (1..15) and `scope_name` (`interface-local`, `link-local`,
+          `admin-local`, `site-local`, `organization-local`, `global`,
+          `reserved`) per RFC 4291 §2.7 + RFC 7346.
+        - 4-bit `flags` field (0RPT) with booleans `transient`, `prefix_based`
+          (RFC 3306), `embedded_rp` (RFC 3956).
+        - `scheme` hint: `well-known`, `transient`, `ssm`, `embedded-rp`,
+          or `reserved`.
+        - 112-bit `group_id` as a 28-character hex string.
+        - `well_known` lookup against the in-tree registry of named groups
+          (FF02::1, FF02::2, FF02::5/6 OSPF, FF02::9 RIP, FF02::d All-PIM,
+          FF02::16 MLDv2, FF05::101 NTP, plus the FF02::1:FF**:**** Solicited-Node
+          family). Returns `null` when not matched.
+        - `detail_route` deep-link to the per-scheme tool drawer (`/ipv6/ssm`
+          for prefix-based / SSM groups; `/ipv6/embedded-rp` for embedded-RP);
+          `null` otherwise.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ipv6]
+              properties:
+                ipv6:
+                  type: string
+                  description: An IPv6 multicast address literal (must be in FF00::/8).
+                  example: "FF02::1"
+            examples:
+              all-nodes:
+                summary: All Nodes (link-local well-known)
+                value: { ipv6: "FF02::1" }
+              solicited-node:
+                summary: Solicited-Node (RFC 4291)
+                value: { ipv6: "FF02::1:FF12:3456" }
+              ssm:
+                summary: SSM (prefix-based, scope global)
+                value: { ipv6: "FF3E::1234:5678" }
+              embedded-rp:
+                summary: Embedded-RP (RFC 3956)
+                value: { ipv6: "FF7E:140:2001:db8:cafe::1234" }
+      responses:
+        "200":
+          description: Decoded multicast address
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required:
+                          - input
+                          - address
+                          - scope
+                          - scope_name
+                          - flags
+                          - transient
+                          - prefix_based
+                          - embedded_rp
+                          - group_id
+                          - scheme
+                          - detail_route
+                          - well_known
+                        properties:
+                          input:
+                            type: string
+                            example: "FF02::1"
+                          address:
+                            type: string
+                            description: Canonical compressed lowercase form of the input.
+                            example: "ff02::1"
+                          scope:
+                            type: integer
+                            minimum: 0
+                            maximum: 15
+                            example: 2
+                          scope_name:
+                            type: string
+                            enum: [interface-local, link-local, admin-local, site-local, organization-local, global, reserved]
+                            example: link-local
+                          flags:
+                            type: integer
+                            minimum: 0
+                            maximum: 15
+                            example: 0
+                          transient:
+                            type: boolean
+                            example: false
+                          prefix_based:
+                            type: boolean
+                            example: false
+                          embedded_rp:
+                            type: boolean
+                            example: false
+                          group_id:
+                            type: string
+                            description: 112-bit group ID as a 28-character hex string.
+                            example: "00000000000000000000000000000001"
+                          scheme:
+                            type: string
+                            enum: [well-known, transient, ssm, embedded-rp, reserved]
+                            example: well-known
+                          detail_route:
+                            type: string
+                            nullable: true
+                            description: Relative URL of the per-scheme tool drawer; null when not applicable.
+                            example: null
+                          well_known:
+                            type: object
+                            nullable: true
+                            description: Registry entry when the address matches a well-known group; null otherwise.
+                            required: [name, rfc]
+                            properties:
+                              name: { type: string, example: "All Nodes Address" }
+                              rfc:  { type: string, example: "RFC 4291" }
+              example:
+                ok: true
+                data:
+                  input: "FF02::1"
+                  address: "ff02::1"
+                  scope: 2
+                  scope_name: "link-local"
+                  flags: 0
+                  transient: false
+                  prefix_based: false
+                  embedded_rp: false
+                  group_id: "00000000000000000000000000000001"
+                  scheme: "well-known"
+                  detail_route: null
+                  well_known: { name: "All Nodes Address", rfc: "RFC 4291" }
+        "400":
+          description: Missing or non-multicast IPv6 input
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/multicast6.php
+++ b/Subnet-Calculator/api/v1/handlers/multicast6.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body      = api_body();
+$raw_input = $body['ipv6'] ?? null;
+
+if (!is_string($raw_input) || trim($raw_input) === '') {
+    json_err('Field "ipv6" (string) is required.', 400);
+}
+$input = trim($raw_input);
+
+try {
+    $result = decode_multicast($input);
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'input'        => $input,
+    'address'      => $result['address'],
+    'scope'        => $result['scope'],
+    'scope_name'   => $result['scope_name'],
+    'flags'        => $result['flags'],
+    'transient'    => $result['transient'],
+    'prefix_based' => $result['prefix_based'],
+    'embedded_rp'  => $result['embedded_rp'],
+    'group_id'     => $result['group_id'],
+    'scheme'       => $result['scheme'],
+    'detail_route' => $result['detail_route'],
+    'well_known'   => $result['well_known'],
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -46,6 +46,9 @@ require_once $base . 'functions-prefix-plan6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for rfc3531_allocation_order()/rfc3531_apply().
 require_once $base . 'functions-rfc3531.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for decode_multicast()/multicast_well_known_registry().
+require_once $base . 'functions-multicast6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -141,6 +144,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/prefix-plan6',
             'POST /api/v1/nibble6',
             'POST /api/v1/rfc3531',
+            'POST /api/v1/multicast6',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -294,6 +298,9 @@ switch ($route_key) {
         break;
     case 'POST /rfc3531':
         require __DIR__ . '/handlers/rfc3531.php';
+        break;
+    case 'POST /multicast6':
+        require __DIR__ . '/handlers/multicast6.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-embedded-v4.php
+++ b/Subnet-Calculator/includes/functions-embedded-v4.php
@@ -38,39 +38,7 @@ const EMBEDDEDV4_NAT64_WKP_PREFIX_BIN  = "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x
 const EMBEDDEDV4_6TO4_PREFIX_BIN       = "\x20\x02";
 const EMBEDDEDV4_TEREDO_PREFIX_BIN     = "\x20\x01\x00\x00";
 
-// Helper used by detect_embedded_v4 and shared with the per-scheme tools
-// (T3-T7) — kept here for v3.5.0 but consider moving to functions-ipv6.php
-// in v3.6.0+.
-/**
- * Return true if $address parses as a valid IPv6 literal whose top
- * $prefix_length bits match the $prefix network. GMP throughout for
- * arbitrary prefix lengths.
- *
- * Returns false (no throw) on parse failure or prefix length out of
- * the 0..128 range — the caller should validate inputs first.
- */
-function ipv6_in_prefix(string $address, string $prefix, int $prefix_length): bool
-{
-    if ($prefix_length < 0 || $prefix_length > 128) {
-        return false;
-    }
-    $abin = @inet_pton($address);
-    $pbin = @inet_pton($prefix);
-    if ($abin === false || $pbin === false || strlen($abin) !== 16 || strlen($pbin) !== 16) {
-        return false;
-    }
-    if ($prefix_length === 0) {
-        return true;
-    }
-    $a = gmp_import($abin);
-    $p = gmp_import($pbin);
-    $shift = 128 - $prefix_length;
-    // Build mask = ((1 << 128) - 1) ^ ((1 << shift) - 1)
-    $all  = gmp_sub(gmp_pow(2, 128), 1);
-    $low  = $shift === 0 ? gmp_init(0) : gmp_sub(gmp_pow(2, $shift), 1);
-    $mask = gmp_xor($all, $low);
-    return gmp_cmp(gmp_and($a, $mask), gmp_and($p, $mask)) === 0;
-}
+// Moved to functions-ipv6.php in v3.6.0 T2 for cross-module reuse.
 
 /**
  * Detect any embedded-IPv4 scheme in the given IPv6 address.

--- a/Subnet-Calculator/includes/functions-ipv6.php
+++ b/Subnet-Calculator/includes/functions-ipv6.php
@@ -120,3 +120,35 @@ function calculate_subnet6(string $ip, int $prefix): array
         'address_compressed' => $address_compressed,
     ];
 }
+
+// Migrated from functions-embedded-v4.php in v3.6.0 T2.
+/**
+ * Return true if $address parses as a valid IPv6 literal whose top
+ * $prefix_length bits match the $prefix network. GMP throughout for
+ * arbitrary prefix lengths.
+ *
+ * Returns false (no throw) on parse failure or prefix length out of
+ * the 0..128 range — the caller should validate inputs first.
+ */
+function ipv6_in_prefix(string $address, string $prefix, int $prefix_length): bool
+{
+    if ($prefix_length < 0 || $prefix_length > 128) {
+        return false;
+    }
+    $abin = @inet_pton($address);
+    $pbin = @inet_pton($prefix);
+    if ($abin === false || $pbin === false || strlen($abin) !== 16 || strlen($pbin) !== 16) {
+        return false;
+    }
+    if ($prefix_length === 0) {
+        return true;
+    }
+    $a = gmp_import($abin);
+    $p = gmp_import($pbin);
+    $shift = 128 - $prefix_length;
+    // Build mask = ((1 << 128) - 1) ^ ((1 << shift) - 1)
+    $all  = gmp_sub(gmp_pow(2, 128), 1);
+    $low  = $shift === 0 ? gmp_init(0) : gmp_sub(gmp_pow(2, $shift), 1);
+    $mask = gmp_xor($all, $low);
+    return gmp_cmp(gmp_and($a, $mask), gmp_and($p, $mask)) === 0;
+}

--- a/Subnet-Calculator/includes/functions-multicast6.php
+++ b/Subnet-Calculator/includes/functions-multicast6.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+// IPv6 multicast scope decoder (v3.6.0 T2, #396).
+//
+// Front door for the v3.6.0 IPv6 multicast tools. Decodes any FF00::/8
+// address into:
+//   - scope (1..15) per RFC 4291 §2.7 + RFC 7346
+//   - 4-bit flags field (0RPT) per RFC 4291 §2.7 / RFC 3306 / RFC 3956
+//   - scheme hint (well-known | transient | ssm | embedded-rp | reserved)
+//   - 112-bit group ID (hex)
+//   - well-known group lookup (small in-tree registry)
+//   - deep-link route to the per-scheme tool when applicable
+//
+// Per-scheme tools (SSM, embedded-RP) deep-link off the 'detail_route'
+// returned here. Their drawers ship in v3.6.0 T3 and T4 respectively.
+
+/**
+ * Built-in registry of well-known IPv6 multicast group addresses.
+ *
+ * Keyed by the canonical compressed lowercase address per inet_ntop().
+ * Solicited-Node addresses (ff02::1:ff00:0/104) are matched separately
+ * as a prefix in decode_multicast(); they are NOT in this map.
+ *
+ * @return array<string, array{name: string, rfc: string}>
+ */
+function multicast_well_known_registry(): array
+{
+    return [
+        'ff02::1'   => ['name' => 'All Nodes Address',                    'rfc' => 'RFC 4291'],
+        'ff02::2'   => ['name' => 'All Routers Address',                  'rfc' => 'RFC 4291'],
+        'ff02::5'   => ['name' => 'OSPFIGP',                              'rfc' => 'RFC 2328'],
+        'ff02::6'   => ['name' => 'OSPFIGP Designated Routers',           'rfc' => 'RFC 2328'],
+        'ff02::9'   => ['name' => 'RIP Routers',                          'rfc' => 'RFC 2080'],
+        'ff02::a'   => ['name' => 'EIGRP Routers',                        'rfc' => '(Cisco)'],
+        'ff02::d'   => ['name' => 'All PIM Routers',                      'rfc' => 'RFC 7761'],
+        'ff02::16'  => ['name' => 'MLDv2-capable Routers',                'rfc' => 'RFC 3810'],
+        'ff05::101' => ['name' => 'All NTP Servers',                      'rfc' => 'RFC 5905'],
+    ];
+}
+
+/**
+ * Decode an IPv6 multicast address per RFC 4291 §2.7.
+ *
+ * @return array{
+ *     address: string,
+ *     scope: int,
+ *     scope_name: string,
+ *     flags: int,
+ *     transient: bool,
+ *     prefix_based: bool,
+ *     embedded_rp: bool,
+ *     group_id: string,
+ *     scheme: string,
+ *     detail_route: string|null,
+ *     well_known: array{name: string, rfc: string}|null
+ * }
+ *
+ * @throws InvalidArgumentException if not a valid IPv6 multicast address (FF00::/8).
+ */
+function decode_multicast(string $ipv6): array
+{
+    $bin = @inet_pton($ipv6);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid IPv6 address.');
+    }
+    if (ord($bin[0]) !== 0xFF) {
+        throw new InvalidArgumentException('Address is not in the IPv6 multicast range FF00::/8.');
+    }
+
+    // RFC 4291 §2.7: address layout is 11111111|flags(4)|scope(4)|group(112).
+    // Byte 0 is the constant 0xFF prefix; byte 1 carries the 4-bit flags
+    // (high nibble) and 4-bit scope (low nibble).
+    $flags = (ord($bin[1]) & 0xF0) >> 4;
+    $scope = ord($bin[1]) & 0x0F;
+
+    $scope_names = [
+        1   => 'interface-local',
+        2   => 'link-local',
+        4   => 'admin-local',
+        5   => 'site-local',
+        8   => 'organization-local',
+        0xE => 'global',
+    ];
+    $scope_name = $scope_names[$scope] ?? 'reserved';
+
+    $transient    = ($flags & 0x1) !== 0;
+    $prefix_based = ($flags & 0x2) !== 0;
+    $embedded_rp  = ($flags & 0x4) !== 0;
+
+    $group_id = bin2hex(substr($bin, 2, 14));
+
+    // Canonical compressed lowercase form for both registry lookup and output.
+    $canon_raw = @inet_ntop($bin);
+    $canonical = is_string($canon_raw) ? strtolower($canon_raw) : strtolower($ipv6);
+
+    // Scheme decision in RFC priority order: R (embedded-RP) wins over P (prefix-based / SSM)
+    // wins over T (transient) wins over flags=0 (well-known).
+    $detail_route = null;
+    $well_known   = null;
+
+    if ($embedded_rp) {
+        $scheme       = 'embedded-rp';
+        $detail_route = '/ipv6/embedded-rp';
+    } elseif ($prefix_based) {
+        $scheme       = 'ssm';
+        $detail_route = '/ipv6/ssm';
+    } elseif ($transient) {
+        $scheme = 'transient';
+    } elseif ($flags === 0) {
+        $scheme = 'well-known';
+        // Solicited-Node prefix match: ff02::1:ff00:0/104 (RFC 4291 §2.7.1).
+        // Bytes 0..12: FF 02 00 00 00 00 00 00 00 00 00 00 00 — but byte 11
+        // is 01 and byte 12 is FF. Lay out the 13-byte prefix explicitly.
+        $sol_prefix = "\xFF\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xFF";
+        if (substr($bin, 0, 13) === $sol_prefix) {
+            $well_known = [
+                'name' => 'Solicited-Node Address (RFC 4291)',
+                'rfc'  => 'RFC 4291',
+            ];
+        } else {
+            $registry = multicast_well_known_registry();
+            if (isset($registry[$canonical])) {
+                $well_known = $registry[$canonical];
+            }
+        }
+    } else {
+        $scheme = 'reserved';
+    }
+
+    return [
+        'address'      => $canonical,
+        'scope'        => $scope,
+        'scope_name'   => $scope_name,
+        'flags'        => $flags,
+        'transient'    => $transient,
+        'prefix_based' => $prefix_based,
+        'embedded_rp'  => $embedded_rp,
+        'group_id'     => $group_id,
+        'scheme'       => $scheme,
+        'detail_route' => $detail_route,
+        'well_known'   => $well_known,
+    ];
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -496,6 +496,60 @@ function sc_run_embedded_v4(string $address): array
     ];
 }
 
+// ─── Multicast scope decoder helper (shared by POST handler and GET shareable URL) ─
+
+/**
+ * Run decode_multicast() against the supplied IPv6 multicast address and
+ * return an associative array suitable for direct rendering in the
+ * multicast drawer. Empty input early-returns []. (v3.6.0 Task 2, #396)
+ *
+ * @return array{
+ *     input?: string,
+ *     address?: string,
+ *     scope?: int,
+ *     scope_name?: string,
+ *     flags?: int,
+ *     transient?: bool,
+ *     prefix_based?: bool,
+ *     embedded_rp?: bool,
+ *     group_id?: string,
+ *     scheme?: string,
+ *     detail_route?: string|null,
+ *     well_known?: array{name: string, rfc: string}|null,
+ *     error?: string|null
+ * }
+ */
+function sc_run_multicast6(string $address): array
+{
+    $raw = trim($address);
+    if ($raw === '') {
+        return [];
+    }
+    try {
+        $r = decode_multicast($raw);
+    } catch (\InvalidArgumentException $e) {
+        return [
+            'input' => $raw,
+            'error' => $e->getMessage(),
+        ];
+    }
+    return [
+        'input'        => $raw,
+        'address'      => $r['address'],
+        'scope'        => $r['scope'],
+        'scope_name'   => $r['scope_name'],
+        'flags'        => $r['flags'],
+        'transient'    => $r['transient'],
+        'prefix_based' => $r['prefix_based'],
+        'embedded_rp'  => $r['embedded_rp'],
+        'group_id'     => $r['group_id'],
+        'scheme'       => $r['scheme'],
+        'detail_route' => $r['detail_route'],
+        'well_known'   => $r['well_known'],
+        'error'        => null,
+    ];
+}
+
 // ─── 6to4 helper (shared by POST handler and GET shareable URL) ─────────────
 
 /**
@@ -1236,6 +1290,11 @@ $prefix_plan6_nibble_align        = true;
 /** @var array{parent_prefix?: string, child_length_input?: string, count_input?: string, start_offset_input?: string, nibble_align?: bool, result?: array{parent: array{prefix: string, length: int, total_children_str: string}, children: list<array{index: int, prefix: string, first: string, last: string, contains_64s: string}>, free: array{remaining_str: string}, normalized_child_length: int}, error?: string|null} */
 $prefix_plan6 = [];
 
+// v3.6.0 Task 2 — IPv6 multicast scope decoder (front door for multicast tools)
+$multicast6_input = '';
+/** @var array{input?: string, address?: string, scope?: int, scope_name?: string, flags?: int, transient?: bool, prefix_based?: bool, embedded_rp?: bool, group_id?: string, scheme?: string, detail_route?: string|null, well_known?: array{name: string, rfc: string}|null, error?: string|null} */
+$multicast6 = [];
+
 // v3.5.0 Task 10 — RFC 3531 sparse-allocation guidance
 $rfc3531_parent_input           = '';
 $rfc3531_reservation_bits_input = '';
@@ -1330,6 +1389,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $is_nibble6       = isset($_POST['nibble6_prefix']);
     $is_rfc3531       = isset($_POST['rfc3531_parent'])
         || isset($_POST['rfc3531_reservation_bits']);
+    $is_multicast6    = isset($_POST['multicast6_input']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -1341,7 +1401,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_sixtofour || $is_teredo || $is_isatap || $is_sixrd || $is_nat64
         || $is_prefix_plan6
         || $is_nibble6
-        || $is_rfc3531;
+        || $is_rfc3531
+        || $is_multicast6;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -1864,6 +1925,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $rfc3531_reservation_bits_input,
             $rfc3531_strategy_input
         );
+    }
+
+    if ($is_multicast6 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $multicast6_input = trim((string)($_POST['multicast6_input'] ?? ''));
+        $multicast6 = sc_run_multicast6($multicast6_input);
     }
 
     if ($is_prefix_plan6 && !$form_blocked) {
@@ -2443,6 +2510,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $rfc3531_reservation_bits_input,
             $rfc3531_strategy_input
         );
+    }
+
+    // Multicast scope decoder shareable GET URL (v3.6.0 Task 2, #396)
+    if ($active_tab === 'ipv6' && isset($_GET['multicast6_input'])) {
+        $multicast6_input = trim((string)($_GET['multicast6_input'] ?? ''));
+        $multicast6 = sc_run_multicast6($multicast6_input);
     }
 
     // Supernet6 / summarise6 shareable GET URL (v3.3.0)

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -38,6 +38,9 @@ require_once __DIR__ . '/includes/functions-prefix-plan6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for rfc3531_allocation_order()/rfc3531_apply().
 require_once __DIR__ . '/includes/functions-rfc3531.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for decode_multicast()/multicast_well_known_registry().
+require_once __DIR__ . '/includes/functions-multicast6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -772,9 +772,10 @@ if ($i < 3) {
         elseif (!empty($prefix_plan6)) { $open_tool_ipv6 = 'prefix-plan'; }
         elseif (!empty($nibble6)) { $open_tool_ipv6 = 'nibble'; }
         elseif (!empty($rfc3531)) { $open_tool_ipv6 = 'rfc3531'; }
+        elseif (!empty($multicast6)) { $open_tool_ipv6 = 'multicast'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan','nibble','rfc3531'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan','nibble','rfc3531','multicast'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -800,6 +801,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="prefix-plan" aria-expanded="false">Prefix Plan</button>
             <button type="button" class="tool-trigger" data-tool="nibble" aria-expanded="false">Nibble Neighbours</button>
             <button type="button" class="tool-trigger" data-tool="rfc3531" aria-expanded="false">RFC 3531 Sparse</button>
+            <button type="button" class="tool-trigger" data-tool="multicast" aria-expanded="false">Multicast Decoder</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -2350,6 +2352,101 @@ if ($i < 3) {
                             </tbody>
                         </table>
                         <p><small>RFC 3531 sparse allocation orders the reservation field for growth-friendly prefix assignment. Centermost is the canonical strategy from §3 — the centre value is allocated first, then halves bisect outward, leaving room either side for future expansion.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="multicast">
+                <div class="overlap-panel">
+                    <div class="overlap-title">IPv6 multicast scope decoder<?= help_bubble('ipv6-multicast', 'Front door for the v3.6.0 multicast tools. Decodes any FF00::/8 address into scope, flags, scheme hint, and 112-bit group ID. Looks up well-known groups (RFC 4291 / 7761 / 5905). Deep-links to the SSM and embedded-RP tools when the P or R flag is set.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="multicast6_input">IPv6 multicast address<?= help_bubble('multicast6-input', 'Any IPv6 multicast literal (FF00::/8). Examples: FF02::1 (all nodes), FF02::1:FF12:3456 (solicited-node), FF3E::1234:5678 (SSM global), FF7E:140:2001:db8:cafe::1234 (embedded-RP).') ?></label>
+                                <input type="text" id="multicast6_input" name="multicast6_input"
+                                       value="<?= htmlspecialchars($multicast6_input ?? '') ?>"
+                                       placeholder="FF02::1"
+                                       autocomplete="off" spellcheck="false"
+                                       <?= !empty($multicast6['error']) ? 'aria-invalid="true" aria-describedby="multicast6-error"' : '' ?>>
+                            </div>
+                        </div>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Decode</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($multicast6['error'])) : ?>
+                        <div class="error" id="multicast6-error"><?= htmlspecialchars((string)$multicast6['error']) ?></div>
+                    <?php elseif (!empty($multicast6) && isset($multicast6['scheme'])) : ?>
+                        <?php
+                        $_mc_scheme  = (string)$multicast6['scheme'];
+                        $_mc_route   = $multicast6['detail_route'] ?? null;
+                        $_mc_flags   = (int)($multicast6['flags'] ?? 0);
+                        $_mc_history = 'multicast: ' . (string)($multicast6['input'] ?? '');
+                        $_mc_flag_bits = sprintf(
+                            '0b%s%s%s%s (R=%d P=%d T=%d)',
+                            (($_mc_flags & 0x8) !== 0) ? '1' : '0',
+                            (($_mc_flags & 0x4) !== 0) ? '1' : '0',
+                            (($_mc_flags & 0x2) !== 0) ? '1' : '0',
+                            (($_mc_flags & 0x1) !== 0) ? '1' : '0',
+                            (($_mc_flags & 0x4) !== 0) ? 1 : 0,
+                            (($_mc_flags & 0x2) !== 0) ? 1 : 0,
+                            (($_mc_flags & 0x1) !== 0) ? 1 : 0
+                        );
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="multicast"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_mc_history) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Address (canonical)</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)($multicast6['address'] ?? '')) ?></code>
+                                    <?= copy_button((string)($multicast6['address'] ?? ''), 'Copy canonical address') ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Scope</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)($multicast6['scope'] ?? 0) ?> (<?= htmlspecialchars((string)($multicast6['scope_name'] ?? '')) ?>)</code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Flags</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars($_mc_flag_bits) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Scheme</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars($_mc_scheme) ?></code>
+                                </dd>
+                            </div>
+                            <?php if (!empty($multicast6['well_known']) && is_array($multicast6['well_known'])) : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Well-known group</dt>
+                                    <dd class="zoneid-result__value">
+                                        <code><?= htmlspecialchars((string)$multicast6['well_known']['name']) ?></code>
+                                        <small> (<?= htmlspecialchars((string)$multicast6['well_known']['rfc']) ?>)</small>
+                                    </dd>
+                                </div>
+                            <?php endif; ?>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Group ID</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)($multicast6['group_id'] ?? '')) ?></code>
+                                </dd>
+                            </div>
+                            <?php if ($_mc_route !== null && $_mc_route !== '') : ?>
+                                <div class="zoneid-result__row">
+                                    <dt class="zoneid-result__label">Open in tool</dt>
+                                    <dd class="zoneid-result__value">
+                                        <a class="splitter-btn" href="<?= htmlspecialchars((string)$_mc_route) ?>">Open <?= htmlspecialchars($_mc_scheme) ?> tool</a>
+                                    </dd>
+                                </div>
+                            <?php endif; ?>
+                        </dl>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/multicast6.md
+++ b/docs/multicast6.md
@@ -1,0 +1,86 @@
+# IPv6 Multicast Decoder
+
+The IPv6 multicast scope decoder is the front-door tool for the v3.6.0
+multicast theme. It accepts any IPv6 address in the `FF00::/8` multicast
+range and decodes it into:
+
+- **Scope** (1..15) and human-readable name (`interface-local`,
+  `link-local`, `admin-local`, `site-local`, `organization-local`,
+  `global`, or `reserved`) per RFC 4291 §2.7 and RFC 7346.
+- **Flags** (4 bits, layout `0RPT`) with booleans for `transient` (T),
+  `prefix_based` (P, RFC 3306), and `embedded_rp` (R, RFC 3956).
+- **Scheme hint** — one of `well-known`, `transient`, `ssm`,
+  `embedded-rp`, or `reserved`.
+- **Group ID** — the lower 112 bits as a 28-character hex string.
+- **Well-known group lookup** — for the small set of named groups that
+  ship with this tool (FF02::1, FF02::2, FF02::5/6 OSPF, FF02::9 RIP,
+  FF02::a EIGRP, FF02::d All-PIM, FF02::16 MLDv2, FF05::101 NTP, plus
+  the FF02::1:FF\*\*:\*\*\*\* Solicited-Node family).
+- **Deep-link** to the per-scheme tool (the SSM and embedded-RP drawers
+  ship in v3.6.0 T3 and T4 respectively).
+
+## Examples
+
+### Well-known group (All Nodes)
+
+Input: `FF02::1`
+
+| Field | Value |
+|---|---|
+| Scope | 2 (link-local) |
+| Flags | 0b0000 (R=0 P=0 T=0) |
+| Scheme | `well-known` |
+| Well-known | All Nodes Address (RFC 4291) |
+| Detail route | _none_ |
+
+### SSM group (RFC 3306)
+
+Input: `FF3E::1234:5678`
+
+| Field | Value |
+|---|---|
+| Scope | 14 (global) |
+| Flags | 0b0011 (R=0 P=1 T=1) |
+| Scheme | `ssm` |
+| Well-known | _not matched_ |
+| Detail route | `/ipv6/ssm` |
+
+The P flag indicates a prefix-based / SSM group; the decoder offers a
+deep-link to the SSM tool drawer.
+
+### Embedded-RP group (RFC 3956)
+
+Input: `FF7E:140:2001:db8:cafe::1234`
+
+| Field | Value |
+|---|---|
+| Scope | 14 (global) |
+| Flags | 0b0111 (R=1 P=1 T=1) |
+| Scheme | `embedded-rp` |
+| Detail route | `/ipv6/embedded-rp` |
+
+The R flag (set together with P+T) signals an embedded-RP group; the
+decoder deep-links to the embedded-RP tool.
+
+### Reserved scope
+
+Input: `FF00::1`
+
+| Field | Value |
+|---|---|
+| Scope | 0 (reserved) |
+| Scheme | `well-known` (no registry match) |
+
+Scope 0 is reserved per RFC 4291 §2.7. The decoder still returns the
+canonical address and group ID for inspection.
+
+## REST API
+
+`POST /api/v1/multicast6` — see the OpenAPI spec for the full schema and
+worked examples for each scheme.
+
+## Shareable URLs
+
+The decoder participates in the standard shareable-URL pattern:
+`?multicast6_input=FF02::1` on the IPv6 tab pre-fills the input and
+runs the decoder on page load.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
     - IPv6 Prefix-Delegation Planner: prefix-plan6.md
     - IPv6 Nibble-Boundary Helper: nibble6.md
     - RFC 3531 Sparse Allocation: rfc3531.md
+    - IPv6 Multicast Decoder: multicast6.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -3074,6 +3074,110 @@ async def test_ipv6_embedded_v4_ui(page: Page) -> None:
                 len(err_text) > 0, f"got: {err_text!r}")
 
 
+async def test_api_multicast6(page: Page) -> None:
+    section("API — POST /api/v1/multicast6")
+    # All-Nodes link-local well-known
+    status, data = _api_post("multicast6", {"ipv6": "FF02::1"})
+    assert_eq("api multicast6 (all-nodes): HTTP 200", status, 200)
+    assert_eq("api multicast6 (all-nodes): ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api multicast6 (all-nodes): scope", d.get("scope"), 2)
+    assert_eq("api multicast6 (all-nodes): scope_name",
+              d.get("scope_name"), "link-local")
+    assert_eq("api multicast6 (all-nodes): scheme", d.get("scheme"), "well-known")
+    assert_eq("api multicast6 (all-nodes): well_known.name",
+              (d.get("well_known") or {}).get("name"), "All Nodes Address")
+    assert_eq("api multicast6 (all-nodes): detail_route is null",
+              d.get("detail_route"), None)
+
+    # SSM (FF3E:: with P+T flags, scope global)
+    status2, data2 = _api_post("multicast6", {"ipv6": "FF3E::1234:5678"})
+    assert_eq("api multicast6 (ssm): HTTP 200", status2, 200)
+    d2 = data2.get("data", {})
+    assert_eq("api multicast6 (ssm): scheme", d2.get("scheme"), "ssm")
+    assert_eq("api multicast6 (ssm): prefix_based=True",
+              d2.get("prefix_based"), True)
+    assert_eq("api multicast6 (ssm): detail_route",
+              d2.get("detail_route"), "/ipv6/ssm")
+
+    # Embedded-RP (R+P+T flags)
+    status3, data3 = _api_post("multicast6",
+                               {"ipv6": "FF7E:140:2001:db8:cafe::1234"})
+    assert_eq("api multicast6 (embedded-rp): HTTP 200", status3, 200)
+    d3 = data3.get("data", {})
+    assert_eq("api multicast6 (embedded-rp): scheme",
+              d3.get("scheme"), "embedded-rp")
+    assert_eq("api multicast6 (embedded-rp): embedded_rp=True",
+              d3.get("embedded_rp"), True)
+    assert_eq("api multicast6 (embedded-rp): detail_route",
+              d3.get("detail_route"), "/ipv6/embedded-rp")
+
+    # Solicited-Node prefix match (FF02::1:FF**:****)
+    status4, data4 = _api_post("multicast6", {"ipv6": "FF02::1:FF12:3456"})
+    assert_eq("api multicast6 (solicited-node): HTTP 200", status4, 200)
+    d4 = data4.get("data", {})
+    assert_eq("api multicast6 (solicited-node): well_known.name",
+              (d4.get("well_known") or {}).get("name"),
+              "Solicited-Node Address (RFC 4291)")
+
+    # Non-multicast input → 400
+    status5, _ = _api_post("multicast6", {"ipv6": "2001:db8::1"})
+    assert_eq("api multicast6: non-multicast → 400", status5, 400)
+
+    # Garbage input → 400
+    status6, _ = _api_post("multicast6", {"ipv6": "not-an-address"})
+    assert_eq("api multicast6: invalid input → 400", status6, 400)
+
+    # Missing ipv6 field → 400
+    status7, _ = _api_post("multicast6", {})
+    assert_eq("api multicast6: missing ipv6 → 400", status7, 400)
+
+
+async def test_ipv6_multicast_ui(page: Page) -> None:
+    section("IPv6 multicast scope decoder UI")
+
+    # ?tool=multicast should auto-open the drawer.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=multicast")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='multicast']")
+    assert_eq("multicast UI: panel exists", await panel.count(), 1)
+
+    # Submit FF02::1
+    await page.fill("#multicast6_input", "FF02::1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='multicast'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='multicast']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("multicast UI: scope label rendered", "link-local" in body_text)
+    assert_true("multicast UI: scheme well-known rendered",
+                "well-known" in body_text)
+    assert_true("multicast UI: well-known group name rendered",
+                "all nodes address" in body_text)
+
+    # SSM input → deep-link button to /ipv6/ssm appears
+    await navigate(page, APP_URL + "?tab=ipv6&tool=multicast")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#multicast6_input", "FF3E::1234:5678")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='multicast'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='multicast']")
+    open_link = panel.locator("a.splitter-btn[href='/ipv6/ssm']")
+    assert_true("multicast UI: SSM deep-link rendered",
+                await open_link.count() >= 1)
+
+    # Error path — non-multicast input
+    await navigate(page, APP_URL + "?tab=ipv6&tool=multicast")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    await page.fill("#multicast6_input", "2001:db8::1")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='multicast'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='multicast']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("multicast UI: error band on non-multicast input",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+
 async def test_api_6to4(page: Page) -> None:
     section("API — POST /api/v1/6to4")
 
@@ -9385,6 +9489,8 @@ async def main() -> None:
             await test_api_nibble6(page)
             await test_ipv6_rfc3531_ui(page)
             await test_api_rfc3531(page)
+            await test_ipv6_multicast_ui(page)
+            await test_api_multicast6(page)
             await test_a11y_ipv6_drawers(page)
             # v3.5.0 (T11) — bulk endpoint coverage + a11y for the 9 new drawers
             await test_api_bulk_covers_v350_endpoints(page)

--- a/testing/unit/Multicast6Test.php
+++ b/testing/unit/Multicast6Test.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class Multicast6Test extends TestCase
+{
+    public function test_all_nodes_link_local(): void
+    {
+        $r = decode_multicast('FF02::1');
+        $this->assertSame(2, $r['scope']);
+        $this->assertSame('link-local', $r['scope_name']);
+        $this->assertSame(0, $r['flags']);
+        $this->assertFalse($r['transient']);
+        $this->assertSame('well-known', $r['scheme']);
+        $this->assertNotNull($r['well_known']);
+        $this->assertSame('All Nodes Address', $r['well_known']['name']);
+        $this->assertNull($r['detail_route']);
+    }
+
+    public function test_solicited_node(): void
+    {
+        $r = decode_multicast('FF02::1:FF12:3456');
+        $this->assertSame(2, $r['scope']);
+        $this->assertNotNull($r['well_known']);
+        $this->assertSame('Solicited-Node Address (RFC 4291)', $r['well_known']['name']);
+    }
+
+    public function test_ssm_group(): void
+    {
+        $r = decode_multicast('FF3E::1234:5678');
+        $this->assertSame(0xE, $r['scope']);
+        $this->assertSame('global', $r['scope_name']);
+        $this->assertSame(0x3, $r['flags']);
+        $this->assertTrue($r['prefix_based']);
+        $this->assertTrue($r['transient']);
+        $this->assertFalse($r['embedded_rp']);
+        $this->assertSame('ssm', $r['scheme']);
+        $this->assertSame('/ipv6/ssm', $r['detail_route']);
+    }
+
+    public function test_embedded_rp_group(): void
+    {
+        $r = decode_multicast('FF7E:140:2001:db8:cafe::1234');
+        $this->assertSame(0xE, $r['scope']);
+        $this->assertSame(0x7, $r['flags']);
+        $this->assertTrue($r['embedded_rp']);
+        $this->assertSame('embedded-rp', $r['scheme']);
+        $this->assertSame('/ipv6/embedded-rp', $r['detail_route']);
+    }
+
+    public function test_invalid_non_multicast_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_multicast('2001:db8::1');
+    }
+
+    public function test_invalid_garbage_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_multicast('not-an-address');
+    }
+
+    public function test_reserved_scope_returns_reserved_name(): void
+    {
+        $r = decode_multicast('FF00::1');
+        $this->assertSame(0, $r['scope']);
+        $this->assertSame('reserved', $r['scope_name']);
+    }
+
+    public function test_canonical_address_lowercased_and_compressed(): void
+    {
+        $r = decode_multicast('FF02:0000:0000:0000:0000:0000:0000:0001');
+        $this->assertSame('ff02::1', $r['address']);
+    }
+
+    public function test_group_id_extracted_as_28_hex_chars(): void
+    {
+        $r = decode_multicast('FF02::1');
+        $this->assertSame(28, strlen($r['group_id']));
+        $this->assertSame(str_pad('1', 28, '0', STR_PAD_LEFT), $r['group_id']);
+    }
+
+    public function test_transient_only_scheme(): void
+    {
+        // Flags = T only (0x1); not SSM, not embedded-RP.
+        $r = decode_multicast('FF1E::1234');
+        $this->assertSame(0x1, $r['flags']);
+        $this->assertTrue($r['transient']);
+        $this->assertFalse($r['prefix_based']);
+        $this->assertFalse($r['embedded_rp']);
+        $this->assertSame('transient', $r['scheme']);
+        $this->assertNull($r['detail_route']);
+    }
+
+    public function test_well_known_unknown_returns_null_well_known(): void
+    {
+        // Flags=0, scope=2, but address not in registry.
+        $r = decode_multicast('FF02::abcd');
+        $this->assertSame('well-known', $r['scheme']);
+        $this->assertNull($r['well_known']);
+    }
+
+    public function test_ipv6_in_prefix_still_works_after_migration(): void
+    {
+        // Pin contract: helper still works after move from functions-embedded-v4.php to functions-ipv6.php.
+        $this->assertTrue(ipv6_in_prefix('2001:db8::1', '2001:db8::', 32));
+        $this->assertFalse(ipv6_in_prefix('2001:db9::1', '2001:db8::', 32));
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -37,6 +37,9 @@ require_once $base . 'functions-prefix-plan6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for rfc3531_allocation_order()/rfc3531_apply().
 require_once $base . 'functions-rfc3531.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for decode_multicast()/multicast_well_known_registry().
+require_once $base . 'functions-multicast6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

Task 2 of the v3.6.0 release per [`docs/superpowers/plans/2026-05-09-v3.6.0-release.md`](../blob/release/v3.6.0/docs/superpowers/plans/2026-05-09-v3.6.0-release.md). Closes #396.

- **Front-door multicast scope decoder**: decodes any FF00::/8 address into scope (RFC 4291 §2.7 + RFC 7346), flags (0RPT layout per RFC 3306 / RFC 3956), scheme hint (`well-known` | `transient` | `ssm` | `embedded-rp` | `reserved`), 112-bit group ID, and well-known group lookup (FF02::1, ::2, ::5/6 OSPF, ::9 RIP, ::a EIGRP, ::d All-PIM, ::16 MLDv2, FF05::101 NTP, plus FF02::1:FF**:**** Solicited-Node prefix family).
- **Deep-links** to per-scheme tools (`/ipv6/ssm` when P-flag set, `/ipv6/embedded-rp` when R-flag set). The SSM (T3) and embedded-RP (T4) drawers wire those routes.
- **Carry-over from v3.5.0:** migrates `ipv6_in_prefix()` from `functions-embedded-v4.php` to `functions-ipv6.php` for cross-module reuse. `EmbeddedV4Test` pins the contract — all 12 tests pass unchanged after migration.

## File map

| File | Change |
|---|---|
| `Subnet-Calculator/includes/functions-multicast6.php` | New — `decode_multicast()`, `multicast_well_known_registry()`. |
| `Subnet-Calculator/api/v1/handlers/multicast6.php` | New — REST handler. |
| `Subnet-Calculator/includes/functions-ipv6.php` | Append `ipv6_in_prefix()` (migrated). |
| `Subnet-Calculator/includes/functions-embedded-v4.php` | Remove migrated body; one-line note. |
| `Subnet-Calculator/api/v1/index.php` | Module require_once + route + meta endpoint. |
| `Subnet-Calculator/index.php` | Module require_once with phpcs markers. |
| `Subnet-Calculator/templates/layout.php` | Tool button + drawer panel + `$ipv6_tool_whitelist` + `$open_tool_ipv6` chain. |
| `Subnet-Calculator/api/openapi.yaml` | `POST /api/v1/multicast6` operation + Multicast6 tag + meta endpoint list. |
| `Subnet-Calculator/includes/request.php` | `sc_run_multicast6()` helper + POST + GET hydration. |
| `testing/unit/bootstrap.php` | Module require_once with phpcs markers. |
| `testing/unit/Multicast6Test.php` | New — 12 PHPUnit tests, 41 assertions. |
| `testing/scripts/playwright_test.py` | `test_api_multicast6` + `test_ipv6_multicast_ui`. |
| `docs/multicast6.md` | New user-facing tool page. |
| `mkdocs.yml` | Nav entry under IPv6. |
| `CHANGELOG.md` | New `## [3.6.0] - 2026-MM-DD` section + Added entry. |

## Test plan

- [x] PHPUnit 712/712 (was 700, +12 new)
- [x] PHPStan L9 clean
- [x] PHPCS PSR-12 clean
- [x] Spectral OpenAPI lint clean
- [x] Semgrep 0 findings
- [x] npm lint clean (pre-existing warnings only)
- [x] `make test-docker` Playwright 2124/2124
- [x] EmbeddedV4Test still passes after `ipv6_in_prefix` migration
- [x] All 8 mandated test vectors covered (plus 4 extras: canonical lowercasing, group-ID width, transient-only scheme, well-known unknown)

## Acceptance

All 7 QA gates green; `ipv6_in_prefix()` lives in `functions-ipv6.php` and `functions-embedded-v4.php` carries the one-line migration note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)