### PR TITLE
feat(v3.6.0): Embedded-RP multicast (RFC 3956) (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SSM / unicast-prefix-based multicast (RFC 3306).** Build and decode
   `FF3x::/12` group addresses with embedded unicast prefix. Composes
   with the multicast scope decoder via deep-link. (#398)
+- **Embedded-RP multicast (RFC 3956).** Build and decode `FF7x::/12`
+  multicast groups with embedded RP address and RIID. Composes with
+  the multicast scope decoder via deep-link. (#397)
 
 ## [3.5.1] - 2026-05-09
 

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -87,6 +87,8 @@ tags:
     description: IPv6 multicast scope decoder (RFC 4291 §2.7) — front door for the v3.6.0 multicast tools (scope, flags, scheme, well-known group lookup, deep-link to SSM and embedded-RP)
   - name: Ssm6
     description: SSM / unicast-prefix-based IPv6 multicast (RFC 3306 / RFC 4607) — bidirectional encode/decode of FF3x::/12 group addresses with embedded unicast prefix and 32-bit group ID
+  - name: EmbeddedRp6
+    description: Embedded-RP IPv6 multicast (RFC 3956) — bidirectional encode/decode of FF7x::/12 group addresses with the Rendezvous Point address and 4-bit RIID embedded directly in the group
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -383,6 +385,7 @@ paths:
                     - "POST /api/v1/nat64"
                     - "POST /api/v1/multicast6"
                     - "POST /api/v1/ssm6"
+                    - "POST /api/v1/embedded-rp6"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -3426,6 +3429,182 @@ paths:
                   group_id: 305419896
         "400":
           description: Missing field or invalid SSM input
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /embedded-rp6:
+    post:
+      operationId: embeddedRp6Build
+      tags: [EmbeddedRp6]
+      summary: Build or decode an embedded-RP multicast group (RFC 3956)
+      description: |
+        Bidirectional tool for the FF7x::/12 embedded-RP multicast range.
+        Encodes the Rendezvous Point address + RP prefix length + 4-bit
+        RIID + scope + 32-bit group ID into an embedded-RP group address,
+        or reverses the process. The flag nibble is fixed at 0x7
+        (R + P + T); SSM-only groups (P + T = 0x3) are deliberately
+        rejected and routed to the SSM tool. The RP prefix length is
+        restricted to 0..64 because only the upper 64 bits of the RP
+        prefix fit in the multicast address per RFC 3956 §4.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  required: [mode, rp_address, rp_prefix_length, riid, scope, group_id]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [encode]
+                    rp_address:
+                      type: string
+                      description: Rendezvous Point IPv6 address. Only the upper bits selected by `rp_prefix_length` are encoded; the host suffix is replaced by `riid`.
+                      example: "2001:db8:cafe::1"
+                    rp_prefix_length:
+                      type: integer
+                      minimum: 0
+                      maximum: 64
+                      example: 48
+                    riid:
+                      type: integer
+                      minimum: 0
+                      maximum: 15
+                      description: 4-bit RP interface ID.
+                      example: 1
+                    scope:
+                      type: integer
+                      minimum: 1
+                      maximum: 15
+                      example: 14
+                    group_id:
+                      type: integer
+                      minimum: 0
+                      maximum: 4294967295
+                      example: 305419896
+                - type: object
+                  required: [mode, ipv6]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [decode]
+                    ipv6:
+                      type: string
+                      description: An embedded-RP multicast address in FF7x::/12.
+                      example: "ff7e:130:2001:db8:cafe:0:1234:5678"
+            examples:
+              encode-rfc-3956-example:
+                summary: RFC 3956 worked example (encode)
+                value:
+                  mode: encode
+                  rp_address: "2001:db8:cafe::1"
+                  rp_prefix_length: 48
+                  riid: 1
+                  scope: 14
+                  group_id: 305419896
+              decode-round-trip:
+                summary: Round-trip decode of the worked example
+                value: { mode: decode, ipv6: "ff7e:130:2001:db8:cafe:0:1234:5678" }
+      responses:
+        "200":
+          description: Built or decoded embedded-RP multicast group
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required:
+                          - mode
+                          - address
+                          - scope
+                          - rp_prefix
+                          - rp_prefix_length
+                          - rp_address
+                          - riid
+                          - group_id
+                        properties:
+                          mode:
+                            type: string
+                            enum: [encode, decode]
+                            example: encode
+                          input:
+                            type: string
+                            description: Echoed input string (decode mode only).
+                            example: "ff7e:130:2001:db8:cafe:0:1234:5678"
+                          address:
+                            type: string
+                            description: Canonical compressed lowercase embedded-RP group address.
+                            example: "ff7e:130:2001:db8:cafe:0:1234:5678"
+                          scope:
+                            type: integer
+                            minimum: 1
+                            maximum: 15
+                            example: 14
+                          rp_prefix:
+                            type: string
+                            description: Canonical lowercase RP prefix with host bits zeroed.
+                            example: "2001:db8:cafe::"
+                          rp_prefix_length:
+                            type: integer
+                            minimum: 0
+                            maximum: 64
+                            example: 48
+                          rp_address:
+                            type: string
+                            description: Canonical RP address reconstructed as `<rp_prefix>::<riid>`.
+                            example: "2001:db8:cafe::1"
+                          riid:
+                            type: integer
+                            minimum: 0
+                            maximum: 15
+                            example: 1
+                          group_id:
+                            type: integer
+                            minimum: 0
+                            maximum: 4294967295
+                            example: 305419896
+              example:
+                ok: true
+                data:
+                  mode: encode
+                  address: "ff7e:130:2001:db8:cafe:0:1234:5678"
+                  scope: 14
+                  rp_prefix: "2001:db8:cafe::"
+                  rp_prefix_length: 48
+                  rp_address: "2001:db8:cafe::1"
+                  riid: 1
+                  group_id: 305419896
+        "400":
+          description: Missing field or invalid embedded-RP input
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/embedded-rp6.php
+++ b/Subnet-Calculator/api/v1/handlers/embedded-rp6.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body     = api_body();
+$raw_mode = $body['mode'] ?? 'encode';
+$mode     = is_string($raw_mode) ? strtolower(trim($raw_mode)) : 'encode';
+if ($mode !== 'encode' && $mode !== 'decode') {
+    json_err('Field "mode" must be "encode" or "decode".', 400);
+}
+
+if ($mode === 'encode') {
+    $raw_rp_addr      = $body['rp_address']       ?? null;
+    $raw_rp_plen      = $body['rp_prefix_length'] ?? null;
+    $raw_riid         = $body['riid']             ?? null;
+    $raw_scope        = $body['scope']            ?? null;
+    $raw_group_id     = $body['group_id']         ?? null;
+
+    if (!is_string($raw_rp_addr) || trim($raw_rp_addr) === '') {
+        json_err('Field "rp_address" (string) is required for encode mode.', 400);
+    }
+    if (!is_int($raw_rp_plen) && !(is_string($raw_rp_plen) && ctype_digit($raw_rp_plen))) {
+        json_err('Field "rp_prefix_length" (integer 0..64) is required for encode mode.', 400);
+    }
+    $rp_plen = (int)$raw_rp_plen;
+    if (!is_int($raw_riid) && !(is_string($raw_riid) && ctype_digit($raw_riid))) {
+        json_err('Field "riid" (integer 0..15) is required for encode mode.', 400);
+    }
+    $riid = (int)$raw_riid;
+    if (!is_int($raw_scope) && !(is_string($raw_scope) && ctype_digit($raw_scope))) {
+        json_err('Field "scope" (integer 1..15) is required for encode mode.', 400);
+    }
+    $scope = (int)$raw_scope;
+    if (!is_int($raw_group_id) && !(is_string($raw_group_id) && preg_match('/^\d+$/', $raw_group_id))) {
+        json_err('Field "group_id" (32-bit unsigned integer) is required for encode mode.', 400);
+    }
+    $group_id = (int)$raw_group_id;
+    if ($group_id < 0 || $group_id > 0xFFFFFFFF) {
+        json_err('Field "group_id" must be 0..2^32-1.', 400);
+    }
+
+    try {
+        $r = build_embedded_rp_group(trim($raw_rp_addr), $rp_plen, $riid, $scope, $group_id);
+    } catch (\InvalidArgumentException $e) {
+        json_err($e->getMessage(), 400);
+    }
+
+    json_ok([
+        'mode'             => 'encode',
+        'address'          => $r['address'],
+        'scope'            => $r['scope'],
+        'rp_prefix'        => $r['rp_prefix'],
+        'rp_prefix_length' => $r['rp_prefix_length'],
+        'rp_address'       => $r['rp_address'],
+        'riid'             => $r['riid'],
+        'group_id'         => $r['group_id'],
+    ]);
+}
+
+// decode mode
+$raw_input = $body['ipv6'] ?? null;
+if (!is_string($raw_input) || trim($raw_input) === '') {
+    json_err('Field "ipv6" (string) is required for decode mode.', 400);
+}
+
+try {
+    $r = decode_embedded_rp_group(trim($raw_input));
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'mode'             => 'decode',
+    'input'            => trim($raw_input),
+    'address'          => $r['address'],
+    'scope'            => $r['scope'],
+    'rp_prefix'        => $r['rp_prefix'],
+    'rp_prefix_length' => $r['rp_prefix_length'],
+    'rp_address'       => $r['rp_address'],
+    'riid'             => $r['riid'],
+    'group_id'         => $r['group_id'],
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -52,6 +52,9 @@ require_once $base . 'functions-multicast6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for build_ssm_group()/decode_ssm_group().
 require_once $base . 'functions-ssm6.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for build_embedded_rp_group()/decode_embedded_rp_group().
+require_once $base . 'functions-embedded-rp6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -149,6 +152,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/rfc3531',
             'POST /api/v1/multicast6',
             'POST /api/v1/ssm6',
+            'POST /api/v1/embedded-rp6',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -308,6 +312,9 @@ switch ($route_key) {
         break;
     case 'POST /ssm6':
         require __DIR__ . '/handlers/ssm6.php';
+        break;
+    case 'POST /embedded-rp6':
+        require __DIR__ . '/handlers/embedded-rp6.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-embedded-rp6.php
+++ b/Subnet-Calculator/includes/functions-embedded-rp6.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+// IPv6 embedded-RP multicast (v3.6.0 T4, #397).
+//
+// Builds and decodes RFC 3956 embedded-RP IPv6 multicast group addresses
+// (FF7x::/12). The Rendezvous Point's IPv6 address is encoded directly
+// into the multicast group address so any router can derive the RP for
+// a group without an out-of-band RP-set distribution protocol.
+//
+// Layout per RFC 3956 §4:
+//
+//   |   8   |  4  |  4  |   4    |  4   |   8    |   64    |    32    |
+//   +-------+-----+-----+--------+------+--------+---------+----------+
+//   | 0xFF  | 0RPT| scop| Rsvd   | RIID | RP plen| RP-prefix| group ID|
+//   |       | =0x7|     | =0x0   |      |        | (upper64)|         |
+//   +-------+-----+-----+--------+------+--------+---------+----------+
+//
+// Flags must be 0x7 (R+P+T set). Prefix length is restricted to 0..64
+// because only the upper 64 bits of the RP prefix fit in the address.
+// RIID is the 4-bit RP interface ID; the canonical RP address is the
+// RP prefix with the RIID set in the low nibble of the last byte
+// (i.e. RP-prefix + ::RIID).
+
+/**
+ * Build an embedded-RP multicast group per RFC 3956.
+ *
+ * The RP address can have any host suffix; only the upper 64 bits (after
+ * applying $rp_prefix_length) and the explicit $riid argument are encoded
+ * in the resulting multicast group address. The returned `rp_address`
+ * field is canonicalized to RP-prefix + `::<riid>`.
+ *
+ * @param string $rp_address       RP IPv6 address (e.g. '2001:db8:cafe::1').
+ * @param int    $rp_prefix_length 0..64.
+ * @param int    $riid             4-bit RP interface ID (0..15).
+ * @param int    $scope            1..15.
+ * @param int    $group_id         32-bit group ID.
+ *
+ * @return array{
+ *   address: string,
+ *   scope: int,
+ *   rp_prefix: string,
+ *   rp_prefix_length: int,
+ *   rp_address: string,
+ *   riid: int,
+ *   group_id: int
+ * }
+ *
+ * @throws InvalidArgumentException on validation failure.
+ */
+function build_embedded_rp_group(
+    string $rp_address,
+    int $rp_prefix_length,
+    int $riid,
+    int $scope,
+    int $group_id
+): array {
+    if ($scope < 1 || $scope > 15) {
+        throw new InvalidArgumentException('Scope must be in 1..15.');
+    }
+    if ($riid < 0 || $riid > 15) {
+        throw new InvalidArgumentException('RIID must be a 4-bit value (0..15).');
+    }
+    if ($rp_prefix_length < 0 || $rp_prefix_length > 64) {
+        throw new InvalidArgumentException('RP prefix length must be in 0..64.');
+    }
+    if ($group_id < 0 || $group_id > 0xFFFFFFFF) {
+        throw new InvalidArgumentException('Group ID must be a 32-bit unsigned integer (0..2^32-1).');
+    }
+
+    $rp_bin = @inet_pton($rp_address);
+    if ($rp_bin === false || strlen($rp_bin) !== 16) {
+        throw new InvalidArgumentException('RP address must be a valid IPv6 address.');
+    }
+
+    // Mask the RP prefix to its declared length; only the upper 64 bits
+    // are actually encoded in the multicast group address.
+    $masked_prefix = embedded_rp6_mask_prefix($rp_bin, $rp_prefix_length);
+    $upper64       = substr($masked_prefix, 0, 8);
+
+    // 16-byte multicast address per RFC 3956 §4.
+    $out  = "\xFF";
+    $out .= chr((0x7 << 4) | $scope);
+    $out .= chr($riid & 0x0F);
+    $out .= chr($rp_prefix_length);
+    $out .= $upper64;
+    $out .= pack('N', $group_id);
+
+    $address = @inet_ntop($out);
+    if (!is_string($address)) {
+        throw new InvalidArgumentException('Failed to encode multicast address.');
+    }
+
+    // Canonical RP prefix string (host bits zeroed, lowercase, compressed).
+    $rp_prefix_bin = $upper64 . str_repeat("\x00", 8);
+    $rp_prefix_str = @inet_ntop($rp_prefix_bin);
+    $rp_prefix     = is_string($rp_prefix_str) ? strtolower($rp_prefix_str) : '::';
+
+    // Canonical RP address = RP-prefix + ::RIID
+    $rp_addr_bin   = $upper64 . str_repeat("\x00", 7) . chr($riid & 0x0F);
+    $rp_addr_str   = @inet_ntop($rp_addr_bin);
+    $canon_rp_addr = is_string($rp_addr_str) ? strtolower($rp_addr_str) : '::';
+
+    return [
+        'address'          => strtolower($address),
+        'scope'            => $scope,
+        'rp_prefix'        => $rp_prefix,
+        'rp_prefix_length' => $rp_prefix_length,
+        'rp_address'       => $canon_rp_addr,
+        'riid'             => $riid,
+        'group_id'         => $group_id,
+    ];
+}
+
+/**
+ * Decode an embedded-RP multicast group (RFC 3956).
+ *
+ * Inverse of build_embedded_rp_group(). Requires the flag nibble to be
+ * exactly 0x7 (R+P+T); SSM-only groups (P+T = 0x3) and other multicast
+ * schemes are rejected and routed to their own tools.
+ *
+ * @return array{
+ *   address: string,
+ *   scope: int,
+ *   rp_prefix: string,
+ *   rp_prefix_length: int,
+ *   rp_address: string,
+ *   riid: int,
+ *   group_id: int
+ * }
+ *
+ * @throws InvalidArgumentException on any malformed or non-embedded-RP input.
+ */
+function decode_embedded_rp_group(string $ipv6): array
+{
+    $bin = @inet_pton($ipv6);
+    if ($bin === false || strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Invalid IPv6 address.');
+    }
+    if (ord($bin[0]) !== 0xFF) {
+        throw new InvalidArgumentException('Address is not in the IPv6 multicast range FF00::/8.');
+    }
+
+    $flags = (ord($bin[1]) & 0xF0) >> 4;
+    $scope = ord($bin[1]) & 0x0F;
+    if ($flags !== 0x7) {
+        throw new InvalidArgumentException(
+            'Address is not an embedded-RP multicast group (flags must be 0x7 = R+P+T).'
+        );
+    }
+
+    // High nibble of byte 2 is reserved; ignore it but expose RIID from the low nibble.
+    $riid = ord($bin[2]) & 0x0F;
+
+    $rp_prefix_length = ord($bin[3]);
+    if ($rp_prefix_length > 64) {
+        throw new InvalidArgumentException('RP prefix length out of range (must be 0..64).');
+    }
+
+    // RP prefix = first 8 bytes of the prefix area + 8 zero bytes,
+    // re-masked defensively in case the source encoded host bits.
+    $upper64       = substr($bin, 4, 8);
+    $masked_prefix = embedded_rp6_mask_prefix($upper64 . str_repeat("\x00", 8), $rp_prefix_length);
+    $rp_prefix_str = @inet_ntop($masked_prefix);
+    $rp_prefix     = is_string($rp_prefix_str) ? strtolower($rp_prefix_str) : '::';
+
+    // Canonical RP address = RP prefix + ::RIID (RIID in last byte's low nibble).
+    $rp_addr_bin = substr($masked_prefix, 0, 8) . str_repeat("\x00", 7) . chr($riid & 0x0F);
+    $rp_addr_str = @inet_ntop($rp_addr_bin);
+    $rp_address  = is_string($rp_addr_str) ? strtolower($rp_addr_str) : '::';
+
+    /** @var array{0: int, 1: int}|false $unpacked */
+    $unpacked = @unpack('N', substr($bin, 12, 4));
+    if ($unpacked === false || !isset($unpacked[1])) {
+        throw new InvalidArgumentException('Failed to extract group ID.');
+    }
+    $group_id = $unpacked[1] & 0xFFFFFFFF;
+
+    $address_raw = @inet_ntop($bin);
+    $address     = is_string($address_raw) ? strtolower($address_raw) : strtolower($ipv6);
+
+    return [
+        'address'          => $address,
+        'scope'            => $scope,
+        'rp_prefix'        => $rp_prefix,
+        'rp_prefix_length' => $rp_prefix_length,
+        'rp_address'       => $rp_address,
+        'riid'             => $riid,
+        'group_id'         => (int)$group_id,
+    ];
+}
+
+/**
+ * Zero host bits beyond $prefix_length in a 16-byte IPv6 binary string.
+ *
+ * Internal helper for build/decode embedded-RP. Returns a fresh 16-byte string.
+ *
+ * @internal
+ */
+function embedded_rp6_mask_prefix(string $bin, int $prefix_length): string
+{
+    if (strlen($bin) !== 16) {
+        throw new InvalidArgumentException('Internal: embedded_rp6_mask_prefix requires 16 bytes.');
+    }
+    if ($prefix_length >= 128) {
+        return $bin;
+    }
+    if ($prefix_length <= 0) {
+        return str_repeat("\x00", 16);
+    }
+    $full_bytes  = intdiv($prefix_length, 8);
+    $remain_bits = $prefix_length % 8;
+    $out         = substr($bin, 0, $full_bytes);
+    if ($remain_bits !== 0) {
+        $mask = (0xFF << (8 - $remain_bits)) & 0xFF;
+        $out .= chr(ord($bin[$full_bytes]) & $mask);
+        $full_bytes++;
+    }
+    $out .= str_repeat("\x00", 16 - strlen($out));
+    return $out;
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -663,6 +663,119 @@ function sc_run_ssm6(
 }
 
 /**
+ * Run the embedded-RP multicast tool against the supplied input. Mode is
+ * 'encode' (RP address + prefix length + RIID + scope + group ID →
+ * FF7x:: embedded-RP group) or 'decode' (FF7x:: group → parts). Empty
+ * input returns []. (v3.6.0 Task 4, RFC 3956, #397)
+ *
+ * @return array{
+ *     mode?: 'encode'|'decode',
+ *     input?: string,
+ *     address?: string,
+ *     scope?: int,
+ *     rp_prefix?: string,
+ *     rp_prefix_length?: int,
+ *     rp_address?: string,
+ *     riid?: int,
+ *     group_id?: int,
+ *     rp_address_input?: string,
+ *     rp_prefix_length_input?: string,
+ *     riid_input?: string,
+ *     scope_input?: string,
+ *     group_id_input?: string,
+ *     error?: string|null
+ * }
+ */
+function sc_run_embedded_rp6(
+    string $mode,
+    string $rp_address_input,
+    string $rp_prefix_length_input,
+    string $riid_input,
+    string $scope_input,
+    string $group_id_input,
+    string $ipv6_input
+): array {
+    $mode = strtolower(trim($mode));
+    if ($mode !== 'encode' && $mode !== 'decode') {
+        $mode = 'encode';
+    }
+
+    if ($mode === 'encode') {
+        $rp = trim($rp_address_input);
+        $pl = trim($rp_prefix_length_input);
+        $ri = trim($riid_input);
+        $sc = trim($scope_input);
+        $gi = trim($group_id_input);
+        if ($rp === '' && $pl === '' && $ri === '' && $gi === '') {
+            return [];
+        }
+        $base_echo = [
+            'mode'                   => 'encode',
+            'rp_address_input'       => $rp,
+            'rp_prefix_length_input' => $pl,
+            'riid_input'             => $ri,
+            'scope_input'            => $sc,
+            'group_id_input'         => $gi,
+        ];
+        if (!ctype_digit($pl)) {
+            return $base_echo + ['error' => 'RP prefix length must be an integer 0..64.'];
+        }
+        if (!ctype_digit($ri)) {
+            return $base_echo + ['error' => 'RIID must be an integer 0..15.'];
+        }
+        if (!ctype_digit($sc)) {
+            return $base_echo + ['error' => 'Scope must be an integer 1..15.'];
+        }
+        $gi_int = sc_ssm6_parse_group_id($gi);
+        if ($gi_int === null) {
+            return $base_echo + ['error' => 'Group ID must be an integer 0..2^32-1 (decimal or 0xHEX).'];
+        }
+        try {
+            $r = build_embedded_rp_group($rp, (int)$pl, (int)$ri, (int)$sc, $gi_int);
+            return $base_echo + [
+                'address'          => $r['address'],
+                'scope'            => $r['scope'],
+                'rp_prefix'        => $r['rp_prefix'],
+                'rp_prefix_length' => $r['rp_prefix_length'],
+                'rp_address'       => $r['rp_address'],
+                'riid'             => $r['riid'],
+                'group_id'         => $r['group_id'],
+                'error'            => null,
+            ];
+        } catch (\InvalidArgumentException $e) {
+            return $base_echo + ['error' => $e->getMessage()];
+        }
+    }
+
+    // decode
+    $raw = trim($ipv6_input);
+    if ($raw === '') {
+        return [];
+    }
+    try {
+        $r = decode_embedded_rp_group($raw);
+        return [
+            'mode'             => 'decode',
+            'input'            => $raw,
+            'address'          => $r['address'],
+            'scope'            => $r['scope'],
+            'rp_prefix'        => $r['rp_prefix'],
+            'rp_prefix_length' => $r['rp_prefix_length'],
+            'rp_address'       => $r['rp_address'],
+            'riid'             => $r['riid'],
+            'group_id'         => $r['group_id'],
+            'error'            => null,
+        ];
+    } catch (\InvalidArgumentException $e) {
+        return [
+            'mode'  => 'decode',
+            'input' => $raw,
+            'error' => $e->getMessage(),
+        ];
+    }
+}
+
+/**
  * Parse a user-supplied group_id. Accepts decimal or 0x-hex.
  * Returns null on parse failure or out-of-range value.
  *
@@ -1449,6 +1562,17 @@ $ssm6_ipv6_input           = '';
 /** @var array{mode?: 'encode'|'decode', input?: string, address?: string, scope?: int, prefix_length?: int, unicast_prefix?: string, group_id?: int, unicast_prefix_input?: string, scope_input?: string, group_id_input?: string, error?: string|null} */
 $ssm6 = [];
 
+// v3.6.0 Task 4 — Embedded-RP multicast (RFC 3956, #397)
+$embedded_rp6_mode                   = 'encode';
+$embedded_rp6_rp_address_input       = '';
+$embedded_rp6_rp_prefix_length_input = '';
+$embedded_rp6_riid_input             = '';
+$embedded_rp6_scope_input            = '14'; // default 0xE (global)
+$embedded_rp6_group_id_input         = '';
+$embedded_rp6_ipv6_input             = '';
+/** @var array{mode?: 'encode'|'decode', input?: string, address?: string, scope?: int, rp_prefix?: string, rp_prefix_length?: int, rp_address?: string, riid?: int, group_id?: int, rp_address_input?: string, rp_prefix_length_input?: string, riid_input?: string, scope_input?: string, group_id_input?: string, error?: string|null} */
+$embedded_rp6 = [];
+
 // v3.5.0 Task 10 — RFC 3531 sparse-allocation guidance
 $rfc3531_parent_input           = '';
 $rfc3531_reservation_bits_input = '';
@@ -1549,6 +1673,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || isset($_POST['ssm6_scope'])
         || isset($_POST['ssm6_group_id'])
         || isset($_POST['ssm6_ipv6']);
+    $is_embedded_rp6  = isset($_POST['embedded_rp6_mode'])
+        || isset($_POST['embedded_rp6_rp_address'])
+        || isset($_POST['embedded_rp6_rp_prefix_length'])
+        || isset($_POST['embedded_rp6_riid'])
+        || isset($_POST['embedded_rp6_scope'])
+        || isset($_POST['embedded_rp6_group_id'])
+        || isset($_POST['embedded_rp6_ipv6']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -1562,7 +1693,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_nibble6
         || $is_rfc3531
         || $is_multicast6
-        || $is_ssm6;
+        || $is_ssm6
+        || $is_embedded_rp6;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -2109,6 +2241,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $ssm6_scope_input,
             $ssm6_group_id_input,
             $ssm6_ipv6_input
+        );
+    }
+
+    if ($is_embedded_rp6 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $embedded_rp6_mode = (string)($_POST['embedded_rp6_mode'] ?? 'encode');
+        if ($embedded_rp6_mode !== 'encode' && $embedded_rp6_mode !== 'decode') {
+            $embedded_rp6_mode = 'encode';
+        }
+        $embedded_rp6_rp_address_input       = trim((string)($_POST['embedded_rp6_rp_address']       ?? ''));
+        $embedded_rp6_rp_prefix_length_input = trim((string)($_POST['embedded_rp6_rp_prefix_length'] ?? ''));
+        $embedded_rp6_riid_input             = trim((string)($_POST['embedded_rp6_riid']             ?? ''));
+        $embedded_rp6_scope_input            = trim((string)($_POST['embedded_rp6_scope']            ?? '14'));
+        $embedded_rp6_group_id_input         = trim((string)($_POST['embedded_rp6_group_id']         ?? ''));
+        $embedded_rp6_ipv6_input             = trim((string)($_POST['embedded_rp6_ipv6']             ?? ''));
+        $embedded_rp6 = sc_run_embedded_rp6(
+            $embedded_rp6_mode,
+            $embedded_rp6_rp_address_input,
+            $embedded_rp6_rp_prefix_length_input,
+            $embedded_rp6_riid_input,
+            $embedded_rp6_scope_input,
+            $embedded_rp6_group_id_input,
+            $embedded_rp6_ipv6_input
         );
     }
 
@@ -2721,6 +2876,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $ssm6_scope_input,
             $ssm6_group_id_input,
             $ssm6_ipv6_input
+        );
+    }
+
+    // Embedded-RP multicast shareable GET URL (v3.6.0 Task 4, RFC 3956, #397)
+    if (
+        $active_tab === 'ipv6'
+        && (
+            isset($_GET['embedded_rp6_mode'])
+            || isset($_GET['embedded_rp6_rp_address'])
+            || isset($_GET['embedded_rp6_rp_prefix_length'])
+            || isset($_GET['embedded_rp6_riid'])
+            || isset($_GET['embedded_rp6_group_id'])
+            || isset($_GET['embedded_rp6_ipv6'])
+        )
+    ) {
+        $embedded_rp6_mode = (string)($_GET['embedded_rp6_mode'] ?? 'encode');
+        if ($embedded_rp6_mode !== 'encode' && $embedded_rp6_mode !== 'decode') {
+            $embedded_rp6_mode = 'encode';
+        }
+        $embedded_rp6_rp_address_input       = trim((string)($_GET['embedded_rp6_rp_address']       ?? ''));
+        $embedded_rp6_rp_prefix_length_input = trim((string)($_GET['embedded_rp6_rp_prefix_length'] ?? ''));
+        $embedded_rp6_riid_input             = trim((string)($_GET['embedded_rp6_riid']             ?? ''));
+        $embedded_rp6_scope_input            = trim((string)($_GET['embedded_rp6_scope']            ?? '14'));
+        $embedded_rp6_group_id_input         = trim((string)($_GET['embedded_rp6_group_id']         ?? ''));
+        $embedded_rp6_ipv6_input             = trim((string)($_GET['embedded_rp6_ipv6']             ?? ''));
+        $embedded_rp6 = sc_run_embedded_rp6(
+            $embedded_rp6_mode,
+            $embedded_rp6_rp_address_input,
+            $embedded_rp6_rp_prefix_length_input,
+            $embedded_rp6_riid_input,
+            $embedded_rp6_scope_input,
+            $embedded_rp6_group_id_input,
+            $embedded_rp6_ipv6_input
         );
     }
 

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -44,6 +44,9 @@ require_once __DIR__ . '/includes/functions-multicast6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for build_ssm_group()/decode_ssm_group().
 require_once __DIR__ . '/includes/functions-ssm6.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for build_embedded_rp_group()/decode_embedded_rp_group().
+require_once __DIR__ . '/includes/functions-embedded-rp6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -774,9 +774,10 @@ if ($i < 3) {
         elseif (!empty($rfc3531)) { $open_tool_ipv6 = 'rfc3531'; }
         elseif (!empty($multicast6)) { $open_tool_ipv6 = 'multicast'; }
         elseif (!empty($ssm6)) { $open_tool_ipv6 = 'ssm'; }
+        elseif (!empty($embedded_rp6)) { $open_tool_ipv6 = 'embedded-rp'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan','nibble','rfc3531','multicast','ssm'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan','nibble','rfc3531','multicast','ssm','embedded-rp'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -804,6 +805,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="rfc3531" aria-expanded="false">RFC 3531 Sparse</button>
             <button type="button" class="tool-trigger" data-tool="multicast" aria-expanded="false">Multicast Decoder</button>
             <button type="button" class="tool-trigger" data-tool="ssm" aria-expanded="false">SSM (RFC 3306)</button>
+            <button type="button" class="tool-trigger" data-tool="embedded-rp" aria-expanded="false">Embedded-RP (RFC 3956)</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -2551,6 +2553,137 @@ if ($i < 3) {
                             </div>
                         </dl>
                         <p><small>RFC 3306 §4 / RFC 4607. The flag nibble is fixed at 0x3 (P+T); embedded-RP groups (R+P+T = 0x7) belong in the embedded-RP tool.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="embedded-rp">
+                <div class="overlap-panel">
+                    <div class="overlap-title">Embedded-RP multicast (RFC 3956)<?= help_bubble('ipv6-embedded-rp', 'Build and decode FF7x::/12 multicast group addresses with the Rendezvous Point address embedded directly in the group address. RFC 3956. Encode mode composes a group from an RP address (whose host suffix is replaced by the explicit RIID), RP prefix length (0..64), 4-bit RIID, scope (1..15), and 32-bit group ID. Decode mode reverses the process; it requires the flag nibble to be exactly 0x7 (R+P+T) — SSM groups (P+T = 0x3) belong in the SSM tool.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="embedded_rp6_mode">Mode<?= help_bubble('embedded-rp6-mode', 'Encode: RP parts → FF7x:: embedded-RP group. Decode: FF7x:: group → RP address, prefix length, RIID, scope, and group ID.') ?></label>
+                                <select id="embedded_rp6_mode" name="embedded_rp6_mode">
+                                    <option value="encode"<?= ($embedded_rp6_mode ?? 'encode') === 'encode' ? ' selected' : '' ?>>Encode (parts → embedded-RP group)</option>
+                                    <option value="decode"<?= ($embedded_rp6_mode ?? 'encode') === 'decode' ? ' selected' : '' ?>>Decode (group → parts)</option>
+                                </select>
+                            </div>
+                        </div>
+                        <?php if (($embedded_rp6_mode ?? 'encode') === 'encode') : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="embedded_rp6_rp_address">RP address<?= help_bubble('embedded-rp6-rp-address', 'Rendezvous Point IPv6 address. Only the upper bits selected by the prefix length are encoded into the multicast group; the host suffix is ignored and replaced by the explicit RIID. Example: <code>2001:db8:cafe::1</code>.') ?></label>
+                                    <input type="text" id="embedded_rp6_rp_address" name="embedded_rp6_rp_address"
+                                           value="<?= htmlspecialchars($embedded_rp6_rp_address_input ?? '') ?>"
+                                           placeholder="2001:db8:cafe::1"
+                                           autocomplete="off" spellcheck="false">
+                                </div>
+                                <div class="form-group form-group--mask">
+                                    <label for="embedded_rp6_rp_prefix_length">RP prefix length<?= help_bubble('embedded-rp6-rp-prefix-length', 'Length of the RP prefix in bits (0..64). RFC 3956 caps this at 64 because only the upper 64 bits of the RP prefix fit in the multicast address. Typical values: 32 (provider prefix), 48 (site prefix), 56 / 64 (subnet).') ?></label>
+                                    <input type="number" id="embedded_rp6_rp_prefix_length" name="embedded_rp6_rp_prefix_length"
+                                           value="<?= htmlspecialchars($embedded_rp6_rp_prefix_length_input ?? '') ?>"
+                                           min="0" max="64"
+                                           placeholder="48"
+                                           autocomplete="off">
+                                </div>
+                                <div class="form-group form-group--mask">
+                                    <label for="embedded_rp6_riid">RIID<?= help_bubble('embedded-rp6-riid', '4-bit RP interface ID (0..15). Selects which interface on the RP terminates the shared tree. The canonical RP address is reconstructed as <code>&lt;rp-prefix&gt;::&lt;riid&gt;</code>.') ?></label>
+                                    <input type="number" id="embedded_rp6_riid" name="embedded_rp6_riid"
+                                           value="<?= htmlspecialchars($embedded_rp6_riid_input ?? '') ?>"
+                                           min="0" max="15"
+                                           placeholder="1"
+                                           autocomplete="off">
+                                </div>
+                                <div class="form-group form-group--mask">
+                                    <label for="embedded_rp6_scope">Scope<?= help_bubble('embedded-rp6-scope', 'Multicast scope (1..15). Common values: 2 (link-local), 5 (site-local), 8 (organization-local), 14 / 0xE (global). RFC 4291 §2.7 + RFC 7346.') ?></label>
+                                    <input type="number" id="embedded_rp6_scope" name="embedded_rp6_scope"
+                                           value="<?= htmlspecialchars($embedded_rp6_scope_input ?? '14') ?>"
+                                           min="1" max="15"
+                                           autocomplete="off">
+                                </div>
+                                <div class="form-group">
+                                    <label for="embedded_rp6_group_id">Group ID<?= help_bubble('embedded-rp6-group-id', '32-bit unsigned group ID (0..4294967295). Accepts decimal or hex (<code>0x12345678</code>). RFC 3956 places this in the low 32 bits of the multicast address.') ?></label>
+                                    <input type="text" id="embedded_rp6_group_id" name="embedded_rp6_group_id"
+                                           value="<?= htmlspecialchars($embedded_rp6_group_id_input ?? '') ?>"
+                                           placeholder="0x12345678 or 305419896"
+                                           autocomplete="off" spellcheck="false">
+                                </div>
+                            </div>
+                        <?php else : ?>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="embedded_rp6_ipv6">Embedded-RP group address<?= help_bubble('embedded-rp6-ipv6', 'An IPv6 multicast literal in FF7x::/12 with the R+P+T flags set (flag nibble 0x7). Example: <code>ff7e:130:2001:db8:cafe:0:1234:5678</code> (RP = 2001:db8:cafe::1, RIID = 1, scope = 0xE, group = 0x12345678).') ?></label>
+                                    <input type="text" id="embedded_rp6_ipv6" name="embedded_rp6_ipv6"
+                                           value="<?= htmlspecialchars($embedded_rp6_ipv6_input ?? '') ?>"
+                                           placeholder="ff7e:130:2001:db8:cafe:0:1234:5678"
+                                           autocomplete="off" spellcheck="false"
+                                           <?= !empty($embedded_rp6['error']) ? 'aria-invalid="true" aria-describedby="embedded-rp6-error"' : '' ?>>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn"><?= ($embedded_rp6_mode ?? 'encode') === 'encode' ? 'Build group' : 'Decode group' ?></button>
+                        </div>
+                    </form>
+                    <?php if (!empty($embedded_rp6['error'])) : ?>
+                        <div class="error" id="embedded-rp6-error"><?= htmlspecialchars((string)$embedded_rp6['error']) ?></div>
+                    <?php elseif (!empty($embedded_rp6) && isset($embedded_rp6['address'])) : ?>
+                        <?php
+                        $_erp_history = 'embedded-rp: ' . (string)($embedded_rp6['address'] ?? '');
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="embedded-rp"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_erp_history) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Embedded-RP group address</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)($embedded_rp6['address'] ?? '')) ?></code>
+                                    <?= copy_button((string)($embedded_rp6['address'] ?? ''), 'Copy embedded-RP group address') ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Scope</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)($embedded_rp6['scope'] ?? 0) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">RP prefix length</dt>
+                                <dd class="zoneid-result__value">
+                                    <code>/<?= (int)($embedded_rp6['rp_prefix_length'] ?? 0) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">RP prefix</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)($embedded_rp6['rp_prefix'] ?? '')) ?></code>
+                                    <?= copy_button((string)($embedded_rp6['rp_prefix'] ?? ''), 'Copy RP prefix') ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">RP address</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars((string)($embedded_rp6['rp_address'] ?? '')) ?></code>
+                                    <?= copy_button((string)($embedded_rp6['rp_address'] ?? ''), 'Copy RP address') ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">RIID</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)($embedded_rp6['riid'] ?? 0) ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Group ID</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= htmlspecialchars(sprintf('0x%08x (%d)', (int)($embedded_rp6['group_id'] ?? 0), (int)($embedded_rp6['group_id'] ?? 0))) ?></code>
+                                </dd>
+                            </div>
+                        </dl>
+                        <p><small>RFC 3956. The flag nibble is fixed at 0x7 (R+P+T); SSM-only groups (P+T = 0x3) belong in the SSM tool.</small></p>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/embedded-rp6.md
+++ b/docs/embedded-rp6.md
@@ -1,0 +1,90 @@
+# Embedded-RP Multicast (RFC 3956)
+
+The embedded-RP tool builds and decodes **embedded Rendezvous Point IPv6
+multicast group addresses** as defined by
+[RFC 3956](https://www.rfc-editor.org/rfc/rfc3956). These are the
+`FF7x::/12` group addresses where the address of the PIM-SM Rendezvous
+Point is embedded directly into the multicast group address. Routers
+can derive the RP for a group from the group address alone, with no
+need for an out-of-band RP-set distribution protocol such as BSR or
+embedded Auto-RP.
+
+## Address layout
+
+```
+|   8   | 4 | 4 |  4   |  4  |   8    |     64      |     32     |
++-------+---+---+------+-----+--------+-------------+------------+
+| 0xFF  | RPT |scop| Rsvd | RIID| RP   | RP-prefix   | group ID   |
+|       | =0x7|    | =0x0 |     | plen | (upper 64)  |            |
++-------+----+----+------+-----+------+-------------+------------+
+```
+
+- Byte 0 — `0xFF` multicast prefix.
+- Byte 1 — flag nibble (`0RPT`) and 4-bit scope. Embedded-RP requires
+  `flags = 0x7` (R + P + T set), which yields the `FF7x::/12` range.
+  SSM-only groups (P + T = `0x3`, `FF3x::/12`) are out of scope and
+  routed to the separate SSM tool.
+- Byte 2 — high nibble reserved (`0x0`); low nibble is the **RIID**, the
+  4-bit RP interface ID.
+- Byte 3 — RP prefix length (0..64). Only the upper 64 bits of the RP
+  prefix fit in the multicast address, so RFC 3956 caps the prefix
+  length at 64.
+- Bytes 4–11 — first 8 bytes of the RP prefix (host bits zeroed).
+- Bytes 12–15 — 32-bit group ID, big-endian.
+
+## Reconstructing the RP address
+
+Per RFC 3956 §3, the canonical RP address is derived as:
+
+```
+RP-address = <RP-prefix> :: <RIID>
+```
+
+i.e. the RP prefix bytes followed by zeros, with the RIID placed in the
+low nibble of the last byte. Encode mode accepts an RP IPv6 address as
+input, masks it to the declared prefix length, and replaces its host
+suffix with the explicit RIID — the host bits of the user-supplied RP
+address are not encoded.
+
+## Worked example
+
+Embedded-RP group with RP `2001:db8:cafe::1`, RP prefix length 48,
+RIID 1, scope `0xE` (global), group ID `0x12345678`:
+
+```
+ff7e:130:2001:db8:cafe:0:1234:5678
+```
+
+Note the `cafe:0:` segment — there is only a single zero group between
+the RP prefix and the group ID, so RFC 5952 leaves it uncompressed.
+The drawer round-trips this address: encode → decode → encode yields
+the same canonical lowercase form.
+
+## Tool drawer
+
+Open the IPv6 tab and click **Embedded-RP (RFC 3956)**, or follow the
+deep-link button on the multicast scope decoder when the input is
+recognised as an embedded-RP group.
+
+The drawer has two modes:
+
+- **Encode** — five inputs: RP address, RP prefix length (0..64),
+  RIID (0..15), scope (1..15), and group ID (decimal or `0x`-hex
+  32-bit unsigned). Produces the canonical lowercase compressed group
+  address plus a structured breakdown.
+- **Decode** — single input: an embedded-RP group address. Reverses
+  the encoding and rejects any address whose flag nibble is not
+  exactly `0x7` (e.g. SSM-only `FF3x::/12` groups), non-multicast
+  input, or an RP prefix length out of range.
+
+## REST API
+
+`POST /api/v1/embedded-rp6` exposes the same logic. See the OpenAPI
+specification for the full request/response shape.
+
+## Composes with the multicast scope decoder
+
+The IPv6 multicast scope decoder (`/ipv6/multicast`) classifies any
+`FF00::/8` address. When the flag nibble is `0x7` it sets the
+`detail_route` field to `/ipv6/embedded-rp`, surfacing an **Open in
+embedded-RP tool** button that deep-links into this drawer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - RFC 3531 Sparse Allocation: rfc3531.md
     - IPv6 Multicast Decoder: multicast6.md
     - IPv6 SSM (RFC 3306): ssm6.md
+    - IPv6 Embedded-RP (RFC 3956): embedded-rp6.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -3306,6 +3306,155 @@ async def test_ipv6_ssm_ui(page: Page) -> None:
                 len(err_text) > 0, f"got: {err_text!r}")
 
 
+async def test_api_embedded_rp6(page: Page) -> None:
+    section("API — POST /api/v1/embedded-rp6")
+    # Encode — RFC 3956 worked example.
+    status, data = _api_post("embedded-rp6", {
+        "mode": "encode",
+        "rp_address": "2001:db8:cafe::1",
+        "rp_prefix_length": 48,
+        "riid": 1,
+        "scope": 14,
+        "group_id": 0x12345678,
+    })
+    assert_eq("api embedded-rp6 encode: HTTP 200", status, 200)
+    assert_eq("api embedded-rp6 encode: ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api embedded-rp6 encode: address",
+              d.get("address"), "ff7e:130:2001:db8:cafe:0:1234:5678")
+    assert_eq("api embedded-rp6 encode: rp_prefix_length",
+              d.get("rp_prefix_length"), 48)
+    assert_eq("api embedded-rp6 encode: riid", d.get("riid"), 1)
+    assert_eq("api embedded-rp6 encode: scope", d.get("scope"), 14)
+    assert_eq("api embedded-rp6 encode: group_id",
+              d.get("group_id"), 0x12345678)
+    assert_eq("api embedded-rp6 encode: rp_address",
+              d.get("rp_address"), "2001:db8:cafe::1")
+    assert_eq("api embedded-rp6 encode: rp_prefix",
+              d.get("rp_prefix"), "2001:db8:cafe::")
+
+    # Decode — round-trip.
+    status2, data2 = _api_post("embedded-rp6", {
+        "mode": "decode",
+        "ipv6": "ff7e:130:2001:db8:cafe:0:1234:5678",
+    })
+    assert_eq("api embedded-rp6 decode: HTTP 200", status2, 200)
+    d2 = data2.get("data", {})
+    assert_eq("api embedded-rp6 decode: scope", d2.get("scope"), 14)
+    assert_eq("api embedded-rp6 decode: rp_prefix_length",
+              d2.get("rp_prefix_length"), 48)
+    assert_eq("api embedded-rp6 decode: rp_prefix",
+              d2.get("rp_prefix"), "2001:db8:cafe::")
+    assert_eq("api embedded-rp6 decode: rp_address",
+              d2.get("rp_address"), "2001:db8:cafe::1")
+    assert_eq("api embedded-rp6 decode: riid", d2.get("riid"), 1)
+    assert_eq("api embedded-rp6 decode: group_id",
+              d2.get("group_id"), 0x12345678)
+
+    # Decode rejects SSM-only flags (FF3E:: has flags=0x3, not 0x7).
+    status3, _ = _api_post("embedded-rp6", {
+        "mode": "decode", "ipv6": "FF3E::1234:5678"})
+    assert_eq("api embedded-rp6 decode (FF3E::): non-embedded-RP → 400",
+              status3, 400)
+
+    # Decode rejects non-multicast input.
+    status4, _ = _api_post("embedded-rp6", {
+        "mode": "decode", "ipv6": "2001:db8::1"})
+    assert_eq("api embedded-rp6 decode (non-multicast): → 400", status4, 400)
+
+    # Encode rejects RIID > 15.
+    status5, _ = _api_post("embedded-rp6", {
+        "mode": "encode",
+        "rp_address": "2001:db8::1",
+        "rp_prefix_length": 48,
+        "riid": 16,
+        "scope": 14,
+        "group_id": 1,
+    })
+    assert_eq("api embedded-rp6 encode (riid=16): → 400", status5, 400)
+
+    # Encode rejects RP prefix length > 64.
+    status6, _ = _api_post("embedded-rp6", {
+        "mode": "encode",
+        "rp_address": "2001:db8::1",
+        "rp_prefix_length": 96,
+        "riid": 1,
+        "scope": 14,
+        "group_id": 1,
+    })
+    assert_eq("api embedded-rp6 encode (/96): → 400", status6, 400)
+
+    # Encode rejects out-of-range scope.
+    status7, _ = _api_post("embedded-rp6", {
+        "mode": "encode",
+        "rp_address": "2001:db8::1",
+        "rp_prefix_length": 48,
+        "riid": 1,
+        "scope": 0,
+        "group_id": 1,
+    })
+    assert_eq("api embedded-rp6 encode (scope 0): → 400", status7, 400)
+
+    # Missing mode-specific field.
+    status8, _ = _api_post("embedded-rp6", {"mode": "encode"})
+    assert_eq("api embedded-rp6 encode: missing field → 400", status8, 400)
+
+
+async def test_ipv6_embedded_rp_ui(page: Page) -> None:
+    section("IPv6 embedded-RP tool UI")
+
+    # Drawer opens via /ipv6/embedded-rp rewrite path used by multicast deep-link.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=embedded-rp")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-rp']")
+    assert_eq("embedded-rp UI: panel exists", await panel.count(), 1)
+
+    # Encode mode (default) — submit RFC 3956 worked example.
+    await page.fill("#embedded_rp6_rp_address", "2001:db8:cafe::1")
+    await page.fill("#embedded_rp6_rp_prefix_length", "48")
+    await page.fill("#embedded_rp6_riid", "1")
+    await page.fill("#embedded_rp6_scope", "14")
+    await page.fill("#embedded_rp6_group_id", "0x12345678")
+    await page.click(
+        "#panel-ipv6 .tool-panel[data-tool='embedded-rp'] button.splitter-btn"
+    )
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-rp']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("embedded-rp UI: built address rendered",
+                "ff7e:130:2001:db8:cafe:0:1234:5678" in body_text)
+    assert_true("embedded-rp UI: rp address rendered",
+                "2001:db8:cafe::1" in body_text)
+
+    # Decode mode — round-trip via shareable GET URL.
+    await navigate(
+        page,
+        APP_URL + "?tab=ipv6&tool=embedded-rp&embedded_rp6_mode=decode"
+        "&embedded_rp6_ipv6=ff7e:130:2001:db8:cafe:0:1234:5678",
+    )
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-rp']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("embedded-rp UI: decode group_id rendered",
+                "0x12345678" in body_text or "305419896" in body_text)
+    assert_true("embedded-rp UI: decode rp prefix rendered",
+                "2001:db8:cafe::" in body_text)
+    assert_true("embedded-rp UI: decode rp address rendered",
+                "2001:db8:cafe::1" in body_text)
+
+    # Error path — SSM-only flags (FF3E::) must be rejected.
+    await navigate(
+        page,
+        APP_URL + "?tab=ipv6&tool=embedded-rp&embedded_rp6_mode=decode"
+        "&embedded_rp6_ipv6=FF3E::1234:5678",
+    )
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='embedded-rp']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("embedded-rp UI: error band on non-embedded-RP input",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+
 async def test_api_6to4(page: Page) -> None:
     section("API — POST /api/v1/6to4")
 
@@ -9621,6 +9770,8 @@ async def main() -> None:
             await test_api_multicast6(page)
             await test_ipv6_ssm_ui(page)
             await test_api_ssm6(page)
+            await test_ipv6_embedded_rp_ui(page)
+            await test_api_embedded_rp6(page)
             await test_a11y_ipv6_drawers(page)
             # v3.5.0 (T11) — bulk endpoint coverage + a11y for the 9 new drawers
             await test_api_bulk_covers_v350_endpoints(page)

--- a/testing/unit/EmbeddedRp6Test.php
+++ b/testing/unit/EmbeddedRp6Test.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class EmbeddedRp6Test extends TestCase
+{
+    public function test_build_embedded_rp(): void
+    {
+        // RP = 2001:db8:cafe::1 (RIID=1, prefix length 48). Bytes 0..15:
+        //   FF 7E 01 30 20 01 0D B8 CA FE 00 00 12 34 56 78
+        // Per RFC 5952, the single zero group (cafe:0000:...) does not
+        // compress with `::`; only runs of >= 2 zero groups do.
+        $r = build_embedded_rp_group('2001:db8:cafe::1', 48, 1, 0xE, 0x12345678);
+        $this->assertSame('ff7e:130:2001:db8:cafe:0:1234:5678', strtolower($r['address']));
+        $this->assertSame(48, $r['rp_prefix_length']);
+        $this->assertSame(1, $r['riid']);
+        $this->assertSame(0xE, $r['scope']);
+        $this->assertSame(0x12345678, $r['group_id']);
+        $this->assertSame('2001:db8:cafe::', strtolower($r['rp_prefix']));
+        // RP address canonicalized = RP-prefix + ::RIID
+        $this->assertSame('2001:db8:cafe::1', strtolower($r['rp_address']));
+    }
+
+    public function test_decode_embedded_rp_round_trip(): void
+    {
+        $r = decode_embedded_rp_group('ff7e:130:2001:db8:cafe:0:1234:5678');
+        $this->assertSame(0xE, $r['scope']);
+        $this->assertSame(48, $r['rp_prefix_length']);
+        $this->assertSame('2001:db8:cafe::', strtolower($r['rp_prefix']));
+        $this->assertSame(1, $r['riid']);
+        $this->assertSame('2001:db8:cafe::1', strtolower($r['rp_address']));
+        $this->assertSame(0x12345678, $r['group_id']);
+    }
+
+    public function test_build_rejects_riid_over_15(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', 48, 16, 0xE, 1);
+    }
+
+    public function test_build_rejects_riid_negative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', 48, -1, 0xE, 1);
+    }
+
+    public function test_build_rejects_prefix_length_over_64(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', 96, 1, 0xE, 1);
+    }
+
+    public function test_build_rejects_negative_prefix_length(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', -1, 1, 0xE, 1);
+    }
+
+    public function test_build_rejects_invalid_scope_zero(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', 48, 1, 0, 1);
+    }
+
+    public function test_build_rejects_invalid_scope_too_high(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', 48, 1, 16, 1);
+    }
+
+    public function test_build_rejects_negative_group_id(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', 48, 1, 0xE, -1);
+    }
+
+    public function test_build_rejects_group_id_over_32_bits(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('2001:db8::1', 48, 1, 0xE, 0x1_0000_0000);
+    }
+
+    public function test_build_rejects_garbage_rp_address(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        build_embedded_rp_group('not-an-address', 48, 1, 0xE, 1);
+    }
+
+    public function test_build_zero_prefix_length(): void
+    {
+        $r = build_embedded_rp_group('::1', 0, 1, 0xE, 0x12345678);
+        // Bytes: FF 7E 01 00 00 00 00 00 00 00 00 00 12 34 56 78
+        // → ff7e:100::1234:5678 (the eight zero bytes between byte3 and byte11
+        //   span four 16-bit groups so `::` compresses them).
+        $this->assertSame('ff7e:100::1234:5678', strtolower($r['address']));
+        $this->assertSame(0, $r['rp_prefix_length']);
+        $this->assertSame(1, $r['riid']);
+        $this->assertSame('::', strtolower($r['rp_prefix']));
+        $this->assertSame('::1', strtolower($r['rp_address']));
+    }
+
+    public function test_build_rp_address_host_bits_other_than_riid(): void
+    {
+        // RFC 3956 §3 — only the RIID is embedded; the RP address can have
+        // any host suffix, but build() canonicalises rp_address to <rp_prefix>::<riid>.
+        $r = build_embedded_rp_group('2001:db8:cafe::abcd', 48, 1, 0xE, 0x12345678);
+        $this->assertSame('2001:db8:cafe::1', strtolower($r['rp_address']));
+        $this->assertSame('ff7e:130:2001:db8:cafe:0:1234:5678', strtolower($r['address']));
+    }
+
+    public function test_decode_rejects_r_flag_unset(): void
+    {
+        // P only, R clear → flags = 0x3, not 0x7.
+        $this->expectException(InvalidArgumentException::class);
+        decode_embedded_rp_group('FF3E::1234:5678');
+    }
+
+    public function test_decode_rejects_non_multicast(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_embedded_rp_group('2001:db8::1');
+    }
+
+    public function test_decode_rejects_garbage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        decode_embedded_rp_group('not-an-address');
+    }
+
+    public function test_decode_rejects_prefix_length_over_64(): void
+    {
+        // FF7E:60:: would carry rp_prefix_length=0x60 (96) — must be rejected.
+        $this->expectException(InvalidArgumentException::class);
+        decode_embedded_rp_group('ff7e:60::1234:5678');
+    }
+
+    public function test_decode_link_local_scope(): void
+    {
+        // Scope 0x2 = link-local. flags must still be 0x7.
+        // byte0=FF byte1=72 byte2=01 byte3=10 (16) prefix=fe80::, gid=1
+        $r = decode_embedded_rp_group('ff72:110:fe80::1');
+        $this->assertSame(0x2, $r['scope']);
+        $this->assertSame(16, $r['rp_prefix_length']);
+        $this->assertSame(1, $r['riid']);
+        $this->assertSame(1, $r['group_id']);
+    }
+
+    public function test_build_riid_15(): void
+    {
+        // RIID = 0xF, prefix length 64.
+        $r = build_embedded_rp_group('2001:db8:cafe:beef::f', 64, 0xF, 0xE, 0xDEADBEEF);
+        $this->assertSame(0xF, $r['riid']);
+        $this->assertSame(64, $r['rp_prefix_length']);
+        $this->assertSame('2001:db8:cafe:beef::f', strtolower($r['rp_address']));
+        $bin = inet_pton($r['address']);
+        $this->assertNotFalse($bin);
+        $this->assertSame(0xFF, ord((string)$bin[0]));
+        // byte 1 high nibble must be 0x7 (R+P+T)
+        $this->assertSame(0x7, (ord((string)$bin[1]) & 0xF0) >> 4);
+        // byte 1 low nibble = scope
+        $this->assertSame(0xE, ord((string)$bin[1]) & 0x0F);
+        // byte 2 low nibble = riid
+        $this->assertSame(0xF, ord((string)$bin[2]) & 0x0F);
+        // byte 3 = prefix length
+        $this->assertSame(64, ord((string)$bin[3]));
+    }
+
+    public function test_decode_zero_prefix_length(): void
+    {
+        // Round-trip of build_embedded_rp_group('::1', 0, 1, 0xE, 0x12345678).
+        $r = decode_embedded_rp_group('ff7e:100::1234:5678');
+        $this->assertSame(0, $r['rp_prefix_length']);
+        $this->assertSame(1, $r['riid']);
+        $this->assertSame('::', strtolower($r['rp_prefix']));
+        $this->assertSame('::1', strtolower($r['rp_address']));
+        $this->assertSame(0x12345678, $r['group_id']);
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -43,6 +43,9 @@ require_once $base . 'functions-multicast6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for build_ssm_group()/decode_ssm_group().
 require_once $base . 'functions-ssm6.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for build_embedded_rp_group()/decode_embedded_rp_group().
+require_once $base . 'functions-embedded-rp6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

Task 4 of v3.6.0 — implements RFC 3956 embedded-RP multicast as the third
per-scheme tool gated by the multicast scope decoder (T2).

- `build_embedded_rp_group()` / `decode_embedded_rp_group()` for the
  FF7x::/12 range, with strict flag-nibble (0x7 = R+P+T) and
  prefix-length (0..64) validation. Mirrors the SSM analog (T3).
- `POST /api/v1/embedded-rp6` bidirectional handler.
- Drawer `data-tool="embedded-rp"` with encode (5 inputs) / decode
  (1 input) modes; whitelist + open-chain wired so the multicast
  scope decoder's "Open in embedded-RP tool" deep-link lands here.
- `sc_run_embedded_rp6()` shared POST + GET helper.
- 20 PHPUnit tests, Playwright API + UI coverage, OpenAPI schema,
  mkdocs nav, docs page, CHANGELOG entry.

## Test plan

- [x] PHPUnit — 750 tests, 1663 assertions pass (20 new tests added).
- [x] PHPStan L9 — no errors.
- [x] PHPCS PSR-12 — clean on new files.
- [x] Spectral OpenAPI lint — no errors.
- [x] semgrep — 0 findings.
- [x] ESLint / Stylelint — 0 errors.
- [x] Playwright `make test-docker` — 2249/2249 assertions pass,
      including new `test_api_embedded_rp6` and
      `test_ipv6_embedded_rp_ui` groups.
- [x] T2 + T3 contracts preserved (multicast6 / ssm6 unchanged).

Closes #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)