### PR TITLE
feat(v3.6.0): IPv6 PMTU helper (RFC 8200) (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Embedded-RP multicast (RFC 3956).** Build and decode `FF7x::/12`
   multicast groups with embedded RP address and RIID. Composes with
   the multicast scope decoder via deep-link. (#397)
+- **IPv6 PMTU helper.** Computes effective payload size, fragmentation
+  breakdown (offsets, M-bit, per-fragment payload), and surfaces
+  RFC 8200 §5 minimum link MTU (1280) warnings. Supports extension
+  header overhead accounting. (#399)
 
 ## [3.5.1] - 2026-05-09
 

--- a/Subnet-Calculator/api/openapi.yaml
+++ b/Subnet-Calculator/api/openapi.yaml
@@ -89,6 +89,8 @@ tags:
     description: SSM / unicast-prefix-based IPv6 multicast (RFC 3306 / RFC 4607) — bidirectional encode/decode of FF3x::/12 group addresses with embedded unicast prefix and 32-bit group ID
   - name: EmbeddedRp6
     description: Embedded-RP IPv6 multicast (RFC 3956) — bidirectional encode/decode of FF7x::/12 group addresses with the Rendezvous Point address and 4-bit RIID embedded directly in the group
+  - name: Pmtu6
+    description: IPv6 PMTU + fragmentation helper (RFC 8200) — compute effective payload, per-fragment breakdown, and surface the §5 minimum link MTU (1280) warning
   - name: Bulk
     description: Batch subnet calculation
   - name: Range
@@ -386,6 +388,7 @@ paths:
                     - "POST /api/v1/multicast6"
                     - "POST /api/v1/ssm6"
                     - "POST /api/v1/embedded-rp6"
+                    - "POST /api/v1/pmtu6"
                     - "POST /api/v1/bulk"
                     - "POST /api/v1/range/ipv4"
                     - "POST /api/v1/range6"
@@ -3605,6 +3608,195 @@ paths:
                   group_id: 305419896
         "400":
           description: Missing field or invalid embedded-RP input
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "401":
+          description: Missing or invalid Bearer token
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "404":
+          description: Endpoint disabled by $api_allowed_endpoints configuration
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
+            X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }
+            X-RateLimit-Reset:     { $ref: "#/components/headers/XRateLimitReset" }
+            Retry-After:           { $ref: "#/components/headers/RetryAfter" }
+          content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+  /pmtu6:
+    post:
+      operationId: pmtu6Compute
+      tags: [Pmtu6]
+      summary: Compute IPv6 PMTU + fragmentation breakdown (RFC 8200)
+      description: |
+        Compute the effective per-packet payload and per-fragment
+        breakdown for sending `payload_size` bytes over a path with the
+        given path MTU and optional list of extension-header sizes.
+
+        The IPv6 fixed header is always 40 bytes (RFC 8200 §3); each
+        extension header must be a positive multiple of 8 bytes. When
+        the payload exceeds `effective_payload`, the helper computes
+        the per-fragment breakdown using an 8-byte-aligned per-fragment
+        max payload (the trailing fragment carries the remainder with
+        M=0). The 8-byte Fragment header (RFC 8200 §4.5) is accounted
+        for automatically and is NOT included in `extension_headers`.
+
+        Path MTUs below the IPv6 minimum link MTU (1280, RFC 8200 §5)
+        are flagged in `meets_minimum` and surfaced via `notes`, but
+        still computed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path_mtu, payload_size]
+              properties:
+                path_mtu:
+                  type: integer
+                  minimum: 1
+                  description: Path MTU in bytes (must be > 0).
+                  example: 1500
+                payload_size:
+                  type: integer
+                  minimum: 0
+                  description: Upper-layer payload size in bytes.
+                  example: 3000
+                extension_headers:
+                  type: array
+                  description: Optional list of extension-header sizes in bytes. Each must be a positive multiple of 8. The 8-byte Fragment header is added automatically when fragmentation occurs and must NOT appear here.
+                  items:
+                    type: integer
+                    minimum: 8
+                  example: [8, 8]
+            examples:
+              no-fragmentation:
+                summary: 1500 MTU, 1000-byte payload (fits in one packet)
+                value: { path_mtu: 1500, payload_size: 1000 }
+              fragmentation:
+                summary: 1280 MTU, 3000-byte payload (3 fragments)
+                value: { path_mtu: 1280, payload_size: 3000 }
+              extensions:
+                summary: HBH + routing extension headers
+                value: { path_mtu: 1500, payload_size: 100, extension_headers: [8, 8] }
+              below-minimum:
+                summary: PMTU below RFC 8200 §5 minimum (1280)
+                value: { path_mtu: 1200, payload_size: 100 }
+      responses:
+        "200":
+          description: PMTU + fragmentation breakdown
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/OkEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required:
+                          - path_mtu
+                          - meets_minimum
+                          - fixed_header
+                          - extension_overhead
+                          - total_overhead
+                          - effective_payload
+                          - payload_size
+                          - needs_fragmentation
+                          - fragment_count
+                          - fragments
+                          - notes
+                        properties:
+                          path_mtu:
+                            type: integer
+                            example: 1280
+                          meets_minimum:
+                            type: boolean
+                            description: True when path_mtu >= 1280 (RFC 8200 §5).
+                            example: true
+                          fixed_header:
+                            type: integer
+                            description: Always 40 (RFC 8200 §3).
+                            example: 40
+                          extension_overhead:
+                            type: integer
+                            example: 0
+                          total_overhead:
+                            type: integer
+                            description: fixed_header + extension_overhead.
+                            example: 40
+                          effective_payload:
+                            type: integer
+                            description: path_mtu - total_overhead. Maximum payload that fits in one unfragmented packet.
+                            example: 1240
+                          payload_size:
+                            type: integer
+                            example: 3000
+                          needs_fragmentation:
+                            type: boolean
+                            example: true
+                          fragment_count:
+                            type: integer
+                            minimum: 1
+                            example: 3
+                          fragments:
+                            type: array
+                            description: Per-fragment breakdown. When fragmentation is not needed, exactly one virtual fragment is returned with offset=0 and m_bit=0.
+                            items:
+                              type: object
+                              required: [offset, m_bit, payload_bytes]
+                              properties:
+                                offset:
+                                  type: integer
+                                  description: Fragment offset in 8-byte units (RFC 8200 §4.5).
+                                  example: 0
+                                m_bit:
+                                  type: integer
+                                  enum: [0, 1]
+                                  description: More-fragments flag. 1 for all fragments except the last; 0 for the last (or the sole virtual fragment when no fragmentation is needed).
+                                  example: 1
+                                payload_bytes:
+                                  type: integer
+                                  example: 1232
+                          notes:
+                            type: array
+                            items: { type: string }
+                            example:
+                              - "End-host fragmentation only; routers do not fragment IPv6 per RFC 8200 §5."
+                              - "IPv6 fixed header is 40 bytes (RFC 8200 §3)."
+              example:
+                ok: true
+                data:
+                  path_mtu: 1280
+                  meets_minimum: true
+                  fixed_header: 40
+                  extension_overhead: 0
+                  total_overhead: 40
+                  effective_payload: 1240
+                  payload_size: 3000
+                  needs_fragmentation: true
+                  fragment_count: 3
+                  fragments:
+                    - { offset: 0,   m_bit: 1, payload_bytes: 1232 }
+                    - { offset: 154, m_bit: 1, payload_bytes: 1232 }
+                    - { offset: 308, m_bit: 0, payload_bytes: 536 }
+                  notes:
+                    - "End-host fragmentation only; routers do not fragment IPv6 per RFC 8200 §5."
+                    - "IPv6 fixed header is 40 bytes (RFC 8200 §3)."
+        "400":
+          description: Missing or invalid input
           headers:
             X-RateLimit-Limit:     { $ref: "#/components/headers/XRateLimitLimit" }
             X-RateLimit-Remaining: { $ref: "#/components/headers/XRateLimitRemaining" }

--- a/Subnet-Calculator/api/v1/handlers/pmtu6.php
+++ b/Subnet-Calculator/api/v1/handlers/pmtu6.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+if ($method !== 'POST') {
+    json_err('Method not allowed.', 405);
+}
+
+$body = api_body();
+
+if (!isset($body['path_mtu']) || !is_int($body['path_mtu'])) {
+    json_err('Field "path_mtu" (positive integer) is required.', 400);
+}
+if (!isset($body['payload_size']) || !is_int($body['payload_size'])) {
+    json_err('Field "payload_size" (non-negative integer) is required.', 400);
+}
+
+$path_mtu     = $body['path_mtu'];
+$payload_size = $body['payload_size'];
+
+$extension_headers = [];
+if (isset($body['extension_headers'])) {
+    if (!is_array($body['extension_headers'])) {
+        json_err('Field "extension_headers" must be an array of integers.', 400);
+    }
+    foreach ($body['extension_headers'] as $ext) {
+        if (!is_int($ext)) {
+            json_err('Field "extension_headers" must be an array of integers.', 400);
+        }
+        $extension_headers[] = $ext;
+    }
+}
+
+try {
+    $r = pmtu_compute($path_mtu, $payload_size, $extension_headers);
+} catch (\InvalidArgumentException $e) {
+    json_err($e->getMessage(), 400);
+}
+
+json_ok([
+    'path_mtu'            => $r['path_mtu'],
+    'meets_minimum'       => $r['meets_minimum'],
+    'fixed_header'        => $r['fixed_header'],
+    'extension_overhead'  => $r['extension_overhead'],
+    'total_overhead'      => $r['total_overhead'],
+    'effective_payload'   => $r['effective_payload'],
+    'payload_size'        => $r['payload_size'],
+    'needs_fragmentation' => $r['needs_fragmentation'],
+    'fragment_count'      => $r['fragment_count'],
+    'fragments'           => $r['fragments'],
+    'notes'               => $r['notes'],
+]);

--- a/Subnet-Calculator/api/v1/index.php
+++ b/Subnet-Calculator/api/v1/index.php
@@ -55,6 +55,9 @@ require_once $base . 'functions-ssm6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for build_embedded_rp_group()/decode_embedded_rp_group().
 require_once $base . 'functions-embedded-rp6.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for pmtu_compute().
+require_once $base . 'functions-pmtu6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require_once $base . 'functions-resolve.php';
@@ -153,6 +156,7 @@ if ($uri === '/' && $method === 'GET') {
             'POST /api/v1/multicast6',
             'POST /api/v1/ssm6',
             'POST /api/v1/embedded-rp6',
+            'POST /api/v1/pmtu6',
             'POST /api/v1/bulk',
             'POST /api/v1/sessions',
             'GET  /api/v1/sessions/{id}',
@@ -315,6 +319,9 @@ switch ($route_key) {
         break;
     case 'POST /embedded-rp6':
         require __DIR__ . '/handlers/embedded-rp6.php';
+        break;
+    case 'POST /pmtu6':
+        require __DIR__ . '/handlers/pmtu6.php';
         break;
     case 'POST /bulk':
         require __DIR__ . '/handlers/bulk.php';

--- a/Subnet-Calculator/includes/functions-pmtu6.php
+++ b/Subnet-Calculator/includes/functions-pmtu6.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+// IPv6 PMTU + fragmentation helper (v3.6.0 T5, #399).
+//
+// Computes effective payload size and the per-fragment breakdown that an
+// end host would emit when sending payload_size bytes over a path with
+// the given path MTU and extension-header overhead. Surfaces the
+// RFC 8200 §5 minimum-link-MTU warning (1280) and the rule that routers
+// do not fragment IPv6.
+//
+// The IPv6 fixed header is always 40 bytes (RFC 8200 §3). Extension
+// headers are independently sized (each must be a positive multiple of
+// 8). When fragmentation is required, an additional 8-byte Fragment
+// header (RFC 8200 §4.5) is added per fragment; the per-fragment
+// payload max is rounded down to an 8-byte boundary so that every
+// fragment except the last carries an 8-byte-aligned chunk. The last
+// fragment's payload is unrestricted (M=0).
+
+/**
+ * Compute IPv6 PMTU + fragmentation breakdown.
+ *
+ * @param int                  $path_mtu          Path MTU in bytes (must be > 0).
+ * @param int                  $payload_size      Payload size in bytes (>= 0).
+ * @param array<int|string,int> $extension_headers List of extension-header byte sizes
+ *                                                 (each must be > 0 and a multiple of 8).
+ *
+ * @return array{
+ *     path_mtu: int,
+ *     meets_minimum: bool,
+ *     fixed_header: int,
+ *     extension_overhead: int,
+ *     total_overhead: int,
+ *     effective_payload: int,
+ *     payload_size: int,
+ *     needs_fragmentation: bool,
+ *     fragment_count: int,
+ *     fragments: list<array{offset: int, m_bit: int, payload_bytes: int}>,
+ *     notes: list<string>
+ * }
+ *
+ * @throws InvalidArgumentException on invalid inputs.
+ */
+function pmtu_compute(int $path_mtu, int $payload_size, array $extension_headers = []): array
+{
+    if ($path_mtu <= 0) {
+        throw new InvalidArgumentException('Path MTU must be a positive integer.');
+    }
+    if ($payload_size < 0) {
+        throw new InvalidArgumentException('Payload size must be zero or a positive integer.');
+    }
+
+    $extension_overhead = 0;
+    foreach ($extension_headers as $ext) {
+        if (!is_int($ext) || $ext <= 0 || ($ext % 8) !== 0) {
+            throw new InvalidArgumentException(
+                'Each extension-header size must be a positive integer multiple of 8 bytes.'
+            );
+        }
+        $extension_overhead += $ext;
+    }
+
+    $fixed_header   = 40;
+    $total_overhead = $fixed_header + $extension_overhead;
+
+    if ($total_overhead >= $path_mtu) {
+        throw new InvalidArgumentException(
+            'Total header overhead (' . $total_overhead .
+            ' bytes) meets or exceeds the path MTU (' . $path_mtu . ' bytes).'
+        );
+    }
+
+    $effective_payload = $path_mtu - $total_overhead;
+    $meets_minimum     = $path_mtu >= 1280;
+
+    $notes = [];
+    if (!$meets_minimum) {
+        $notes[] = 'PMTU ' . $path_mtu .
+            ' is below the IPv6 minimum link MTU (1280) per RFC 8200 §5.';
+    }
+
+    $fragments = [];
+    if ($payload_size <= $effective_payload) {
+        // No fragmentation: one virtual fragment carrying the full payload.
+        $fragments[] = [
+            'offset'        => 0,
+            'm_bit'         => 0,
+            'payload_bytes' => $payload_size,
+        ];
+        $needs_fragmentation = false;
+        $fragment_count      = 1;
+    } else {
+        // Fragmentation required. Per-fragment max payload subtracts the
+        // 8-byte Fragment header and rounds down to an 8-byte boundary
+        // (RFC 8200 §4.5: fragment offset is in 8-byte units).
+        $per_fragment_max = intdiv($path_mtu - $total_overhead - 8, 8) * 8;
+        if ($per_fragment_max <= 0) {
+            throw new InvalidArgumentException(
+                'Path MTU is too small to carry any fragmented payload after ' .
+                'fixed and extension headers and the 8-byte Fragment header.'
+            );
+        }
+
+        $remaining   = $payload_size;
+        $byte_offset = 0;
+        while ($remaining > $per_fragment_max) {
+            $fragments[] = [
+                'offset'        => intdiv($byte_offset, 8),
+                'm_bit'         => 1,
+                'payload_bytes' => $per_fragment_max,
+            ];
+            $byte_offset += $per_fragment_max;
+            $remaining   -= $per_fragment_max;
+        }
+        // Last fragment — payload doesn't need to be 8-byte aligned.
+        $fragments[] = [
+            'offset'        => intdiv($byte_offset, 8),
+            'm_bit'         => 0,
+            'payload_bytes' => $remaining,
+        ];
+
+        $needs_fragmentation = true;
+        $fragment_count      = count($fragments);
+        $notes[] = 'End-host fragmentation only; routers do not fragment IPv6 per RFC 8200 §5.';
+    }
+
+    $notes[] = 'IPv6 fixed header is 40 bytes (RFC 8200 §3).';
+
+    return [
+        'path_mtu'             => $path_mtu,
+        'meets_minimum'        => $meets_minimum,
+        'fixed_header'         => $fixed_header,
+        'extension_overhead'   => $extension_overhead,
+        'total_overhead'       => $total_overhead,
+        'effective_payload'    => $effective_payload,
+        'payload_size'         => $payload_size,
+        'needs_fragmentation'  => $needs_fragmentation,
+        'fragment_count'       => $fragment_count,
+        'fragments'            => $fragments,
+        'notes'                => $notes,
+    ];
+}

--- a/Subnet-Calculator/includes/request.php
+++ b/Subnet-Calculator/includes/request.php
@@ -776,6 +776,77 @@ function sc_run_embedded_rp6(
 }
 
 /**
+ * Run the IPv6 PMTU helper against the supplied inputs. Computes the
+ * fragmentation breakdown for `payload_size` bytes over a path with the
+ * given `path_mtu` and optional list of extension-header sizes.
+ * Empty inputs return []. (v3.6.0 Task 5, RFC 8200, #399)
+ *
+ * @return array{
+ *     path_mtu_input?: string,
+ *     payload_size_input?: string,
+ *     extension_headers_input?: string,
+ *     result?: array{
+ *         path_mtu: int,
+ *         meets_minimum: bool,
+ *         fixed_header: int,
+ *         extension_overhead: int,
+ *         total_overhead: int,
+ *         effective_payload: int,
+ *         payload_size: int,
+ *         needs_fragmentation: bool,
+ *         fragment_count: int,
+ *         fragments: list<array{offset: int, m_bit: int, payload_bytes: int}>,
+ *         notes: list<string>
+ *     },
+ *     error?: string|null
+ * }
+ */
+function sc_run_pmtu6(
+    string $path_mtu_input,
+    string $payload_size_input,
+    string $extension_headers_input
+): array {
+    $pm = trim($path_mtu_input);
+    $ps = trim($payload_size_input);
+    $eh = trim($extension_headers_input);
+    if ($pm === '' && $ps === '' && $eh === '') {
+        return [];
+    }
+    $base_echo = [
+        'path_mtu_input'          => $pm,
+        'payload_size_input'      => $ps,
+        'extension_headers_input' => $eh,
+    ];
+    if (!ctype_digit($pm) || (int)$pm <= 0) {
+        return $base_echo + ['error' => 'Path MTU must be a positive integer.'];
+    }
+    if (!ctype_digit($ps)) {
+        return $base_echo + ['error' => 'Payload size must be a non-negative integer.'];
+    }
+    $ext_list = [];
+    if ($eh !== '') {
+        $parts = array_map('trim', explode(',', $eh));
+        foreach ($parts as $part) {
+            if ($part === '') {
+                continue;
+            }
+            if (!ctype_digit($part)) {
+                return $base_echo + [
+                    'error' => 'Each extension-header size must be a positive integer multiple of 8 bytes.',
+                ];
+            }
+            $ext_list[] = (int)$part;
+        }
+    }
+    try {
+        $r = pmtu_compute((int)$pm, (int)$ps, $ext_list);
+        return $base_echo + ['result' => $r, 'error' => null];
+    } catch (\InvalidArgumentException $e) {
+        return $base_echo + ['error' => $e->getMessage()];
+    }
+}
+
+/**
  * Parse a user-supplied group_id. Accepts decimal or 0x-hex.
  * Returns null on parse failure or out-of-range value.
  *
@@ -1573,6 +1644,13 @@ $embedded_rp6_ipv6_input             = '';
 /** @var array{mode?: 'encode'|'decode', input?: string, address?: string, scope?: int, rp_prefix?: string, rp_prefix_length?: int, rp_address?: string, riid?: int, group_id?: int, rp_address_input?: string, rp_prefix_length_input?: string, riid_input?: string, scope_input?: string, group_id_input?: string, error?: string|null} */
 $embedded_rp6 = [];
 
+// v3.6.0 Task 5 — IPv6 PMTU + fragmentation helper (RFC 8200, #399)
+$pmtu6_path_mtu_input          = '';
+$pmtu6_payload_size_input      = '';
+$pmtu6_extension_headers_input = '';
+/** @var array{path_mtu_input?: string, payload_size_input?: string, extension_headers_input?: string, result?: array{path_mtu: int, meets_minimum: bool, fixed_header: int, extension_overhead: int, total_overhead: int, effective_payload: int, payload_size: int, needs_fragmentation: bool, fragment_count: int, fragments: list<array{offset: int, m_bit: int, payload_bytes: int}>, notes: list<string>}, error?: string|null} */
+$pmtu6 = [];
+
 // v3.5.0 Task 10 — RFC 3531 sparse-allocation guidance
 $rfc3531_parent_input           = '';
 $rfc3531_reservation_bits_input = '';
@@ -1680,6 +1758,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || isset($_POST['embedded_rp6_scope'])
         || isset($_POST['embedded_rp6_group_id'])
         || isset($_POST['embedded_rp6_ipv6']);
+    $is_pmtu6         = isset($_POST['pmtu6_path_mtu'])
+        || isset($_POST['pmtu6_payload_size'])
+        || isset($_POST['pmtu6_extension_headers']);
 
     // Tool drawers (splitter/overlap/vlsm/vlsm6/supernet/ula/session/range/tree/wildcard/lookup/diff)
     // bypass honeypot/CAPTCHA gates because they're follow-on actions in an already-loaded session,
@@ -1694,7 +1775,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         || $is_rfc3531
         || $is_multicast6
         || $is_ssm6
-        || $is_embedded_rp6;
+        || $is_embedded_rp6
+        || $is_pmtu6;
 
     if (!$is_tool && $form_protection === 'honeypot') {
         if (trim((string)($_POST['url'] ?? '')) !== '') {
@@ -2264,6 +2346,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $embedded_rp6_scope_input,
             $embedded_rp6_group_id_input,
             $embedded_rp6_ipv6_input
+        );
+    }
+
+    if ($is_pmtu6 && !$form_blocked) {
+        $active_tab = 'ipv6';
+        $pmtu6_path_mtu_input          = trim((string)($_POST['pmtu6_path_mtu']          ?? ''));
+        $pmtu6_payload_size_input      = trim((string)($_POST['pmtu6_payload_size']      ?? ''));
+        $pmtu6_extension_headers_input = trim((string)($_POST['pmtu6_extension_headers'] ?? ''));
+        $pmtu6 = sc_run_pmtu6(
+            $pmtu6_path_mtu_input,
+            $pmtu6_payload_size_input,
+            $pmtu6_extension_headers_input
         );
     }
 
@@ -2909,6 +3003,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $embedded_rp6_scope_input,
             $embedded_rp6_group_id_input,
             $embedded_rp6_ipv6_input
+        );
+    }
+
+    // PMTU helper shareable GET URL (v3.6.0 Task 5, RFC 8200, #399)
+    if (
+        $active_tab === 'ipv6'
+        && (
+            isset($_GET['pmtu6_path_mtu'])
+            || isset($_GET['pmtu6_payload_size'])
+            || isset($_GET['pmtu6_extension_headers'])
+        )
+    ) {
+        $pmtu6_path_mtu_input          = trim((string)($_GET['pmtu6_path_mtu']          ?? ''));
+        $pmtu6_payload_size_input      = trim((string)($_GET['pmtu6_payload_size']      ?? ''));
+        $pmtu6_extension_headers_input = trim((string)($_GET['pmtu6_extension_headers'] ?? ''));
+        $pmtu6 = sc_run_pmtu6(
+            $pmtu6_path_mtu_input,
+            $pmtu6_payload_size_input,
+            $pmtu6_extension_headers_input
         );
     }
 

--- a/Subnet-Calculator/index.php
+++ b/Subnet-Calculator/index.php
@@ -47,6 +47,9 @@ require_once __DIR__ . '/includes/functions-ssm6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for build_embedded_rp_group()/decode_embedded_rp_group().
 require_once __DIR__ . '/includes/functions-embedded-rp6.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for pmtu_compute().
+require_once __DIR__ . '/includes/functions-pmtu6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require __DIR__ . '/includes/functions-tree.php';
 require __DIR__ . '/includes/functions-tree-diff.php';
 require __DIR__ . '/includes/functions-lookup.php';

--- a/Subnet-Calculator/templates/layout.php
+++ b/Subnet-Calculator/templates/layout.php
@@ -775,9 +775,10 @@ if ($i < 3) {
         elseif (!empty($multicast6)) { $open_tool_ipv6 = 'multicast'; }
         elseif (!empty($ssm6)) { $open_tool_ipv6 = 'ssm'; }
         elseif (!empty($embedded_rp6)) { $open_tool_ipv6 = 'embedded-rp'; }
+        elseif (!empty($pmtu6)) { $open_tool_ipv6 = 'pmtu'; }
         // v3.4.0 — fallback: /ipv6/<tool> rewrites to ?tool=<tool>; honour it
         // when no other GET trigger has already chosen a tool above.
-        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan','nibble','rfc3531','multicast','ssm','embedded-rp'];
+        $ipv6_tool_whitelist = ['split6','ula','range6','supernet6','zoneid','derive','slaac','lookup','diff','rdns6','mapped6','embedded-v4','6to4','teredo','isatap','6rd','prefix-plan','nibble','rfc3531','multicast','ssm','embedded-rp','pmtu'];
         if ($open_tool_ipv6 === null && $active_tab === 'ipv6'
             && in_array($requested_tool, $ipv6_tool_whitelist, true)) {
             $open_tool_ipv6 = $requested_tool;
@@ -806,6 +807,7 @@ if ($i < 3) {
             <button type="button" class="tool-trigger" data-tool="multicast" aria-expanded="false">Multicast Decoder</button>
             <button type="button" class="tool-trigger" data-tool="ssm" aria-expanded="false">SSM (RFC 3306)</button>
             <button type="button" class="tool-trigger" data-tool="embedded-rp" aria-expanded="false">Embedded-RP (RFC 3956)</button>
+            <button type="button" class="tool-trigger" data-tool="pmtu" aria-expanded="false">PMTU Helper</button>
         </div>
 
         <div class="tool-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title-ipv6">
@@ -2684,6 +2686,141 @@ if ($i < 3) {
                             </div>
                         </dl>
                         <p><small>RFC 3956. The flag nibble is fixed at 0x7 (R+P+T); SSM-only groups (P+T = 0x3) belong in the SSM tool.</small></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="tool-panel" data-tool="pmtu">
+                <div class="overlap-panel">
+                    <div class="overlap-title">IPv6 PMTU helper<?= help_bubble('ipv6-pmtu', 'Compute the effective payload and per-fragment breakdown for an IPv6 packet over a path with the given MTU and extension-header overhead. Surfaces RFC 8200 §5 minimum link MTU (1280) warnings, the rule that routers do not fragment IPv6, and the RFC 8200 §3 fixed 40-byte header. Per-fragment payload is rounded down to an 8-byte boundary; the last fragment carries the remainder with M=0.') ?></div>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="tab" value="ipv6">
+                        <div class="form-row">
+                            <div class="form-group form-group--mask">
+                                <label for="pmtu6_path_mtu">Path MTU (bytes)<?= help_bubble('pmtu6-path-mtu', 'Path MTU in bytes. The IPv6 minimum link MTU is 1280 (RFC 8200 §5); values below that are flagged but still computed. Common values: 1280 (IPv6 minimum), 1500 (Ethernet), 9000 (jumbo frame).') ?></label>
+                                <input type="number" id="pmtu6_path_mtu" name="pmtu6_path_mtu"
+                                       value="<?= htmlspecialchars($pmtu6_path_mtu_input ?? '') ?>"
+                                       min="1"
+                                       placeholder="1500"
+                                       autocomplete="off"
+                                       <?= !empty($pmtu6['error']) ? 'aria-invalid="true" aria-describedby="pmtu6-error"' : '' ?>>
+                            </div>
+                            <div class="form-group form-group--mask">
+                                <label for="pmtu6_payload_size">Payload size (bytes)<?= help_bubble('pmtu6-payload-size', 'Upper-layer payload to send (bytes). Zero is allowed. If the payload exceeds the effective per-packet payload, the helper computes the per-fragment breakdown.') ?></label>
+                                <input type="number" id="pmtu6_payload_size" name="pmtu6_payload_size"
+                                       value="<?= htmlspecialchars($pmtu6_payload_size_input ?? '') ?>"
+                                       min="0"
+                                       placeholder="3000"
+                                       autocomplete="off">
+                            </div>
+                            <div class="form-group">
+                                <label for="pmtu6_extension_headers">Extension headers (bytes, comma-separated)<?= help_bubble('pmtu6-extension-headers', 'Optional list of extension-header sizes in bytes, separated by commas. Each value must be a positive multiple of 8. Example: <code>8,8</code> for Hop-by-Hop + Routing. The 8-byte Fragment header (RFC 8200 §4.5) is added automatically per fragment when fragmentation is needed.') ?></label>
+                                <input type="text" id="pmtu6_extension_headers" name="pmtu6_extension_headers"
+                                       value="<?= htmlspecialchars($pmtu6_extension_headers_input ?? '') ?>"
+                                       placeholder="e.g. 8,8 for HBH+routing"
+                                       autocomplete="off" spellcheck="false">
+                            </div>
+                        </div>
+                        <div class="splitter-row">
+                            <button type="submit" class="splitter-btn">Compute</button>
+                        </div>
+                    </form>
+                    <?php if (!empty($pmtu6['error'])) : ?>
+                        <div class="error" id="pmtu6-error"><?= htmlspecialchars((string)$pmtu6['error']) ?></div>
+                    <?php elseif (!empty($pmtu6['result'])) : ?>
+                        <?php
+                        $_pmtu_r       = $pmtu6['result'];
+                        $_pmtu_history = sprintf(
+                            'pmtu: %d / %d',
+                            (int)$_pmtu_r['path_mtu'],
+                            (int)$_pmtu_r['payload_size']
+                        );
+                        ?>
+                        <dl class="zoneid-result"
+                            data-history-source="pmtu"
+                            data-history-active="1"
+                            data-history-label="<?= htmlspecialchars($_pmtu_history) ?>">
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Path MTU</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)$_pmtu_r['path_mtu'] ?> bytes</code>
+                                    <?php if (!$_pmtu_r['meets_minimum']) : ?>
+                                        <small> (below IPv6 minimum 1280)</small>
+                                    <?php endif; ?>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Fixed header</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)$_pmtu_r['fixed_header'] ?> bytes</code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Extension overhead</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)$_pmtu_r['extension_overhead'] ?> bytes</code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Total overhead</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)$_pmtu_r['total_overhead'] ?> bytes</code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Effective payload</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)$_pmtu_r['effective_payload'] ?> bytes</code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Payload size</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)$_pmtu_r['payload_size'] ?> bytes</code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Needs fragmentation</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= $_pmtu_r['needs_fragmentation'] ? 'yes' : 'no' ?></code>
+                                </dd>
+                            </div>
+                            <div class="zoneid-result__row">
+                                <dt class="zoneid-result__label">Fragment count</dt>
+                                <dd class="zoneid-result__value">
+                                    <code><?= (int)$_pmtu_r['fragment_count'] ?></code>
+                                </dd>
+                            </div>
+                        </dl>
+                        <?php if ($_pmtu_r['needs_fragmentation']) : ?>
+                            <table class="vlsm-table" style="margin-top:1rem;">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">#</th>
+                                        <th scope="col">Offset (8-byte units)</th>
+                                        <th scope="col">M-bit</th>
+                                        <th scope="col">Payload bytes</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($_pmtu_r['fragments'] as $_frag_i => $_frag) : ?>
+                                        <tr>
+                                            <td><?= (int)$_frag_i + 1 ?></td>
+                                            <td><code><?= (int)$_frag['offset'] ?></code></td>
+                                            <td><code><?= (int)$_frag['m_bit'] ?></code></td>
+                                            <td><code><?= (int)$_frag['payload_bytes'] ?></code></td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        <?php endif; ?>
+                        <?php if (!empty($_pmtu_r['notes'])) : ?>
+                            <ul class="zoneid-notes" style="margin-top:1rem;">
+                                <?php foreach ($_pmtu_r['notes'] as $_pmtu_note) : ?>
+                                    <li><?= htmlspecialchars((string)$_pmtu_note) ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
                     <?php endif; ?>
                 </div>
             </div>

--- a/docs/pmtu6.md
+++ b/docs/pmtu6.md
@@ -1,0 +1,80 @@
+# IPv6 PMTU Helper
+
+The IPv6 PMTU helper computes the effective per-packet payload and
+per-fragment breakdown for sending a payload over a path with a given
+MTU and optional list of extension-header sizes.
+
+It surfaces three rules from RFC 8200 alongside the numeric output:
+
+- The IPv6 fixed header is always 40 bytes (RFC 8200 §3).
+- The minimum link MTU is 1280 bytes (RFC 8200 §5); path MTUs below
+  that are flagged in `meets_minimum` and via a note, but still
+  computed.
+- Routers do not fragment IPv6 — fragmentation is an end-host
+  operation only (RFC 8200 §5).
+
+## Inputs
+
+| Field | Required | Notes |
+|---|---|---|
+| `path_mtu` | yes | Path MTU in bytes; must be a positive integer. |
+| `payload_size` | yes | Upper-layer payload size in bytes; zero is allowed. |
+| `extension_headers` | no | Comma-separated list of extension-header sizes (UI) or array of integers (API). Each must be a positive multiple of 8. |
+
+The 8-byte Fragment header (RFC 8200 §4.5) is **not** listed in
+`extension_headers` — it is added automatically per fragment when
+fragmentation is needed.
+
+## Output fields
+
+- `path_mtu`, `meets_minimum`
+- `fixed_header` (always 40), `extension_overhead`, `total_overhead`
+- `effective_payload` — `path_mtu - total_overhead`; the maximum
+  payload that fits in one unfragmented packet.
+- `payload_size`, `needs_fragmentation`, `fragment_count`
+- `fragments` — list of `{offset, m_bit, payload_bytes}`. When no
+  fragmentation is needed, exactly one virtual fragment is returned
+  with `offset=0` and `m_bit=0`.
+- `notes` — RFC-anchored notes appended based on the inputs.
+
+When fragmentation is required, the per-fragment max payload is
+`floor((path_mtu - total_overhead - 8) / 8) * 8`, rounded down to an
+8-byte boundary because the Fragment header offset is in 8-byte units.
+The trailing fragment carries the remainder with `m_bit=0`; its
+payload does not need to be 8-byte aligned.
+
+## Examples
+
+### No fragmentation (1500 MTU, 1000 payload)
+
+| Field | Value |
+|---|---|
+| Effective payload | 1460 |
+| Needs fragmentation | no |
+| Fragment count | 1 |
+
+### Fragmentation (1280 MTU, 3000 payload)
+
+| # | Offset (8-byte units) | M-bit | Payload bytes |
+|---|---|---|---|
+| 1 | 0   | 1 | 1232 |
+| 2 | 154 | 1 | 1232 |
+| 3 | 308 | 0 | 536  |
+
+Per-fragment max = `floor((1280 - 40 - 8) / 8) * 8 = 1232`. Three
+fragments cover 3000 bytes.
+
+### Below minimum (PMTU 1200)
+
+`meets_minimum` is `false` and the notes include
+`PMTU 1200 is below the IPv6 minimum link MTU (1280) per RFC 8200 §5.`
+
+## REST API
+
+`POST /api/v1/pmtu6` — see the OpenAPI spec for the full schema and
+worked examples.
+
+## Shareable URLs
+
+`?pmtu6_path_mtu=1280&pmtu6_payload_size=3000&pmtu6_extension_headers=8,8`
+on the IPv6 tab pre-fills the inputs and runs the helper on page load.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - IPv6 Multicast Decoder: multicast6.md
     - IPv6 SSM (RFC 3306): ssm6.md
     - IPv6 Embedded-RP (RFC 3956): embedded-rp6.md
+    - IPv6 PMTU Helper: pmtu6.md
     - Allocation Tree: tree.md
     - Wildcard ↔ CIDR: wildcard.md
     - IP Lookup: lookup.md

--- a/testing/scripts/playwright_test.py
+++ b/testing/scripts/playwright_test.py
@@ -3455,6 +3455,137 @@ async def test_ipv6_embedded_rp_ui(page: Page) -> None:
                 len(err_text) > 0, f"got: {err_text!r}")
 
 
+async def test_api_pmtu6(page: Page) -> None:
+    section("API — POST /api/v1/pmtu6")
+
+    # No-fragmentation case — 1500 MTU, 1000-byte payload.
+    status, data = _api_post("pmtu6", {"path_mtu": 1500, "payload_size": 1000})
+    assert_eq("api pmtu6 (fits): HTTP 200", status, 200)
+    assert_eq("api pmtu6 (fits): ok=true", data.get("ok"), True)
+    d = data.get("data", {})
+    assert_eq("api pmtu6 (fits): fixed_header", d.get("fixed_header"), 40)
+    assert_eq("api pmtu6 (fits): effective_payload",
+              d.get("effective_payload"), 1460)
+    assert_eq("api pmtu6 (fits): needs_fragmentation",
+              d.get("needs_fragmentation"), False)
+    assert_eq("api pmtu6 (fits): fragment_count", d.get("fragment_count"), 1)
+    assert_eq("api pmtu6 (fits): meets_minimum", d.get("meets_minimum"), True)
+
+    # Fragmentation case — 1280 MTU, 3000-byte payload, 3 fragments.
+    status2, data2 = _api_post("pmtu6", {"path_mtu": 1280, "payload_size": 3000})
+    assert_eq("api pmtu6 (frag): HTTP 200", status2, 200)
+    d2 = data2.get("data", {})
+    assert_eq("api pmtu6 (frag): needs_fragmentation",
+              d2.get("needs_fragmentation"), True)
+    assert_eq("api pmtu6 (frag): fragment_count", d2.get("fragment_count"), 3)
+    frags = d2.get("fragments") or []
+    assert_eq("api pmtu6 (frag): first payload", frags[0].get("payload_bytes"), 1232)
+    assert_eq("api pmtu6 (frag): first m_bit", frags[0].get("m_bit"), 1)
+    assert_eq("api pmtu6 (frag): second offset", frags[1].get("offset"), 154)
+    assert_eq("api pmtu6 (frag): last m_bit", frags[2].get("m_bit"), 0)
+    assert_eq("api pmtu6 (frag): last payload", frags[2].get("payload_bytes"), 536)
+
+    # Below-minimum PMTU is flagged but still computed.
+    status3, data3 = _api_post("pmtu6", {"path_mtu": 1200, "payload_size": 100})
+    assert_eq("api pmtu6 (below-min): HTTP 200", status3, 200)
+    d3 = data3.get("data", {})
+    assert_eq("api pmtu6 (below-min): meets_minimum",
+              d3.get("meets_minimum"), False)
+    notes = d3.get("notes") or []
+    assert_true("api pmtu6 (below-min): minimum-link-MTU note rendered",
+                any("1280" in str(n) for n in notes))
+
+    # Extension headers are accumulated.
+    status4, data4 = _api_post("pmtu6", {
+        "path_mtu": 1500,
+        "payload_size": 100,
+        "extension_headers": [8, 8, 8],
+    })
+    assert_eq("api pmtu6 (ext): HTTP 200", status4, 200)
+    d4 = data4.get("data", {})
+    assert_eq("api pmtu6 (ext): extension_overhead",
+              d4.get("extension_overhead"), 24)
+    assert_eq("api pmtu6 (ext): total_overhead", d4.get("total_overhead"), 64)
+    assert_eq("api pmtu6 (ext): effective_payload",
+              d4.get("effective_payload"), 1436)
+
+    # Invalid path_mtu (zero) → 400.
+    status5, _ = _api_post("pmtu6", {"path_mtu": 0, "payload_size": 100})
+    assert_eq("api pmtu6: zero path_mtu → 400", status5, 400)
+
+    # Extension header not multiple of 8 → 400.
+    status6, _ = _api_post("pmtu6", {
+        "path_mtu": 1500,
+        "payload_size": 100,
+        "extension_headers": [7],
+    })
+    assert_eq("api pmtu6: bad ext header → 400", status6, 400)
+
+    # Missing fields → 400.
+    status7, _ = _api_post("pmtu6", {})
+    assert_eq("api pmtu6: missing fields → 400", status7, 400)
+
+
+async def test_ipv6_pmtu_ui(page: Page) -> None:
+    section("IPv6 PMTU helper UI")
+
+    # ?tool=pmtu should auto-open the drawer.
+    await navigate(page, APP_URL + "?tab=ipv6&tool=pmtu")
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='pmtu']")
+    assert_eq("pmtu UI: panel exists", await panel.count(), 1)
+
+    # No-fragmentation submit.
+    await page.fill("#pmtu6_path_mtu", "1500")
+    await page.fill("#pmtu6_payload_size", "1000")
+    await page.click("#panel-ipv6 .tool-panel[data-tool='pmtu'] button.splitter-btn")
+    await page.wait_for_load_state("load")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='pmtu']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("pmtu UI: effective_payload rendered (1460)",
+                "1460" in body_text)
+    assert_true("pmtu UI: no fragmentation rendered",
+                "no" in body_text)
+
+    # Fragmentation submit via shareable GET URL.
+    await navigate(
+        page,
+        APP_URL + "?tab=ipv6&tool=pmtu&pmtu6_path_mtu=1280&pmtu6_payload_size=3000",
+    )
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='pmtu']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("pmtu UI: fragmentation count 3 rendered",
+                "3" in body_text)
+    assert_true("pmtu UI: fragment payload 1232 rendered",
+                "1232" in body_text)
+    assert_true("pmtu UI: fragment payload 536 rendered",
+                "536" in body_text)
+
+    # Below-minimum warning rendered.
+    await navigate(
+        page,
+        APP_URL + "?tab=ipv6&tool=pmtu&pmtu6_path_mtu=1200&pmtu6_payload_size=100",
+    )
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='pmtu']")
+    body_text = (await panel.text_content() or "").lower()
+    assert_true("pmtu UI: minimum-link-MTU warning rendered",
+                "1280" in body_text)
+
+    # Error path — invalid extension header.
+    await navigate(
+        page,
+        APP_URL + "?tab=ipv6&tool=pmtu&pmtu6_path_mtu=1500"
+        "&pmtu6_payload_size=100&pmtu6_extension_headers=7",
+    )
+    await page.wait_for_selector("#panel-ipv6 .tool-drawer.open")
+    panel = page.locator("#panel-ipv6 .tool-panel[data-tool='pmtu']")
+    err_text = await panel.locator(".error").text_content() or ""
+    assert_true("pmtu UI: error band on bad ext header",
+                len(err_text) > 0, f"got: {err_text!r}")
+
+
 async def test_api_6to4(page: Page) -> None:
     section("API — POST /api/v1/6to4")
 
@@ -9772,6 +9903,8 @@ async def main() -> None:
             await test_api_ssm6(page)
             await test_ipv6_embedded_rp_ui(page)
             await test_api_embedded_rp6(page)
+            await test_ipv6_pmtu_ui(page)
+            await test_api_pmtu6(page)
             await test_a11y_ipv6_drawers(page)
             # v3.5.0 (T11) — bulk endpoint coverage + a11y for the 9 new drawers
             await test_api_bulk_covers_v350_endpoints(page)

--- a/testing/unit/Pmtu6Test.php
+++ b/testing/unit/Pmtu6Test.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class Pmtu6Test extends TestCase
+{
+    public function test_no_fragmentation_when_payload_fits(): void
+    {
+        $r = pmtu_compute(1500, 1000);
+        $this->assertSame(40, $r['fixed_header']);
+        $this->assertSame(0, $r['extension_overhead']);
+        $this->assertSame(40, $r['total_overhead']);
+        $this->assertSame(1460, $r['effective_payload']);
+        $this->assertFalse($r['needs_fragmentation']);
+        $this->assertSame(1, $r['fragment_count']);
+        $this->assertCount(1, $r['fragments']);
+        $this->assertSame(0, $r['fragments'][0]['offset']);
+        $this->assertSame(0, $r['fragments'][0]['m_bit']);
+        $this->assertSame(1000, $r['fragments'][0]['payload_bytes']);
+        $this->assertTrue($r['meets_minimum']);
+    }
+
+    public function test_fragmentation_when_payload_exceeds(): void
+    {
+        // PMTU 1280, no extensions, payload 3000.
+        // Per-fragment payload max = floor((1280 - 40 - 8) / 8) * 8 = floor(1232/8)*8 = 1232.
+        // 3000 / 1232 → 3 fragments: 1232 + 1232 + 536.
+        $r = pmtu_compute(1280, 3000);
+        $this->assertTrue($r['needs_fragmentation']);
+        $this->assertSame(3, $r['fragment_count']);
+        $this->assertCount(3, $r['fragments']);
+        $this->assertSame(0, $r['fragments'][0]['offset']);
+        $this->assertSame(1, $r['fragments'][0]['m_bit']);
+        $this->assertSame(1232, $r['fragments'][0]['payload_bytes']);
+        $this->assertSame(154, $r['fragments'][1]['offset']);   // 1232 / 8 = 154 (8-byte units)
+        $this->assertSame(1, $r['fragments'][1]['m_bit']);
+        $this->assertSame(1232, $r['fragments'][1]['payload_bytes']);
+        $this->assertSame(308, $r['fragments'][2]['offset']);   // 2464 / 8 = 308
+        $this->assertSame(0, $r['fragments'][2]['m_bit']);     // last fragment M=0
+        $this->assertSame(536, $r['fragments'][2]['payload_bytes']);
+    }
+
+    public function test_below_minimum_flagged(): void
+    {
+        $r = pmtu_compute(1200, 100);
+        $this->assertFalse($r['meets_minimum']);
+        $this->assertContains(
+            'PMTU 1200 is below the IPv6 minimum link MTU (1280) per RFC 8200 §5.',
+            $r['notes']
+        );
+    }
+
+    public function test_extension_headers_accumulated(): void
+    {
+        // HBH (8) + routing (8) + dest-opts (8) = 24 bytes overhead beyond fixed 40.
+        $r = pmtu_compute(1500, 100, [8, 8, 8]);
+        $this->assertSame(24, $r['extension_overhead']);
+        $this->assertSame(64, $r['total_overhead']);
+        $this->assertSame(1436, $r['effective_payload']);
+        $this->assertFalse($r['needs_fragmentation']);
+    }
+
+    public function test_invalid_path_mtu_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        pmtu_compute(0, 100);
+    }
+
+    public function test_extension_header_not_multiple_of_8_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        pmtu_compute(1500, 100, [7]);
+    }
+
+    public function test_negative_payload_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        pmtu_compute(1500, -1);
+    }
+
+    public function test_zero_byte_extension_header_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        pmtu_compute(1500, 100, [0]);
+    }
+
+    public function test_notes_include_router_and_fixed_header(): void
+    {
+        $r = pmtu_compute(1280, 3000);
+        $this->assertContains(
+            'End-host fragmentation only; routers do not fragment IPv6 per RFC 8200 §5.',
+            $r['notes']
+        );
+        $this->assertContains(
+            'IPv6 fixed header is 40 bytes (RFC 8200 §3).',
+            $r['notes']
+        );
+    }
+
+    public function test_zero_payload_no_fragmentation(): void
+    {
+        $r = pmtu_compute(1500, 0);
+        $this->assertFalse($r['needs_fragmentation']);
+        $this->assertSame(1, $r['fragment_count']);
+        $this->assertSame(0, $r['fragments'][0]['payload_bytes']);
+    }
+
+    public function test_exact_fit_no_fragmentation(): void
+    {
+        // payload exactly equals effective_payload → fits in one packet.
+        $r = pmtu_compute(1500, 1460);
+        $this->assertFalse($r['needs_fragmentation']);
+        $this->assertSame(1, $r['fragment_count']);
+        $this->assertSame(1460, $r['fragments'][0]['payload_bytes']);
+    }
+
+    public function test_one_byte_over_triggers_fragmentation(): void
+    {
+        // PMTU 1500: effective = 1460. Payload 1461 → fragmentation.
+        // Per-fragment max = floor((1500-40-8)/8)*8 = floor(1452/8)*8 = 1448.
+        // 1461 = 1448 + 13.
+        $r = pmtu_compute(1500, 1461);
+        $this->assertTrue($r['needs_fragmentation']);
+        $this->assertSame(2, $r['fragment_count']);
+        $this->assertSame(1448, $r['fragments'][0]['payload_bytes']);
+        $this->assertSame(1, $r['fragments'][0]['m_bit']);
+        $this->assertSame(181, $r['fragments'][1]['offset']);  // 1448 / 8 = 181
+        $this->assertSame(0, $r['fragments'][1]['m_bit']);
+        $this->assertSame(13, $r['fragments'][1]['payload_bytes']);
+    }
+}

--- a/testing/unit/bootstrap.php
+++ b/testing/unit/bootstrap.php
@@ -46,6 +46,9 @@ require_once $base . 'functions-ssm6.php';
 // phpcs:disable PSR1.Files.SideEffects -- module include for build_embedded_rp_group()/decode_embedded_rp_group().
 require_once $base . 'functions-embedded-rp6.php';
 // phpcs:enable PSR1.Files.SideEffects
+// phpcs:disable PSR1.Files.SideEffects -- module include for pmtu_compute().
+require_once $base . 'functions-pmtu6.php';
+// phpcs:enable PSR1.Files.SideEffects
 require $base . 'functions-ula.php';
 require $base . 'functions-session.php';
 require $base . 'functions-resolve.php';


### PR DESCRIPTION
## Summary

- Adds the v3.6.0 IPv6 PMTU helper (Task 5, #399). Computes effective payload, fragmentation breakdown (offsets, M-bit, per-fragment payload), and surfaces RFC 8200 §3 fixed-header, §4.5 fragmentation, and §5 minimum-link-MTU rules.
- Single-mode tool (compute-only). Independent of multicast — no scope-decoder integration.
- New `pmtu_compute()` in `Subnet-Calculator/includes/functions-pmtu6.php`; new `POST /api/v1/pmtu6`; drawer wired into the IPv6 tab with shareable POST + GET.

## Implementation notes

- IPv6 fixed header is always 40 bytes; extension headers must be positive multiples of 8 (validated server-side).
- Per-fragment payload max = `floor((path_mtu - total_overhead - 8) / 8) * 8` — accounts for the 8-byte Fragment header automatically and rounds to an 8-byte boundary because RFC 8200 §4.5 uses 8-byte units for fragment offsets. The trailing fragment carries the remainder with M=0 and is not 8-byte-aligned.
- PMTU below 1280 is flagged in `meets_minimum` and via `notes`, but still computed.
- Single virtual fragment returned in the no-fragmentation path (offset=0, m_bit=0, payload_bytes=payload_size) for a stable shape.

## Test plan

- [x] PHPUnit — 12 tests / 48 assertions in `testing/unit/Pmtu6Test.php` (full suite: 762/762 passing, 14 skipped on platforms without GMP).
- [x] PHPStan level 9 (`--memory-limit=512M`) clean.
- [x] PHPCS clean for new files; no new errors introduced in shared files (request.php, layout.php errors are pre-existing patterns).
- [x] Spectral — `npx @stoplight/spectral-cli@6 lint` reports no errors.
- [x] ESLint + Stylelint — 0 errors (existing warnings unchanged).
- [x] Semgrep — `p/php`, `p/owasp-top-ten`, `p/sql-injection` + custom rules — 0 findings.
- [x] Playwright (`make test-docker`) — 2306/2306 passing including new `test_api_pmtu6` + `test_ipv6_pmtu_ui`.
- [x] T2 / T3 / T4 contracts unchanged — only additive wiring (new `is_pmtu6` POST flag, new whitelist entry, new open-chain branch); no edits to multicast6 / ssm6 / embedded-rp6 logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)