### PR TITLE
docs(internal): establish docs/internal/ as single-source-of-truth doc set

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,5 +15,16 @@ Run the full Subnet Calculator release workflow:
    - Bump `extra.version` in `mkdocs.yml` to `"X.Y.Z"`.
    - Update the tarball filename in `docs/index.md` (the `tar -xzf` install snippet).
 7. Build the release tarball: `tar -czf releases/subnet-calculator-X.Y.Z.tar.gz -C Subnet-Calculator .`
-8. Commit all changes with message: `release: vX.Y.Z`
-9. Confirm with user before pushing and opening a PR from `dev → main`.
+8. **Sync internal docs** (`docs/internal/`). Review the per-release spec/plan files (`docs/superpowers/specs/` and `docs/superpowers/plans/`) for this version and propagate anything load-bearing into the long-lived docs:
+   - `design-document.md` — new invariants (§5), design decisions (§6), tools (§7), endpoints (§8); update scale numbers (test counts, line counts) in §3/§9.
+   - `design-guide.md` — new UX patterns or principles.
+   - `coding-guide.md` — convention changes.
+   - `api-contract.md` — new error codes, breaking-change notes, deprecations.
+   - `data-dictionary.md` — schema, column, index, migration, or DB-path changes.
+   - `config-reference.md` — added/removed/renamed/redefaulted operator config variables.
+   - `security-model.md` — threat-surface changes or new controls.
+   - `runbooks.md` — new incident classes learned this cycle.
+   - Bump the "Last updated" header on every doc touched.
+   - If nothing changed for a given doc, skip it (don't bump just to bump).
+9. Commit all changes with message: `release: vX.Y.Z`
+10. Confirm with user before pushing and opening a PR from `dev → main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,208 +1,92 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Agent quick-reference for this repository. **Source of truth for "how this project works" is `docs/internal/`** — start there for anything beyond the commands and operational quirks below.
+
+## Internal documentation
+
+| If you need… | Read |
+|---|---|
+| Architecture, invariants, design decisions | [`docs/internal/design-document.md`](docs/internal/design-document.md) |
+| UX principles before adding tools / changing UI | [`docs/internal/design-guide.md`](docs/internal/design-guide.md) |
+| PHP / JS / CSS conventions before writing code | [`docs/internal/coding-guide.md`](docs/internal/coding-guide.md) |
+| Test layers, when to add what | [`docs/internal/testing-guide.md`](docs/internal/testing-guide.md) |
+| Threat model + trust boundaries | [`docs/internal/security-model.md`](docs/internal/security-model.md) |
+| API versioning + breaking-change policy | [`docs/internal/api-contract.md`](docs/internal/api-contract.md) |
+| SQLite schemas + migration policy | [`docs/internal/data-dictionary.md`](docs/internal/data-dictionary.md) |
+| Operator-tunable config variables | [`docs/internal/config-reference.md`](docs/internal/config-reference.md) |
+| What to do when production breaks | [`docs/internal/runbooks.md`](docs/internal/runbooks.md) |
+| Index + reading order | [`docs/internal/README.md`](docs/internal/README.md) |
+
+## Hot invariants (must hold in working memory)
+
+Full list: [`docs/internal/design-document.md`](docs/internal/design-document.md) §5 (22 invariants). The ones you cannot afford to look up:
+
+1. **IPv4 arithmetic:** mask every bitwise op with `& 0xFFFFFFFF` — `ip2long` is signed on 64-bit.
+2. **IPv6 arithmetic:** GMP only. Subnet counts ≥ 2^63 return as the string `"2^N"`.
+3. **Output escaping:** `htmlspecialchars($val, ENT_QUOTES, 'UTF-8')` on every echo.
+4. **Production deploy:** anchored rsync excludes (`--exclude='/config.php' --exclude='/data/'`) + `sleep 3` after `systemctl restart lsws`.
+5. **`CACHE_NAME` in `sw.js`:** bump every release. Skipped bumps break the service-worker shell silently (the v3.2.2 lesson).
+6. **`--color-bg` CSS custom property:** never rename. iframe consumers depend on the exact name.
+7. **Pure functions + boundary validation:** `request.php` / handlers validate; functions in `includes/*.php` trust their inputs.
 
 ## Development
 
-**Prereqs (macOS):** `brew install gnu-tar` — the release build uses `gtar`
-to strip build-user UID/GID from tarball entries (`--owner=0 --group=0
---numeric-owner`) and to avoid the macOS-only PAX xattr records that
-bsdtar otherwise materialises as `._FILENAME` AppleDouble sidecars on
-extract. The other PHP/composer/node tools are standard.
+**Prereqs (macOS):** `brew install gnu-tar`. The release build uses `gtar` to strip build-user UID/GID and skip macOS PAX xattr records that bsdtar would materialise as `._FILENAME` AppleDouble sidecars.
+
+**QA gates (PHPUnit, PHPStan, PHPCS, ESLint/Stylelint, Spectral, Semgrep, `make test-docker`):** canonical command list lives in [`testing-guide.md`](docs/internal/testing-guide.md) "Running tests locally." Run them all green before pushing any PR.
 
 ```bash
 # Run the app locally (serve the Subnet-Calculator/ subfolder)
 php -S localhost:8080 -t Subnet-Calculator/
 
-# Syntax check all PHP files
-php -l Subnet-Calculator/index.php
-for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php \
-         Subnet-Calculator/api/v1/*.php Subnet-Calculator/api/v1/handlers/*.php; do php -l "$f"; done
-
-# Static analysis (PHPStan level 9, configured in phpstan.neon)
-# --memory-limit=512M required — default 128M causes a crash on this codebase
-phpstan analyse --no-progress --memory-limit=512M
-
-# Unit tests (PHPUnit 11, requires: composer install)
-composer install --no-interaction --prefer-dist
-vendor/bin/phpunit
-
-# PHPCS (PSR-12) — use .phpcs.xml for config
-vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
-
-# PHPCS — admin/*.php template-aware ruleset (PSR-12 with relaxations for
-# inline `<?php if (...): ?>...<?php endif; ?>` patterns and HTML/PHP
-# transitions in mixed-output controller pages).
-vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/
-
-# JS/CSS linting (requires: npm install)
-npm run lint:js   # ESLint on app.js
-npm run lint:css  # Stylelint on app.css
-npm run lint      # both
-
-# OpenAPI spec lint (errors fail; warnings should be reviewed and triaged each run)
-npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
-
-# Security scan
-semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten \
-    --config p/sql-injection --error \
-    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
-
-# Run the end-to-end browser test suite via Docker (preferred — no dev server needed)
-# SKIP_SNAPSHOTS=1 and SKIP_LINT=1 set automatically via docker-compose.yml
-# Run npm run lint separately for ESLint/Stylelint; update snapshots via dev server flow
-make test-docker
-
-# Deploy to test instance (manual inspection — Playwright runs via make test-docker, no dev server needed)
-# Requires: dev server running at root@192.168.80.15
+# Deploy to dev test instance for manual inspection
 rsync -a --delete Subnet-Calculator/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
 scp testing/fixtures/iframe-test.html root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
 
-# Build a release tarball (files at root level — untar directly in webroot to install/upgrade)
-# Also bump $app_version in Subnet-Calculator/includes/config.php before building
-# CHANGELOG.md is bundled so GET /api/v1/changelog works in tarball installs
+# Build a release tarball (admin/_test-drain.php is test-rig only — never ship it; #324)
 cp CHANGELOG.md Subnet-Calculator/CHANGELOG.md
-# Use GNU tar (gtar on macOS — `brew install gnu-tar`) so we can strip the
-# build user's UID/GID and skip macOS-only PAX xattr records that bsdtar
-# would otherwise materialise as `._FILENAME` AppleDouble sidecars on
-# extract. --owner=0 --group=0 --numeric-owner make the artifact
-# reproducible and prevent leaking local account names into the tarball.
-# admin/_test-drain.php is a test-rig-only endpoint (#324) — never ship it.
 gtar --owner=0 --group=0 --numeric-owner \
      --exclude='admin/_test-drain.php' \
      -czf releases/subnet-calculator-X.Y.Z.tar.gz -C Subnet-Calculator .
 rm Subnet-Calculator/CHANGELOG.md
 ```
 
-**Release checklist:**
-1. Bump `$app_version` in `Subnet-Calculator/includes/config.php`
-2. **Bump `CACHE_NAME` in `Subnet-Calculator/sw.js`** to `sc-vX.Y.Z`. The
-   service worker's activate handler only purges old caches when this
-   constant changes — skip this and existing browsers keep serving the
-   previously-cached app shell, masking the release entirely. (v3.2.2
-   shipped specifically to recover from this gap accumulating across
-   v2.7.0 → v3.2.1.)
-3. Update `CHANGELOG.md` with new release section
-4. Add row to `README.md` downloads table
-5. Update docs: bump `extra.version` in `mkdocs.yml`; update tarball filename in `docs/index.md`
-6. Build tarball (see Development block above)
-7. Commit, push, verify on GitHub
-8. Create PR `dev → main`
+Release checklist: [`design-document.md`](docs/internal/design-document.md) §10.2. Run `/release` to automate steps 1–7.
 
-(Or run `/release` to automate steps 1–7.)
-
-PHP unit tests: `testing/unit/` (226 tests, 379 assertions; 14 skipped on platforms without GMP). Playwright browser tests: `testing/scripts/playwright_test.py` (135 test groups) covers page load, security headers, Permissions-Policy, CSP nonce integrity, IPv4/IPv6 calculation, reverse DNS zones, edge cases, address type badges, subnet splitters, copy buttons, splitter shareable URLs, binary representation, VLSM planner, overlap checker, shareable GET URLs, iframe integration, UI interactions, VLSM shareable URL, VLSM CSV/JSON/XLSX export, VLSM reset/validation, Copy All buttons, VLSM utilisation summary, IPv6 overlap, multi-CIDR overlap, IPv6 binary/hex, v1.3.0 regression tests, supernet/summarise UI, ULA generator UI, VLSM session TTL notice, REST API endpoints (meta, IPv4, IPv6, VLSM, overlap, split, supernet, ULA, rdns, bulk, OpenAPI spec, range/ipv4, tree), IPv4 binary hex/decimal rows, IPv6 address expanded/compressed forms, API v2.2.0 new fields, ASCII export, tooltips/help bubbles, visual regression, docs footer link, IP range→CIDR UI, tree view UI, API v2.3.0 endpoints, tooltip visual polish (#205), tooltip accessibility, CSP inline-style violations (#206), print stylesheet (#193), locale number format (#191), ESLint/Stylelint clean, full visual inspection, all-tooltips direction, console error monitoring, light/dark theme testing, a11y landmarks/skip link, a11y input focus ring, a11y toast ARIA, a11y help bubble keyboard, a11y prefers-reduced-motion CSS, VLSM keyboard Delete, IPv6 VLSM (UI + API + shareable URL + exports + utilisation summary), inverse subnet lookup (UI + API + shareable URL), subnet aggregation diff (UI + API + shareable URL + canonical-form normalisation), copy-as-Markdown / copy-as-Cisco buttons.
-
-## Repository layout
+## Repository layout (top-level only)
 
 ```
-Subnet-Calculator/      ← docroot (serve this directory)
-  index.php             ← entry point (bootstrap only)
-  includes/             ← PHP includes (blocked from direct web access)
-    config.php          ← config defaults + optional config.php override
-    functions-ipv4.php  ← IPv4 utility functions
-    functions-ipv6.php  ← IPv6 utility functions
-    functions-ipv6.php  ← IPv6 utility functions
-    functions-split.php ← subnet splitter functions
-    functions-util.php  ← address type detection + badge helpers + help_bubble()
-    functions-vlsm.php  ← VLSM planner function
-    functions-supernet.php ← supernet_find(), summarise_cidrs()
-    functions-ula.php   ← generate_ula_prefix() (RFC 4193)
-    functions-session.php ← SQLite session CRUD
-    functions-resolve.php ← resolve_ipv4_input(), resolve_ipv6_input() (shared by web + API)
-    functions-range.php ← range_to_cidrs() — IP range → minimal CIDR list
-    functions-tree.php  ← build_subnet_tree() — allocation tree with gap detection
-    request.php         ← Turnstile verify, GET/POST handling; requires functions-resolve.php
-  templates/            ← HTML template (blocked from direct web access)
-    layout.php
-  assets/               ← CSS, JS, and image assets (publicly served, long-cached)
-    app.css
-    app.js
-    logo.webp
-    logo.png            ← PNG fallback for Safari <14
-    favicon-32.webp
-    favicon-32.png      ← PNG fallback for browsers without WebP favicon support
-    vendor/
-      xlsx/
-        xlsx.full.min.js ← SheetJS 0.20.3, SRI-verified, defer-loaded
-  api/
-    openapi.yaml        ← OpenAPI 3.1 specification for all REST endpoints
-    v1/
-      index.php         ← API router + bootstrap
-      helpers.php       ← json_ok/json_err, auth, rate limit, CORS (blocked from web)
-      .htaccess         ← front-controller rewrite; blocks helpers.php
-      handlers/         ← one file per endpoint (blocked from direct web access)
-        ipv4.php, ipv6.php, vlsm.php, overlap.php, split.php,
-        supernet.php, ula.php, sessions.php, range.php, tree.php
-  data/                 ← SQLite DB location (blocked from web; git-ignored)
-  .htaccess             ← blocks config files, tarballs, subdirs; cache headers
-  robots.txt
-  config.php.example    ← copy to config.php to override defaults
-  config.php            ← local overrides (git-ignored)
-docs/                   ← MkDocs Material source (deployed to GitHub Pages)
-  mkdocs.yml
-  requirements.txt
-  index.md, ipv4.md, ipv6.md, vlsm.md, splitter.md, overlap.md,
-  supernet.md, ula.md, binary.md, rdns.md, sessions.md, sharing.md,
-  tree.md, api.md, config.md
-releases/               ← versioned release tarballs
-testing/
-  snapshots/            ← Pillow visual regression baselines (committed PNGs)
-  scripts/
-    playwright_test.py  ← 135 test groups, ~560 assertions
-    snapshot_utils.py   ← capture_snapshot / compare_snapshot helpers
-README.md
-CHANGELOG.md
-CONTRIBUTING.md
-SECURITY.md
-LICENSE
-.phpcs.xml             ← PHPCS PSR-12 config (excludes vendor/; test-file naming)
-.github/
-  workflows/
-    docs.yml            ← MkDocs GitHub Pages deploy on push to main
-.claude/
+Subnet-Calculator/      ← docroot (point webserver here)
+  index.php, sw.js, .htaccess, config.php.example
+  includes/             ← pure functions; web-blocked
+  templates/            ← layout.php + _tools/<slug>.php partials
+  assets/               ← app.css, app.js, vendored SheetJS
+  api/v1/               ← router + handlers/<name>.php
+  admin/                ← TOTP-gated operator console
+  data/                 ← SQLite DBs; web-blocked; git-ignored
+docs/
+  internal/             ← architecture + guides + runbooks (this set)
+  superpowers/          ← per-release plans, specs, style guide
+  ...mkdocs sources...  ← user-facing docs deployed to GH Pages
+releases/               ← versioned tarballs
+testing/                ← unit, scripts (Playwright), snapshots, fixtures
+.github/workflows/      ← php.yml (3-version matrix), docs.yml
+.claude/                ← skills + hooks
 ```
 
-## Architecture
+Full annotated layout: [`design-document.md`](docs/internal/design-document.md) §3.
 
-PHP application with a slim entry point (`index.php`) that bootstraps includes and renders a template. Execution order:
+## Architecture (TL;DR)
 
-1. **`index.php`** — requires all includes in order, sends security headers (CSP nonce, `X-Content-Type-Options`, etc.), then requires the template.
-2. **`includes/config.php`** — all operator-tunable `$variables` (`$fixed_bg_color`, `$default_tab`, `$split_max_subnets`, `$form_protection`, `$turnstile_site_key`, `$turnstile_secret_key`, `$canonical_url`, etc.). If `config.php` exists in the docroot it is `require`d here to allow overrides without touching source files.
-3. **`includes/functions-*.php`** — pure utility functions, all typed with `declare(strict_types=1)`: IPv4 (`cidr_to_mask`, `calculate_subnet`, etc.), IPv6 (`ipv6_to_gmp`, `calculate_subnet6`, etc.), splitters (`split_subnet`, `split_subnet6`), type detection (`get_ipv4_type`, `get_ipv6_type`), supernet (`supernet_find`, `summarise_cidrs`), ULA (`generate_ula_prefix`), session (`session_db_open`, `session_create`, `session_load`, `session_purge`), input resolvers (`resolve_ipv4_input`, `resolve_ipv6_input` — in `functions-resolve.php`, shared by web and API).
-4. **`includes/request.php`** — reads `$_GET`/`$_POST`, populates `$result`/`$result6`/`$error`/`$split_result`/`$split_result6`; GET triggers auto-calculation for shareable URLs. Form protection (honeypot / Turnstile) is checked before calculation. Also computes `$bg_override_style`, `$share_url`, `$canonical_url`.
-5. **`templates/layout.php`** — full HTML output; references `assets/app.css` (external stylesheet) and `assets/app.js` (external script); theme-init `<script>` stays inline (prevents FOUC); conditional `bg_override_style` `<style>` stays inline with nonce.
+PHP application with a slim entry point (`index.php`) that requires all `includes/`, runs `request.php` to dispatch input, then renders `templates/layout.php` which `require`s per-drawer partials from `templates/_tools/<slug>.php`. The REST API at `/api/v1/*` calls the **same pure functions** as the web UI; only input shape and output rendering differ. SQLite (sessions, admin, audit, API keys) is the only persistence layer. GMP is the IPv6 math runtime.
 
-### Key implementation details
-
-- **IPv4 arithmetic**: always `& 0xFFFFFFFF` after bitwise ops — PHP's `ip2long()` returns a signed integer on 64-bit systems
-- **IPv6 arithmetic**: uses PHP GMP extension (`gmp_init`, `gmp_and`, etc.) with `inet_pton()`/`inet_ntop()` and a hex string intermediary
-- **IPv6 splitter large counts**: when the prefix difference is ≥ 63, `1 << diff` overflows; total is represented as the string `'2^N'` consistent with `calculate_subnet6()`
-- **CIDR paste auto-detection**: handled both server-side (in all GET/POST handlers via `strpos($input, '/')`) and client-side (JS `blur` event) to cover the case where a user types CIDR notation and presses Enter without blurring
-- **Shareable URLs**: GET parameters auto-trigger calculation; JS prepends `window.location.origin + pathname` to the relative query string for display/copy
-- **iframe auto-sizing**: `window.self !== window.top` detection adds `in-iframe` to `<html>`, activating CSS overrides (`min-height:0`, `align-items:flex-start`) and a `postMessage` height reporter via `ResizeObserver`; target origin uses `window.location.ancestorOrigins[0]` (Chrome/Edge) with a `sessionStorage` fallback (Firefox) — **not** `document.referrer`, which breaks after same-origin form-submit navigations inside the iframe
-- **Clipboard**: `navigator.clipboard.writeText()` with `document.execCommand('copy')` fallback via hidden textarea for cross-origin iframes
-- **Theme**: `html[data-theme="light"]` CSS overrides; dark is default; `localStorage` persistence via inline `<script>` in `<head>` (runs before render to avoid flash)
-- **Page landmark**: the outermost card is `<main id="main-content">` — the skip link and any iframe consumers that need to target the content area should use `#main-content`
-- **`help_bubble()` icons**: all icons carry `tabindex="0" role="button" aria-label="Help"` — any new help bubbles created via `help_bubble()` inherit this automatically; the existing `:focus-within` CSS in `app.css` reveals the tooltip on keyboard focus without any JS
-- **`--color-bg` token must not be renamed** — `app.js` calls `document.documentElement.style.setProperty('--color-bg', color)` to implement the iframe background override API (`?bg=…` query param + `postMessage` override). Renaming this CSS custom property breaks all iframe consumers that customise the background.
-- **`--color-btn-text` must stay dark (`#0a1a12`) for teal buttons** — teal `#06d6a0` background with white text fails WCAG AA contrast. Both the dark and light themes keep this token dark. Do not "fix" it to white.
-- **`.card` overflow is intentionally split across breakpoints** — `overflow-x: clip` at the base level preserves vertically-escaping help-bubble tooltips; `overflow: clip` (both axes) is added only in the `@media (width <= 480px)` block to contain the bottom-sheet tool drawer. Setting full `overflow: clip` at the base level would clip tooltip content that extends above/below the card boundary.
-- **`cidr_to_wildcard()` accepts `int|string`** — the helper in `functions-ipv4.php` was widened in v2.10.0 so user-facing handlers can pass raw strings (`"/24"` or `"24"`); existing internal callers passing an int continue to work. Companion `wildcard_to_cidr(string)` rejects non-contiguous masks via `InvalidArgumentException`. Both helpers underpin the `POST /api/v1/wildcard` endpoint and the IPv4 tab's Wildcard↔CIDR tool drawer entry.
-- **Print stylesheet redefines tokens, not selectors** — for v2.10.0 (#291), the dark-mode print path inside `@media print` redefines the CSS custom properties (`--color-bg/-surface/-text/-border/-accent/-btn-text`) under `html[data-theme="dark"]` to print-safe light values. Component-level `!important` overrides cover panels/tables/inputs that bypass the tokens. Adding a new dark-mode component? It will get printed correctly automatically as long as it uses the tokens.
-- **CI matrix runs on PHP 8.2–8.4** — `.github/workflows/php.yml` is a 3-version matrix (`8.2`, `8.3`, `8.4`) running PHPUnit, PHPStan L9 (`--memory-limit=512M`), PHPCS (PSR-12), and Spectral on every PR and push to `main`/`dev`. PHP 8.1 is dropped because PHPUnit 11 and PHPStan 2 both require 8.2+; the app runtime still supports 8.1.
-- **IPv6 VLSM `2^N` host counts** — `vlsm6_allocate()` in `functions-vlsm6.php` (v2.11.0) accepts each requirement's `hosts` as either a positive PHP integer or a `"2^N"` string (N is 0–128). The string form is required for sizings that overflow PHP's signed 64-bit int (>= 2^63). The allocator uses GMP throughout and selects the smallest prefix `/p` such that `2^(128-p) >= hosts`; every IPv6 address in an allocated block is treated as usable (no broadcast/network reservation). Returned `usable` is also an integer or `"2^N"` string consistent with `calculate_subnet6()`.
-- **`subnet_diff()` canonical-form normalisation** — `functions-diff.php` (v2.11.0) normalises every input CIDR to canonical form before comparison: host bits are zeroed, IPv6 is lowercased and compressed via `inet_ntop()`. Two CIDRs that print differently but resolve to the same network address + prefix length are treated as identical. The `changed` category is detected by matching network addresses across `before` and `after` whose prefix lengths differ; the `reason` string records the transition (e.g. `"prefix changed /24 → /23"`).
-- **`sc_run_lookup()` / `sc_run_diff()` shared POST+GET helpers** — `request.php` (v2.11.0) factors each new tool into a single helper that handles both web-form POST submission and shareable-URL GET hydration. Both helpers populate the same `$lookup_*` / `$diff_*` template variables regardless of method, so the template partials (`templates/_diff_result.php` and inline lookup blocks in `layout.php`) render identically for either entry path. New tools should follow this pattern rather than splitting POST and GET into separate code paths.
-- **Clipboard test interception via `add_init_script`** — production HTTPS uses the native `navigator.clipboard.writeText()` API, but the docker test harness serves the app over insecure HTTP where `navigator.clipboard` is undefined. The Playwright test for copy-as-Markdown / copy-as-Cisco (v2.11.0) installs a stub via `page.add_init_script()` that records every `writeText` payload into `window.__lastClipboard`, then asserts on that recorded value. Do not switch to `page.expose_function` for this — `add_init_script` runs before page scripts and matches the production API surface exactly.
+Full architecture + execution order: [`design-document.md`](docs/internal/design-document.md) §2.
 
 ## Branching
 
-- Active development branch: `dev`
-- All PRs target `main`
-- Issues are labelled by release milestone (`v0.4`, `v0.5`, etc.)
+Branching model, naming, patch + hotfix flow, and merge style: [`design-document.md`](docs/internal/design-document.md) §10.1.
 
-## Git and GitHub
+## Git and GitHub (operational quirk)
 
 The local git remote (`origin`) points to a session-scoped proxy at `127.0.0.1`. **`git push` output is not reliable confirmation that commits reached GitHub** — the proxy accepts the push locally but may not forward it depending on the session. Always verify that commits actually landed on GitHub using the MCP GitHub tools (e.g. `mcp__github__list_commits`) before declaring a push successful.
 
@@ -212,10 +96,10 @@ To write files to GitHub from a Claude Code session, prefer `mcp__github__push_f
 
 **Skills** (invoke with `/skill-name`):
 - `/deploy-test` — rsync to dev server + run CDP browser suite
-- `/release` — full release checklist (bump version, changelog, tarball, PR)
+- `/release` — full release checklist (version, changelog, internal-docs sync, tarball, PR)
 
 **Hooks** (PostToolUse, auto-run on every PHP edit):
 - `php -l` — syntax check (~50ms)
 - `phpstan analyse` — level 9 static analysis (~2s)
 
-**Session start hook**: `.claude/hooks/session-start.sh` — installs `php-gmp` in remote sessions if missing.
+**Session start hook** (`.claude/hooks/session-start.sh`): installs `php-gmp` in remote sessions if missing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Release checklist: [`design-document.md`](docs/internal/design-document.md) §10
 
 ## Repository layout (top-level only)
 
-```
+```text
 Subnet-Calculator/      ← docroot (point webserver here)
   index.php, sw.js, .htaccess, config.php.example
   includes/             ← pure functions; web-blocked

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -1,0 +1,51 @@
+# Internal Documentation
+
+> Source of truth for **how this project actually works** — beyond the user-facing docs at `docs/`.
+
+These documents are not deployed to GitHub Pages. They're read by:
+- The operator (Sean), to recover context across long gaps.
+- Future agent sessions, to load decision history without re-deriving it from git archaeology.
+- Anyone reviewing a PR who needs to know "why does this code look weird?"
+
+## Map
+
+| Document | When to read |
+|---|---|
+| [`design-document.md`](design-document.md) | Architecture, invariants, design decisions. **Start here.** |
+| [`design-guide.md`](design-guide.md) | UX principles. Read before adding tools or changing UI. |
+| [`coding-guide.md`](coding-guide.md) | PHP/JS/CSS conventions. Read before writing code. |
+| [`testing-guide.md`](testing-guide.md) | Test layers, when to add what. Read before changing test coverage. |
+| [`security-model.md`](security-model.md) | Threat model + trust boundaries. Read before security-sensitive changes. |
+| [`api-contract.md`](api-contract.md) | API versioning, breaking-change policy, envelope contract. Read before API changes. |
+| [`data-dictionary.md`](data-dictionary.md) | SQLite schemas + migration policy. Read before DB-level changes. |
+| [`config-reference.md`](config-reference.md) | Operator-tunable config variables. Read before adding/changing config knobs. |
+| [`runbooks.md`](runbooks.md) | Production incident playbooks. Read when something breaks. |
+| [`specs/`](specs/) | One-shot internal specs (e.g., the v3.3.0 IPv6 foundations spec). |
+
+## Companion documents (elsewhere in the repo)
+
+| Document | Lives at | Purpose |
+|---|---|---|
+| `README.md` | repo root | User-facing project README |
+| `CHANGELOG.md` | repo root | Per-release log |
+| `CONTRIBUTING.md` | repo root | External contributor on-ramp |
+| `SECURITY.md` | repo root | Vulnerability reporting process |
+| `CLAUDE.md` | repo root | Agent quick-reference (commands, hotspots) |
+| `docs/superpowers/style-guide.md` | docs/ | Visual identity (logo, colours, typography) |
+| `docs/superpowers/plans/2026-04-25-v2.9.0-ui-ux-style-guide.md` | docs/ | Detailed UI/UX pattern catalogue |
+| `docs/superpowers/plans/` + `docs/superpowers/specs/` | docs/ | Per-release plans + design specs |
+
+## Update protocol
+
+Each document has its own "Update protocol" section at the bottom. Common rule: update *with the same PR* that changes the underlying reality. Don't let docs drift.
+
+When in doubt about where information belongs:
+- Architecture / invariants / why → `design-document.md`
+- How to do X in code → `coding-guide.md`
+- What the UI should look like → `design-guide.md` (principles) or visual style guide (specifics)
+- How to test → `testing-guide.md`
+- What attacks we defend against → `security-model.md`
+- How the API behaves → `api-contract.md`
+- What to do when things break → `runbooks.md`
+
+If something doesn't fit any of these, the doc set is incomplete — propose a new file.

--- a/docs/internal/api-contract.md
+++ b/docs/internal/api-contract.md
@@ -1,0 +1,245 @@
+# API Contract
+
+**Audience:** Developer / API consumer / future-agent making API changes.
+**Companion to:** `Subnet-Calculator/api/openapi.yaml` (the spec).
+**Premise:** OpenAPI is the *spec*. This document is the *policy*: what's a breaking change, how versioning works, how deprecation is announced, what the envelope guarantees.
+
+---
+
+## Versioning
+
+The API is versioned in the URL path: `/api/v1/...`.
+
+- **`v1`** = the current major version.
+- A new major version (`v2`) ships only when a breaking change is unavoidable.
+- The app's release version (e.g., `3.7.0`) is independent of the API version. App `3.x.y` and `4.x.y` are both expected to expose `v1`. The `v2` jump is reserved for genuine API breakage.
+
+**`v2` will require:**
+- A clear migration guide.
+- A deprecation window for `v1` (minimum 6 months).
+- Both versions live concurrently during the window.
+- `Deprecation` and `Sunset` headers on `v1` responses during the window.
+
+---
+
+## What counts as a breaking change
+
+| Change | Breaking? | Why |
+|---|---|---|
+| Add a new endpoint | No | Existing consumers ignore it. |
+| Add an optional request field | No | Consumers can omit it. |
+| Add a response field | No | JSON consumers ignore unknown fields. |
+| Add a response field that consumers were reading via `Object.keys()` | **Maybe** | Defensive consumers shouldn't, but real-world consumers do. Call it out in CHANGELOG. |
+| Rename a request field | **Yes** | Existing payloads break. |
+| Rename a response field | **Yes** | Existing parsers break. The `ul_bit_flipped` rename is parked behind v4.0.0 for this reason. |
+| Remove an endpoint | **Yes** | 404 where 200 was expected. |
+| Remove a response field | **Yes** | Parsers reading the field break. |
+| Tighten input validation (reject inputs that used to be accepted) | **Yes** | Surprises existing clients. PMTU cap in v3.6.3 was technically breaking but justified by DoS risk — documented prominently. |
+| Loosen input validation | No | Existing clients still work. |
+| Change error code in `error.code` | **Yes** | Clients switch on it. |
+| Add a new error code | No | Clients should treat unknown codes as generic failures. |
+| Change HTTP status code | **Yes** (usually) | Clients switch on status. |
+| Reorder response fields | No | JSON is unordered. |
+| Reorder array elements (where order isn't documented) | No | But if order *is* documented, yes. |
+| Change auth requirement on an endpoint | **Yes** | Was anonymous → now requires key = breaking. |
+| Add a new auth method | No | Existing auth still works. |
+| Tighter rate limit | Soft-breaking | Existing burst patterns may now hit 429. Document. |
+| Looser rate limit | No | — |
+
+When in doubt, treat it as breaking. The cost of an over-cautious CHANGELOG note is zero; the cost of breaking a client is real.
+
+---
+
+## Response envelope
+
+Every endpoint returns one of two shapes:
+
+### Success
+
+```json
+{
+  "ok": true,
+  "data": { ...endpoint-specific payload... }
+}
+```
+
+- HTTP status: `200` (or `201` for resource creation, e.g., `POST /api/v1/sessions`).
+- `data` is always an object. Never a bare array, never a scalar.
+- Endpoint-specific fields live inside `data`. The envelope itself is invariant.
+
+### Error
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "INVALID_INPUT",
+    "message": "human-readable explanation"
+  }
+}
+```
+
+- HTTP status: `4xx` for caller errors, `5xx` for server errors.
+- `error.code` is a stable identifier. `error.message` is human-readable and may be tuned for clarity over releases.
+- Clients **must switch on `error.code`**, not `error.message`.
+
+### Error codes (stable surface)
+
+| Code | HTTP | Meaning |
+|---|---|---|
+| `INVALID_INPUT` | 400 | Malformed or out-of-range request body / query param |
+| `MISSING_FIELD` | 400 | A required field is absent |
+| `METHOD_NOT_ALLOWED` | 405 | Wrong HTTP method for this endpoint |
+| `UNAUTHORIZED` | 401 | Missing or invalid `Authorization` header |
+| `FORBIDDEN` | 403 | Authenticated but not permitted for this resource (admin-only endpoints) |
+| `RATE_LIMITED` | 429 | Per-IP or per-key rate limit hit |
+| `NOT_FOUND` | 404 | No matching session / resource |
+| `PAYLOAD_TOO_LARGE` | 413 | Request body or computed result exceeds bounds (PMTU caps, splitter caps, etc.) |
+| `INTERNAL_ERROR` | 500 | Unhandled exception — accompanied by an entry in the operator's error log |
+
+Adding a new code is non-breaking. Renaming or removing a code is **breaking**.
+
+---
+
+## Authentication
+
+| Mode | Header | Rate limit | Notes |
+|---|---|---|---|
+| Anonymous | none | Per-IP, tight | Default for all endpoints unless documented otherwise |
+| API key | `Authorization: Bearer <key>` | Per-key, configurable | Issued via admin console |
+| Admin | cookie session (TOTP) | Per-IP login limit | UI only; not for programmatic consumers |
+
+API keys never appear in URLs or request bodies. Never log them. Never echo them in responses (except in the admin issuance flow, exactly once).
+
+---
+
+## Content types
+
+- Request body: `application/x-www-form-urlencoded` **or** `application/json`. The router accepts both for backwards compatibility with form-style consumers (and the original web UI used form encoding before any API existed).
+- Response body: `application/json; charset=utf-8`.
+- CORS: `Access-Control-Allow-Origin: *` for read-only endpoints; preflight for write endpoints; `Access-Control-Expose-Headers` includes `X-Request-Id`.
+
+---
+
+## Idempotency
+
+- All `GET` endpoints are idempotent (HTTP guarantee).
+- All `POST` calculator endpoints (ipv4, ipv6, vlsm, split, etc.) are idempotent in practice — same input always yields same output. They use `POST` because input may be longer than safe URL length, not because they mutate state.
+- `POST /api/v1/sessions` is the only true write endpoint (creates a row in `data/sessions.sqlite`). It is **not** idempotent — each call creates a new session with a new ID.
+- Admin write endpoints (`/api/v1/admin/keys` etc.) are not idempotent.
+
+---
+
+## Pagination
+
+Not currently used. If/when added (e.g., listing API keys for an operator with many), the convention will be:
+- Cursor-based, not offset-based.
+- `next_cursor` in response if more results exist.
+- `?cursor=<opaque>` in next request.
+
+Avoid offset pagination — it breaks under concurrent inserts and doesn't scale.
+
+---
+
+## Deprecation policy
+
+When deprecating an endpoint or field:
+
+1. **Announce in CHANGELOG.md** under the release that introduces the deprecation.
+2. Add **`Deprecation: true`** response header (and **`Sunset: <RFC 3339 date>`** if a removal date is known) per [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html).
+3. Update OpenAPI spec with `deprecated: true` on the endpoint or schema property.
+4. Minimum window before removal: **6 months**.
+5. Remove only in a major version bump (i.e., `v2`).
+
+This pattern is not yet exercised. The first opportunity is the v4.0.0 `ul_bit_flipped` rename.
+
+---
+
+## Backwards compatibility commitments
+
+In `v1`, we commit to:
+
+- Endpoint paths under `/api/v1/` will not change.
+- Response envelope shape (`ok` + `data`/`error`) will not change.
+- Documented `error.code` values will not be renamed or removed.
+- Optional request fields will remain optional.
+- Required request fields will not be added retroactively.
+
+We do **not** commit to:
+
+- Stability of internal `data` shapes if marked `experimental: true` in OpenAPI. (Currently nothing is.)
+- Wire-format stability of *new* fields added mid-version. Best-effort, but not contractual.
+- Performance characteristics. A future release may make a fast endpoint slower or vice versa.
+
+---
+
+## OpenAPI spec — source of truth
+
+`api/openapi.yaml` is the source of truth for:
+- Endpoint paths + methods.
+- Request schemas.
+- Response schemas.
+- Auth requirements.
+- Examples.
+
+If code and spec disagree, **the spec is wrong** — fix the spec to match the code in the same PR. The reverse (code changing to match spec) only happens when the spec was *intentional* and the code drifted.
+
+Spectral CI gate enforces:
+- All endpoints documented.
+- All schemas valid OpenAPI 3.1.
+- Examples conform to schemas.
+
+---
+
+## Bulk endpoint
+
+`POST /api/v1/bulk` accepts an array of `{op, params}` items and returns an array of `{ok, data|error}` results in the same order. Operations supported are the subset that doesn't mutate (calculator-style only).
+
+- Anonymous rate limit applies once per outer request, not per inner op.
+- API key rate limit applies per outer request, but a configurable per-key multiplier scales inner-op cost.
+- Max array length is bounded; documented in OpenAPI.
+
+When adding a new calculator endpoint, decide whether bulk should support it. Default: yes. Exceptions: anything that writes (sessions, admin) — bulk is read-only.
+
+---
+
+## Client expectations
+
+What consumers should do:
+
+- **Switch on `error.code`, never `error.message`.**
+- **Tolerate unknown response fields.** They mean the API added something; ignore it gracefully.
+- **Respect `Retry-After` header on 429 responses.** Don't hammer.
+- **Pin to `/api/v1/`** in client code, not bare `/api/`.
+- **Use API keys** for any volume above casual single-request use.
+
+What they shouldn't:
+
+- Don't parse `error.message` strings.
+- Don't assume response field ordering.
+- Don't depend on undocumented response fields.
+- Don't store API keys in URLs.
+
+---
+
+## Open questions / future work
+
+Tracked here for visibility; not commitments:
+
+- **API key expiry** — currently keys live forever. Adding `expires_at` to issuance + a rotation reminder is candidate for v3.8.0 if API DX becomes the theme.
+- **`X-RateLimit-*` response headers** — explicitly exposing remaining quota would help well-behaved clients self-throttle.
+- **Webhook surface** — not in scope. Operator-driven calculator app doesn't need event delivery. Skip unless a use case appears.
+- **GraphQL** — explicitly out of scope. REST + OpenAPI fits the operator audience.
+- **`Idempotency-Key` header on POST** — would let clients retry safely on network errors. Easy to add; defer until a consumer asks.
+
+---
+
+## Update protocol
+
+Every PR that changes the API:
+1. Update `api/openapi.yaml`.
+2. Update CHANGELOG entry — note if breaking.
+3. If a new `error.code` is introduced, add it to the table above.
+4. If a breaking change is unavoidable in `v1`, push back: is there a non-breaking alternative? If not, escalate to a `v2` discussion.
+5. If a deprecation lands, set `Deprecation`/`Sunset` headers per the policy above.
+6. Bump the "Last updated" header.

--- a/docs/internal/coding-guide.md
+++ b/docs/internal/coding-guide.md
@@ -1,0 +1,406 @@
+# Coding Guide
+
+**Audience:** Developer / future-agent writing PHP, JS, or CSS in this repository.
+**Companion to:** `design-document.md` §4 (code methodology, in summary form). This guide expands with practical rules.
+
+The guide is split into:
+- **PHP conventions** — the bulk of the codebase.
+- **JS conventions** — vanilla, single-file.
+- **CSS conventions** — token-based.
+- **Cross-cutting** — naming, comments, commits.
+
+---
+
+## PHP conventions
+
+### Strict typing — always
+
+Every file in `includes/`, `api/v1/`, `api/v1/handlers/`, `admin/` starts with:
+
+```php
+<?php
+
+declare(strict_types=1);
+```
+
+No exceptions. PHPStan L9 enforces this transitively (functions must declare types; arrays must declare shapes via PHPDoc).
+
+### Naming
+
+| Construct | Convention | Example |
+|---|---|---|
+| File | `kebab-case.php` for modules, lowercase for entry points | `functions-multicast6.php`, `index.php` |
+| Function | `snake_case` | `calculate_subnet6`, `cidrs_overlap` |
+| Class (rare — we prefer pure functions) | `PascalCase` | `SessionStore` |
+| Constant | `UPPER_SNAKE` | `MAX_SPLIT_SUBNETS` |
+| Variable | `$snake_case` | `$ipv6_address`, `$prefix_length` |
+| Template global (set by `request.php` for template) | `$snake_case` | `$result`, `$vlsm_plan` |
+
+Function names should be read as a verb phrase: `calculate_subnet`, `parse_ipv6`, `validate_cidr`. If you find yourself wanting "and" in the name, it's two functions.
+
+### Pure functions are the default
+
+Every `functions-*.php` file exports pure functions. Pure means:
+- No globals read or written (except in the dedicated `functions-session.php` / admin / audit / apikeys files where SQLite is the data store).
+- No I/O.
+- Deterministic for the same input.
+- No side effects.
+
+If you're tempted to write a non-pure helper outside the session/admin/audit/apikeys files, stop. Either:
+- Refactor to take the I/O dependency as an argument, or
+- Put the side-effecting code in `request.php` or the relevant handler, calling the pure function for the calculation.
+
+### Error handling
+
+Throw `InvalidArgumentException` for caller-controlled bad input. Don't return `false` or `null` to signal invalid — the type system carries the contract.
+
+```php
+// Good
+function calculate_subnet(string $cidr): array
+{
+    if (!str_contains($cidr, '/')) {
+        throw new InvalidArgumentException('CIDR must contain a slash');
+    }
+    // ...
+}
+
+// Bad
+function calculate_subnet(string $cidr): array|false
+{
+    if (!str_contains($cidr, '/')) {
+        return false;
+    }
+    // ...
+}
+```
+
+Catch exceptions at the boundary (`request.php` or `api/v1/handlers/*.php`), not in pure functions. Pure functions should propagate.
+
+### IPv4 arithmetic (invariant I1)
+
+`ip2long()` returns a signed integer on 64-bit PHP. After **every** bitwise op, mask with `& 0xFFFFFFFF`:
+
+```php
+// Good
+$network = ($ip & $mask) & 0xFFFFFFFF;
+$broadcast = ($network | ~$mask) & 0xFFFFFFFF;
+
+// Bad — bug waiting to happen
+$network = $ip & $mask;
+```
+
+Test with values ≥ 128.0.0.0 to make sure the masking is correct.
+
+### IPv6 arithmetic (invariants I2, I3)
+
+GMP only. Never PHP signed-int math. Standard pipeline:
+
+```php
+$gmp = gmp_init(bin2hex(inet_pton($address)), 16);
+$gmp_result = gmp_and($gmp, $mask_gmp);
+$hex = str_pad(gmp_strval($gmp_result, 16), 32, '0', STR_PAD_LEFT);
+$result = inet_ntop(hex2bin($hex));
+```
+
+Subnet/host counts that may exceed 2^63 are returned as the **string** `"2^N"`, never as a PHP int. Match the convention in `calculate_subnet6` and `vlsm6_allocate`.
+
+### Validation at the boundary
+
+`request.php` (web) and `api/v1/handlers/*.php` (API) are the validators. Pure functions trust their inputs. This means:
+
+```php
+// In api/v1/handlers/ipv4.php (the boundary)
+$cidr = $_POST['cidr'] ?? '';
+if (!is_string($cidr) || strlen($cidr) > 18 || !str_contains($cidr, '/')) {
+    json_err(400, 'INVALID_INPUT', 'cidr must be a CIDR string like 10.0.0.0/24');
+    return;
+}
+
+$result = calculate_subnet($cidr);  // Pure function; assumes preconditions hold.
+```
+
+Don't re-validate inside `calculate_subnet`. If the boundary missed something, fix the boundary.
+
+### Output escaping (invariant I12)
+
+Every `echo` of user-influenced data:
+
+```php
+<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>
+```
+
+Always `ENT_QUOTES`. Always UTF-8. Single-quoted attribute safety depends on `ENT_QUOTES`.
+
+For JSON in templates (rare):
+```php
+<?= htmlspecialchars(json_encode($data, JSON_UNESCAPED_SLASHES), ENT_QUOTES, 'UTF-8') ?>
+```
+
+For URLs in attributes:
+```php
+href="<?= htmlspecialchars($url, ENT_QUOTES, 'UTF-8') ?>"
+```
+
+### Schema changes — update the data dictionary
+
+Any PR that touches `CREATE TABLE`, `CREATE INDEX`, `ALTER TABLE`, `PRAGMA table_info`, or any DB-path config variable **must** update [`data-dictionary.md`](data-dictionary.md) in the same PR. New tables/columns get a row; migrations get a sub-section entry; DB-path changes update the physical-layout section. PRs that don't are incomplete.
+
+See `data-dictionary.md` "Migration policy" for the idempotent-migration pattern (PRAGMA-check + ALTER, hard-fail on partial schema, never rename/remove in place).
+
+### Config-variable changes — update the config reference
+
+Any PR that adds, removes, renames, or changes the default of an operator-tunable `$variable` in `includes/config.php` **must** update [`config-reference.md`](config-reference.md) and `config.php.example` in the same PR. The reference must catalogue every operator-facing variable; if a variable exists in code but not in the reference, the docs are stale.
+
+### SQL — always parameterised
+
+Every SQLite query uses prepared statements with bound parameters:
+
+```php
+// Good
+$stmt = $db->prepare('SELECT * FROM sessions WHERE id = :id');
+$stmt->execute(['id' => $session_id]);
+
+// Bad — and impossible to ship past Semgrep
+$rows = $db->query("SELECT * FROM sessions WHERE id = '$session_id'");
+```
+
+No user-controlled table or column names anywhere. If you're tempted, you're modelling something wrong.
+
+### No silent fallbacks (design-document §4.6)
+
+If a feature can't run, surface it. Don't degrade silently:
+
+```php
+// Good
+if (!extension_loaded('gmp')) {
+    throw new RuntimeException('GMP extension required for IPv6 operations');
+}
+
+// Bad — masks a real problem
+if (!extension_loaded('gmp')) {
+    return ['error' => 'IPv6 unavailable'];
+}
+```
+
+### `sc_run_*` symmetry (design-document §4.7)
+
+Tools with shareable URLs use one helper in `request.php`:
+
+```php
+function sc_run_<name>(): void
+{
+    global $<name>_result, $<name>_error;
+
+    $input = $_POST['x'] ?? $_GET['x'] ?? null;
+    if ($input === null) {
+        return;
+    }
+
+    try {
+        $<name>_result = <name>_compute($input);
+    } catch (InvalidArgumentException $e) {
+        $<name>_error = $e->getMessage();
+    }
+}
+```
+
+The template renders identically whether the helper was triggered by POST or GET. Don't split paths.
+
+### Function size
+
+Aim for ≤50 lines per pure function. Beyond that, look for an extraction point. Hard cap: 100 lines. If you can't get under 100, the function is doing too much.
+
+### PHPDoc
+
+Required when the type system can't express the contract — typically array shapes:
+
+```php
+/**
+ * @return array{
+ *     network: string,
+ *     broadcast: string,
+ *     hosts: int,
+ *     prefix: int<0, 32>,
+ *     mask: string,
+ *     wildcard: string,
+ *     class: string,
+ * }
+ */
+function calculate_subnet(string $cidr): array
+```
+
+PHPStan reads these and enforces them. Don't write decorative PHPDoc that restates the signature — it's noise.
+
+### Comments
+
+Default to none. Add a comment only when the *why* is non-obvious:
+
+```php
+// `& 0xFFFFFFFF` keeps the result unsigned — ip2long is signed on 64-bit.
+$network = ($ip & $mask) & 0xFFFFFFFF;
+```
+
+Don't write what the code does — names should do that. Don't reference issue numbers, PRs, or commit hashes — they rot.
+
+---
+
+## JavaScript conventions
+
+`app.js` is single-file vanilla JS. ~2845 lines. No build step, no transpilation, no framework.
+
+### Style
+
+- ES2020 minimum (we ship to all modern browsers).
+- `const` by default; `let` when reassignment is needed; never `var`.
+- Strict equality (`===`, `!==`).
+- Template literals for string composition.
+- Arrow functions for callbacks; named `function` for hoisted handlers.
+- Module pattern via IIFEs or top-level `const`s; no ES modules (the file is `<script src=...>` not `<script type=module>`).
+
+### DOM
+
+- `document.querySelector` / `querySelectorAll`. No `getElementById` chains.
+- Avoid string-concatenation into `innerHTML` for user-supplied content — use `textContent` or `dataset`.
+- For dynamic markup, use `document.createElement` + `append`. Don't write template strings of HTML.
+
+### Event handling
+
+- Delegate where sensible (one listener on `document` for `[data-tool]` clicks, not 30 listeners).
+- Always feature-detect (`if (navigator.clipboard) ...`) — fall back gracefully.
+- Use `addEventListener`, not `onclick`.
+
+### State
+
+- `localStorage` for user preferences (theme, tool-group collapse state). Always handle JSON parse failures.
+- `sessionStorage` for ephemeral session data (iframe target origin fallback).
+- No global mutable state objects. If you need to share state across functions, pass it explicitly.
+
+### Async
+
+- `async`/`await`, never `.then()` chains beyond 2 levels.
+- Catch errors at the boundary; don't let promises reject silently.
+
+### Testing
+
+- Browser tests cover JS behaviour via Playwright. There's no unit-test layer for JS — the surface area is small enough that E2E is sufficient.
+- Clipboard interception in tests uses `page.add_init_script()` to stub `navigator.clipboard.writeText` (see `design-document.md` and the layout-PHP CLAUDE.md note about `add_init_script` matching the production API surface).
+
+---
+
+## CSS conventions
+
+`app.css` is single-file, token-based, ~3115 lines.
+
+### Tokens — reuse, don't add
+
+CSS custom properties (`--color-*`, `--space-*`, `--text-*`) are the design system. Reuse them. Adding a new token requires a formal style-guide bump.
+
+Frozen names that **cannot** be renamed:
+- `--color-bg` (invariant I4 — iframe API depends on this exact name).
+- `--color-btn-text` (invariant I5 — must stay dark for teal-button contrast).
+
+### Theming
+
+Light mode: `html[data-theme="light"] { ... }` overrides.
+Dark mode: default.
+Print: `@media print` redefines tokens (not selectors) to print-safe values.
+
+### Selectors
+
+- Class-based. No ID selectors except `#main-content` (the page landmark — invariant I13).
+- Avoid `!important` except in print stylesheet overrides (`@media print` block).
+- Nesting depth ≤ 3 levels.
+
+### Focus
+
+`:focus-visible` for focus rings (invariant I21). Never `:focus` alone — that gives the sticky mouse-click outline that v3.7.0 T5 specifically removed.
+
+### Responsive
+
+- Mobile-first where it doesn't hurt readability of the rule.
+- Breakpoints: 480px is the only formal one (mobile/desktop switch). Others are situational.
+- `.card` overflow handling is split (invariant I6): `overflow-x: clip` base, full `clip` only at ≤480px.
+
+### Animation
+
+- Respect `prefers-reduced-motion`. Use a `@media (prefers-reduced-motion: reduce)` block to neutralise transforms/transitions.
+- No infinite animations except very subtle loaders.
+
+### Stylelint
+
+Enforced in CI. Conventions are partly automated; run `npm run lint:css` before pushing.
+
+---
+
+## Cross-cutting
+
+### File headers
+
+Every PHP file starts with:
+
+```php
+<?php
+
+declare(strict_types=1);
+```
+
+Nothing else. No copyright block, no author tag, no version comment.
+
+### Imports
+
+`require` at the top. Use `require_once` for files that may be required transitively; `require` for files we know are loaded exactly once (bootstrap chain in `index.php`).
+
+### Commit messages
+
+Format:
+- Line 1: `type(scope): short summary` (e.g., `fix(ipv4): cidrs_overlap should use min not max`).
+- Blank line.
+- Body: what + why, not how. Reference invariants when fixing one (e.g., "Fixes I18 violation introduced in v1.2.0.").
+- Footer: `Co-Authored-By: ...` if applicable.
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `release`.
+Scopes: `ipv4`, `ipv6`, `api`, `ui`, `vlsm`, `vlsm6`, `admin`, `release`, `docs`, etc.
+
+### PR descriptions
+
+```
+## Summary
+1–3 bullets
+
+## Test plan
+- [ ] PHPUnit green
+- [ ] PHPStan L9 clean
+- [ ] make test-docker green
+- [ ] Manual smoke test of the affected surface
+```
+
+### Branch names
+
+Branching model + naming conventions (including hotfix and patch-release flow) live in [`design-document.md`](design-document.md) §10.1. Don't duplicate them here — read the canonical source before naming a branch.
+
+### Code review
+
+CodeRabbit auto-reviews. Treat actionable findings as required; nitpicks may be deferred only with explicit operator approval. Merge with `--merge` (repo policy disallows squash); `--admin` only when CodeRabbit posted stale CHANGES_REQUESTED on early task commits.
+
+Manual review by the operator is also required for any non-trivial change. The pattern is: PR opens → CodeRabbit + CI run → operator skims and approves → merge.
+
+### When in doubt
+
+Ask the existing code. The 50+ `functions-*.php` files are the corpus. If your new function looks different from every existing one, *you* are probably the outlier, not the codebase.
+
+---
+
+## Update protocol
+
+Update this guide when:
+1. A new convention emerges (e.g., we adopt readonly classes when PHP 8.1 support drops).
+2. A linter rule changes (PHPStan or PHPCS config updates).
+3. A new anti-pattern is identified.
+4. A naming convention shifts.
+
+Bump the "Last updated" header.
+
+Don't update this guide for:
+- Per-PR style preferences.
+- Personal taste differences (use the existing style).
+- Library version bumps that don't change conventions.

--- a/docs/internal/coding-guide.md
+++ b/docs/internal/coding-guide.md
@@ -363,7 +363,7 @@ Scopes: `ipv4`, `ipv6`, `api`, `ui`, `vlsm`, `vlsm6`, `admin`, `release`, `docs`
 
 ### PR descriptions
 
-```
+```text
 ## Summary
 1–3 bullets
 

--- a/docs/internal/config-reference.md
+++ b/docs/internal/config-reference.md
@@ -1,0 +1,202 @@
+# Configuration Reference
+
+**Audience:** Operator (Sean) + future-agent setting up or tuning a deployment.
+**Source:** `Subnet-Calculator/includes/config.php` (defaults) overridden by `Subnet-Calculator/config.php` if present (operator-only overrides; git-ignored).
+**Last updated:** 2026-05-13 (app v3.7.0)
+
+Every operator-tunable variable shipped by the app is enumerated here. If you find a `$variable` in code that isn't documented here, the docs are stale — add it.
+
+---
+
+## How configuration works
+
+1. `includes/config.php` (shipped, tracked in git) defines defaults for every variable.
+2. `config.php` at the docroot (operator-only, **not** in git, **not** in releases — anchored-rsync-excluded per invariant I8) is `require`d if present and may override any value.
+3. Validators near the bottom of `includes/config.php` clamp/normalise some values (e.g., `$split_max_subnets = max(1, min(256, ...))`).
+
+To override a value: copy `config.php.example` → `config.php` and edit. Never edit `includes/config.php` directly; deploys will overwrite it.
+
+---
+
+## Core display
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$app_version` | `'3.7.0'` | Read-only at runtime. Bumped via `/release` skill. Do not override. |
+| `$locale` | `'en'` | BCP 47 locale tag for number formatting (e.g., `'de'`, `'fr'`). |
+| `$fixed_bg_color` | `'null'` | Optional hard-coded background colour (overrides theme `--color-bg`). String `'null'` = no override. |
+| `$default_tab` | `'ipv4'` | Initial tab on page load. Valid: `'ipv4'`, `'ipv6'`, `'vlsm'`. |
+| `$page_title` | `'Subnet Calculator'` | `<title>` tag + `og:title`. |
+| `$page_description` | (long string) | `<meta description>` + `og:description`. |
+| `$show_share_bar` | `true` | Toggle the "Share" UI on the calculator output panel. |
+| `$canonical_url` | `''` | If set, emits `<link rel="canonical">`. Use when serving the same app behind multiple hostnames. |
+
+---
+
+## Calculator limits (DoS caps)
+
+| Variable | Default | Clamped to | Purpose |
+|---|---|---|---|
+| `$split_max_subnets` | `16` | `[1, 256]` | Maximum subnets the splitter will emit per request. Hard cap protects against `?ip=10.0.0.0/8&new_prefix=32` style explosions. See threat T7. |
+| `$lookup_max_cidrs` | `100` | — | Inverse subnet lookup: max CIDRs accepted per request. |
+| `$lookup_max_ips` | `1000` | — | Inverse subnet lookup: max IPs accepted per request. |
+| `$range_max_cidrs` | `256` | — | IP-range→CIDR converter: max output CIDRs per request (v3.3.0). |
+
+Hard caps that aren't operator-tunable (in the function, not config):
+- PMTU `payload_size ≤ 65535`, `fragment_count ≤ 4096` (invariant I19).
+- Session ID is always 16 hex chars (invariant I20).
+
+---
+
+## Form protection
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$form_protection` | `'none'` | Mode for calculator forms. Valid: `'none'`, `'honeypot'`, `'turnstile'`, `'hcaptcha'`, `'recaptcha'`. |
+| `$turnstile_site_key` | `''` | Cloudflare Turnstile site key (required when `$form_protection = 'turnstile'`). |
+| `$turnstile_secret_key` | `''` | Cloudflare Turnstile secret. |
+| `$hcaptcha_site_key` | `''` | hCaptcha site key. |
+| `$hcaptcha_secret_key` | `''` | hCaptcha secret. |
+| `$recaptcha_enterprise_site_key` | `''` | Google reCAPTCHA Enterprise site key. |
+| `$recaptcha_enterprise_api_key` | `''` | Google reCAPTCHA Enterprise API key. |
+| `$recaptcha_enterprise_project_id` | `''` | Google reCAPTCHA Enterprise project ID. |
+| `$recaptcha_score_threshold` | `0.5` | Minimum reCAPTCHA score to accept. Higher = stricter. |
+
+Only one mode is active at a time. Honeypot is recommended for low-traffic deployments; switch to a CAPTCHA only if you're seeing real abuse.
+
+---
+
+## CSP / headers
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$frame_ancestors` | `'*'` | CSP `frame-ancestors`. Set to a specific origin or `'none'` to lock down iframe embedding. |
+| `$csp_connect_extra` | `''` | Appended to CSP `connect-src` (e.g., to allow a custom analytics endpoint). |
+| `$csp_script_extra` | `''` | Appended to CSP `script-src`. |
+| `$csp_img_extra` | `''` | Appended to CSP `img-src`. |
+| `$hsts_max_age` | `31536000` | HSTS max-age in seconds (default 1 year; max 2 years = `63072000`). |
+| `$hsts_preload` | `false` | Operator opt-in for HSTS `preload` directive. Only enable after confirming you can keep HTTPS indefinitely — see [hstspreload.org](https://hstspreload.org/) before flipping. |
+
+---
+
+## REST API auth + rate limiting
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$api_tokens` | `[]` | Static legacy API tokens. `[]` = open (no auth); `['secret1', 'secret2']` = require `Authorization: Bearer <one of these>`. **For new deployments use API keys via the admin console, not static tokens.** |
+| `$api_rate_limit_rpm` | `60` | Per-IP requests/minute. `0` = disabled. |
+| `$api_rate_limit_tokens` | `[]` | Per-token RPM overrides: `['token1' => 600]` raises the limit for that specific token. |
+| `$api_allowed_endpoints` | `[]` | Endpoint allowlist. `[]` = all enabled; non-empty restricts to listed slugs (e.g., `['ipv4', 'ipv6', 'vlsm']`). |
+| `$api_cors_origins` | `['*']` | CORS allowlist for the API. `['*']` = any origin (default for public deployments); restrict to specific origins for private deployments. |
+| `$api_trusted_proxies` | `[]` | CIDRs whose `X-Forwarded-For` headers should be honoured for rate-limiting (e.g., your Cloudflare ranges). Empty = trust only the immediate peer. |
+
+---
+
+## Sessions (shareable URLs)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$session_enabled` | `false` | Master switch for the SQLite-backed VLSM session save/restore feature. |
+| `$session_db_path` | `''` | Absolute path to the sessions SQLite file. Empty = auto (`data/sessions.sqlite` under the docroot). See [`data-dictionary.md`](data-dictionary.md). |
+| `$session_ttl_days` | `30` | Days before a saved session expires. Lazy-purged on each new session creation. |
+
+---
+
+## API request logging
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$api_request_log` | `false` | Enable SQLite-backed API request logging. |
+| `$api_request_log_db_path` | `''` | Absolute path to the log DB. Empty = auto. |
+
+Disabled by default. Enable only if you need operational forensics; the log table grows linearly with traffic.
+
+---
+
+## Admin console + API keys
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$admin_ui_enabled` | `false` | Master switch for `/admin/` routes and the admin-keys API. Off by default — admin UI does not exist for the operator until this is flipped. |
+| `$admin_user` | `''` | Admin username (HTTP Basic Auth fallback path before TOTP gates further actions). |
+| `$admin_pass_hash` | `''` | `PASSWORD_BCRYPT` hash of the admin password. Generate via `php -r "echo password_hash('your-password', PASSWORD_BCRYPT);"`. |
+| `$apikey_db_path` | `''` | SQLite file for `api_keys` + admin tables. Empty = auto. Setting this to a path distinct from `$session_db_path` separates admin state from session state (different files, different backup cadence possible). |
+| `$admin_totp_secret` | `''` | Base32 RFC 6238 secret for admin TOTP. Empty = TOTP disabled. The setup wizard writes this; do not set by hand unless restoring from backup. |
+
+---
+
+## Admin audit
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$admin_audit_retention_days` | `90` | Rows older than this are removed on each audit write. `0` = never purge (keep forever). |
+| `$admin_audit_trust_xff` | `false` | Trust the `X-Forwarded-For` header when recording the source IP of an admin action. Enable only when behind a trusted reverse proxy (Cloudflare) — otherwise spoofable. Filtered via `FILTER_VALIDATE_BOOLEAN`. |
+| `$admin_audit_purge_strategy` | `'sampled'` | When to run the retention sweep. Valid: `'always'` (every write — strongest GC but costlier) or `'sampled'` (random sample, controlled by next variable). |
+| `$admin_audit_purge_sample_rate` | `0.001` | When `$admin_audit_purge_strategy = 'sampled'`, the probability per write that the purge runs. `0.001` = ~1 in 1000 writes triggers a sweep. |
+
+---
+
+## Tree presets
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `$tree_presets_dir` | `''` | Directory containing operator-defined tree-preset JSON files. Empty = built-in presets only. |
+
+---
+
+## Override patterns
+
+### Minimal production override (`config.php`)
+
+```php
+<?php
+// Cloudflare-fronted, public deployment with anonymous + per-key auth.
+$canonical_url       = 'https://subnetcalculator.app/';
+$form_protection     = 'turnstile';
+$turnstile_site_key  = '...';
+$turnstile_secret_key = '...';
+$api_rate_limit_rpm  = 60;
+$api_trusted_proxies = ['173.245.48.0/20', '103.21.244.0/22', ...]; // Cloudflare ranges
+$admin_ui_enabled    = true;
+$apikey_db_path      = '/var/lib/subnet-calculator/admin.sqlite';
+$session_enabled     = true;
+$hsts_preload        = true;
+```
+
+### Internal / iframe-only deployment
+
+```php
+<?php
+$frame_ancestors      = "'self' https://intranet.example.com";
+$api_tokens           = ['s3cret-token-here'];
+$api_cors_origins     = ['https://intranet.example.com'];
+$form_protection      = 'none';
+$show_share_bar       = false;
+$admin_ui_enabled     = false;
+```
+
+---
+
+## Update protocol
+
+Any PR that:
+- Adds, removes, or renames a config variable in `includes/config.php`.
+- Changes a default value.
+- Changes a validator (clamping range, allowed values).
+- Adds a new config-driven feature.
+
+The PR must:
+1. Update the relevant section here.
+2. Update `config.php.example` if the variable is operator-relevant.
+3. Add a CHANGELOG entry.
+4. Bump the "Last updated" header.
+
+If a config variable appears in code but not here, the doc is stale — fix it in the same PR.
+
+---
+
+## Cross-references
+
+- Persistence and what each `*_db_path` points to: [`data-dictionary.md`](data-dictionary.md).
+- Threat model around CORS / rate-limit / form protection: [`security-model.md`](security-model.md).
+- Release-time `config.php` preservation rule (anchored rsync): [`design-document.md`](design-document.md) §5 invariant I8.

--- a/docs/internal/data-dictionary.md
+++ b/docs/internal/data-dictionary.md
@@ -1,0 +1,223 @@
+# Data Dictionary
+
+**Audience:** Developer / future-agent making schema changes or reasoning about persisted state.
+**Premise:** SQLite is the only persistence layer. Every table is enumerated here. Schema changes must update this doc in the same PR.
+
+**Last updated:** 2026-05-13 (app v3.7.0)
+
+---
+
+## Physical layout
+
+All databases live under `Subnet-Calculator/data/` (web-blocked via `.htaccess`, git-ignored). The runtime opens them through operator-configurable paths from `includes/config.php`:
+
+| Operator variable | Default | Used by |
+|---|---|---|
+| `$session_db_path` | `data/sessions.sqlite` (auto) | `sessions` table only |
+| `$apikey_db_path` | falls back to `$session_db_path`; else `data/sessions.sqlite` | `api_keys` + all admin tables |
+
+In a default deployment, **one SQLite file** (`data/sessions.sqlite`) holds every table. Operators with stricter separation may configure `$apikey_db_path` to a distinct file (e.g., `data/admin.sqlite`) so the admin surface lives on a separately-backed-up volume; the schema does not change between the two arrangements.
+
+All connections use:
+- `$db->enableExceptions(true)` — never silent failures.
+- `$db->busyTimeout(1500–3000)` — concurrent-writer retry window.
+
+---
+
+## Tables
+
+### `sessions`
+
+**Defined in:** `includes/functions-session.php`
+**Purpose:** Shareable-URL state. Write-once, read-many. Each row is one shareable session created via `POST /api/v1/sessions` or the UI "Share" action.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | TEXT | NOT NULL PRIMARY KEY | 16-hex-char (8 random bytes via `random_bytes()`). Invariant I20 widened this from 8 to 16 in v3.6.4. |
+| `payload` | TEXT | NOT NULL | JSON-encoded session payload (calculator inputs + computed result). Schema is application-defined; no foreign keys. |
+| `created_at` | INTEGER | NOT NULL | Unix epoch seconds. |
+| `expires_at` | INTEGER | NOT NULL | Unix epoch seconds. Honoured by `session_purge()`, called on every `session_create()` for lazy GC. |
+
+**Indexes:**
+- `idx_sessions_expires (expires_at)` — supports the lazy-purge sweep.
+
+**Lifecycle:**
+- Created by `session_create($db, $payload, $ttl_days)`.
+- Read by `session_load($db, $id)` — returns NULL if expired or absent.
+- Purged opportunistically by `session_purge($db)` on every new session creation. No external cron required.
+
+**Security notes:**
+- ID entropy: 64 bits. Adequate for non-secret shareable URLs. If session contents were ever sensitive, the entropy should be widened again.
+- IDOR class threat documented in `security-model.md` T11.
+
+---
+
+### `api_keys`
+
+**Defined in:** `includes/functions-apikeys.php`
+**Purpose:** API key lifecycle for `Authorization: Bearer <key>` consumers.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | Internal row ID. |
+| `name` | TEXT | NOT NULL | Operator-assigned label (e.g., "Network team automation"). |
+| `prefix` | TEXT | NOT NULL | First few characters of the key, plaintext — for operator identification in the admin UI. Not secret on its own. |
+| `token_hash` | TEXT | NOT NULL | Argon2id hash of the full key (`password_hash(..., PASSWORD_ARGON2ID)`). The plaintext key is shown to the operator exactly once at issuance. |
+| `created_at` | INTEGER | NOT NULL | Unix epoch seconds. |
+| `last_used_at` | INTEGER | NULL | Unix epoch seconds; updated by the auth path on each successful verification. |
+| `revoked_at` | INTEGER | NULL | Unix epoch seconds when revoked; NULL = active. Revocation is soft (row retained for audit). |
+| `rate_limit_rpm` | INTEGER | NULL | Per-key requests-per-minute override. NULL → inherits global setting. **Added in v3.0.0 (#312) via `apikey_migrate_add_rate_limit()`.** Idempotent migration; safe to re-run. |
+
+**Indexes:**
+- `idx_api_keys_prefix (prefix)` — supports the admin UI's "find by prefix" lookup. The auth path itself hashes the candidate key and probes by `token_hash`, not prefix.
+
+**Migrations history:**
+- **v3.0.0 (#312)** — added `rate_limit_rpm`. Backfill: NULL on existing rows. Implemented in `apikey_migrate_add_rate_limit()`; runs on every `apikey_db_open()` call.
+
+**Security notes:** see `security-model.md` T12 (key theft) and T7 hardening (per-key rate limits).
+
+---
+
+### `admin_audit`
+
+**Defined in:** `includes/functions-audit.php`
+**Purpose:** Append-only log of every admin action. Operational forensics, not non-repudiation (see N5 in `security-model.md`).
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | Row ID. |
+| `ts` | INTEGER | NOT NULL | Unix epoch seconds. |
+| `actor` | TEXT | NULL | Admin username; NULL for system actions. Truncated to `AUDIT_ACTOR_MAX`. |
+| `ip` | TEXT | NULL | Source IP; NULL when not derivable. |
+| `action` | TEXT | NOT NULL | Action verb (e.g., `apikey.create`, `apikey.revoke`, `auth.login`, `auth.fail`). Length-capped at `AUDIT_ACTION_MAX`. |
+| `target_id` | INTEGER | NULL | Row ID of the affected entity (e.g., the `api_keys.id` being revoked). NULL when action has no target. |
+| `meta` | TEXT | NULL | JSON-encoded action-specific detail. |
+
+**Indexes:**
+- `idx_admin_audit_ts (ts)` — chronological scan.
+- `idx_admin_audit_action (action)` — filter by action type.
+
+**Write semantics:** `audit_log()` is **best-effort** — a write failure logs to `error_log` but never throws. Rationale (in code): "we never want an audit failure to mask the underlying admin action."
+
+---
+
+### `admin_sessions`
+
+**Defined in:** `includes/functions-admin-session.php`
+**Purpose:** Cookie-backed admin authentication sessions (post-TOTP).
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `session_id` | TEXT | PRIMARY KEY | 64-hex-char (32 random bytes). Set as an HttpOnly cookie. |
+| `user` | TEXT | NOT NULL | Admin username. |
+| `created_at` | INTEGER | NOT NULL | Unix epoch seconds. |
+| `last_seen` | INTEGER | NOT NULL | Updated on each authenticated request; supports idle-timeout. |
+| `expires_at` | INTEGER | NOT NULL | Hard expiry = `created_at + ADMIN_SESSION_TTL`. |
+| `totp_pending` | INTEGER | NOT NULL DEFAULT 0 | `1` between password verify and TOTP verify; `0` after full auth. |
+| `csrf` | TEXT | NOT NULL | 64-hex-char per-session CSRF token (32 random bytes). Validated on every admin POST. |
+| `ip` | TEXT | NULL | Source IP at session creation. |
+| `user_agent` | TEXT | NULL | UA string at session creation. |
+
+**Indexes:**
+- `idx_admin_sessions_expires_at (expires_at)` — supports session sweep.
+
+---
+
+### `auth_rate_limit`
+
+**Defined in:** `includes/functions-admin-session.php`
+**Purpose:** Admin-login throttling — track failed-auth bursts per `(IP, username)` pair.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `ip` | TEXT | NOT NULL (PK part) | Client IP. |
+| `user` | TEXT | NOT NULL (PK part) | Username attempted. |
+| `failures` | INTEGER | NOT NULL DEFAULT 0 | Consecutive failure count; reset on successful auth. |
+| `last_at` | INTEGER | NOT NULL DEFAULT 0 | Unix epoch seconds of the most recent failure. |
+
+**Primary key:** `(ip, user)` composite.
+
+**Throttle policy:** ≥5 failures within 15 minutes triggers cooldown. See `functions-admin-auth.php` for the current threshold.
+
+---
+
+### `admin_recovery_codes`
+
+**Defined in:** `includes/functions-admin-totp.php`
+**Purpose:** One-time-use recovery codes for admin TOTP. Issued at TOTP setup; consumed when used.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | Row ID. |
+| `code_hash` | TEXT | NOT NULL | Argon2id hash of the recovery code. Plaintext shown to operator once at issuance. |
+| `created_at` | INTEGER | NOT NULL | Unix epoch seconds. |
+| `used_at` | INTEGER | NULL | Unix epoch seconds when consumed; NULL = unused. |
+| `used_via_ip` | TEXT | NULL | IP that consumed the code, for forensics. **Added later via `ALTER TABLE` migration** in `functions-admin-totp.php`. Idempotent; checks `PRAGMA table_info` before adding. |
+
+**Indexes:**
+- `idx_admin_recovery_used (used_at)` — fast "any unused codes remaining?" query.
+
+---
+
+### `admin_state`
+
+**Defined in:** `includes/functions-admin-totp.php`
+**Purpose:** Key/value bag for small admin-scope settings that don't merit their own table (e.g., `totp_secret`, `wizard_complete`, etc.).
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `key` | TEXT | PRIMARY KEY | Setting name. |
+| `value` | TEXT | NOT NULL | Setting value (string; callers JSON-encode if they need structure). |
+| `updated_at` | INTEGER | NOT NULL | Unix epoch seconds. |
+
+Use sparingly. Anything with more than a handful of related settings or any relational structure deserves its own table.
+
+---
+
+## Migration policy
+
+The app uses **idempotent migrations baked into each `*_db_open()` function**, not a versioned migration tool. Rules:
+
+1. **Every `*_db_open()` runs `CREATE TABLE IF NOT EXISTS`.** New installs land on the current schema.
+2. **Adding a column = `PRAGMA table_info` check + `ALTER TABLE ADD COLUMN`** inside a dedicated `*_migrate_*()` function. Safe to re-run on every open.
+3. **Never remove a column in place** — keep it nullable, stop writing to it, document deprecation here. Real removal only in a major-version migration (e.g., dropping `dev` SQLite files and asking operators to re-init).
+4. **Never rename a column in place** — same reason.
+5. **No data backfill in the migration path** unless it's O(N) over a small table. Anything else needs an explicit operator step documented in CHANGELOG.
+6. **On migration failure: hard-fail.** Don't continue with a partial schema (see `apikey_migrate_add_rate_limit()` for the pattern). A partial schema crashes later, mysteriously; a thrown exception is deterministic.
+
+---
+
+## When to update this doc
+
+Any PR that:
+- Adds, removes, or renames a table.
+- Adds, removes, or renames a column.
+- Changes a primary key or index.
+- Adds a migration function.
+- Adds, changes, or removes a database file path / operator config variable.
+
+The PR must:
+1. Update the relevant table section here.
+2. Add a row to the table's "Migrations history" sub-section (or create the sub-section if none exists).
+3. Add a CHANGELOG entry under the release where the migration lands.
+4. If the change affects security posture (e.g., new auth-related field), cross-reference `security-model.md` and update its threat/control inventory.
+5. Bump the "Last updated" header.
+
+If a PR touches any `CREATE TABLE`, `CREATE INDEX`, `ALTER TABLE`, or `PRAGMA table_info` and does NOT update this doc, the PR is incomplete.
+
+---
+
+## What's intentionally not in this dictionary
+
+- **Application-level JSON shapes** stored inside `sessions.payload` — those are versioned by the app code, not by the DB schema. The DB sees opaque text.
+- **In-memory caches.** PHP request-scope arrays don't persist; no schema applies.
+- **OPcache / service-worker caches.** Not data, not relational, not in scope.
+- **External logs.** OLS error log, PHP error log, etc. are operator-managed text files.
+
+---
+
+## Cross-references
+
+- Threat model for each data store: [`security-model.md`](security-model.md) — see T11 (sessions), T12 (api_keys), T13 (admin).
+- Operational runbook for "SQLite locked / corrupt": [`runbooks.md`](runbooks.md) R8.
+- Pure-function rules vs. DB-touching code: [`design-document.md`](design-document.md) §4.1 (only `functions-session.php`, `functions-apikeys.php`, `functions-audit.php`, `functions-admin-*.php` are allowed to touch persistence).

--- a/docs/internal/design-document.md
+++ b/docs/internal/design-document.md
@@ -1,0 +1,634 @@
+# Subnet Calculator — Master Design Document
+
+**Status:** Living document. Update at the end of any release or major change.
+**Current version:** v3.7.0
+**Last updated:** 2026-05-13
+**Authoritative for:** Architecture, design decisions, code methodology, invariants, and the "why" behind every load-bearing choice.
+
+This document is the single source of truth for understanding the app's structure and intent. The `README.md` is for users; `CLAUDE.md` is the agent quick-reference; `CHANGELOG.md` is the per-release log. **This file explains why the code looks the way it does.**
+
+---
+
+## 1. Product purpose
+
+A zero-install, self-hostable IPv4 + IPv6 subnet calculator with deep tooling for network engineers: split, summarise, plan, decode transition mechanisms, lay out multicast groups, generate ULAs, plan VLSM, diff allocations, share results via URL, and consume any of it via a documented REST API. Runs as a single PHP app behind a generic webserver. No SaaS dependency, no telemetry, no required database (SQLite is used only for the optional shareable-session store).
+
+**Design north star:** a single page that does everything inline. No SPA, no build step for end users, no JS framework. The app must work with JS disabled for everything except clipboard/iframe niceties.
+
+---
+
+## 2. High-level architecture
+
+```mermaid
+flowchart TD
+    Browser["Browser<br/>HTML + CSS + vanilla JS<br/>(app.js, app.css)"]
+    Web["Apache / OpenLiteSpeed<br/>.htaccess routes /api/v1/* → api/v1/index.php<br/>blocks includes/, templates/, data/, config.php"]
+    Index["index.php<br/>bootstrap + request.php + layout.php"]
+    Api["api/v1/index.php<br/>router → handlers/<br/>helpers.php (auth, rate-limit, CORS)"]
+    Admin["admin/*.php<br/>TOTP-gated config UI<br/>+ API key mgmt"]
+    Core["includes/functions-*.php<br/>(pure functions, strict_types=1)<br/>IPv4 / IPv6 / split / vlsm / supernet / ula<br/>multicast / transition / range / tree / diff / bulk"]
+    DB[("data/*.sqlite<br/>shareable sessions<br/>admin TOTP + audit<br/>API keys")]
+
+    Browser -- HTTP --> Web
+    Web --> Index
+    Web --> Api
+    Web --> Admin
+    Index --> Core
+    Api --> Core
+    Admin --> Core
+    Core --> DB
+```
+
+### 2.1 Request flow (web UI)
+
+1. `index.php` sends security headers (CSP with nonce, HSTS, X-Content-Type-Options, Permissions-Policy), requires `config.php` then every `functions-*.php`, then `request.php`.
+2. `request.php` reads `$_GET`/`$_POST`, runs form protection (honeypot/Turnstile), dispatches to `sc_run_*()` helpers that populate template globals (`$result`, `$result6`, `$split_result`, `$vlsm_plan`, etc.).
+3. `templates/layout.php` renders the chrome (head, header, tab strip, footer) and includes per-tool partials from `templates/_tools/<slug>.php` which render trigger buttons + drawer panels and read the template globals.
+4. Browser hydrates: theme init runs in `<head>` before paint to avoid FOUC; `app.js` wires drawer open/close, copy buttons, iframe resize reporter, and tool-group localStorage persistence.
+
+### 2.2 Request flow (REST API)
+
+1. `.htaccess` rewrites `/api/v1/<path>` → `api/v1/index.php`.
+2. `api/v1/index.php` requires `helpers.php` (CORS, rate-limit, auth, `json_ok`/`json_err`) and `../../includes/*.php`.
+3. Dispatches by path to `handlers/<name>.php`. Each handler validates input, calls the same pure functions the web UI uses, and emits JSON via `json_ok()`.
+4. OpenAPI 3.1 spec lives at `api/openapi.yaml`; lint gate enforces it on every PR.
+
+**Key invariant:** the web UI and the REST API call the **same pure functions**. The only divergence is input shape (form-encoded vs JSON) and output rendering (HTML partial vs JSON envelope). New tools register both surfaces in lockstep.
+
+---
+
+## 3. Repository layout
+
+```
+Subnet-Calculator/              ← docroot (point webserver here)
+  index.php                     ← bootstrap (~30 lines)
+  config.php.example            ← copy → config.php for overrides
+  sw.js                         ← service worker (offline shell + CACHE_NAME)
+  .htaccess                     ← routing + asset cache + secret blocks
+  robots.txt
+  includes/                     ← pure functions; web-blocked
+    config.php                  ← defaults + optional config.php require
+    request.php                 ← form/GET dispatch
+    functions-resolve.php       ← hostname → IP resolution (web+API shared)
+    functions-ipv4.php          ← IPv4 arithmetic
+    functions-ipv6.php          ← IPv6 arithmetic (GMP)
+    functions-vlsm.php          ← IPv4 VLSM allocator
+    functions-vlsm6.php         ← IPv6 VLSM allocator (GMP)
+    functions-split.php         ← subnet splitter
+    functions-supernet.php      ← IPv4 supernet/summarise
+    functions-supernet6.php     ← IPv6 supernet/summarise
+    functions-ula.php           ← RFC 4193 ULA generator
+    functions-range.php         ← IP-range → CIDR list (IPv4)
+    functions-range6.php        ← IP-range → CIDR list (IPv6)
+    functions-tree.php          ← allocation tree + gap detection
+    functions-tree-presets.php  ← named tree templates
+    functions-tree-diff.php     ← tree-level diff for tree editor
+    functions-diff.php          ← CIDR-list diff with canonical-form normalisation
+    functions-lookup.php        ← inverse subnet lookup (IP+mask → CIDR)
+    functions-bulk.php          ← batch endpoint dispatcher
+    functions-rdns6.php         ← IPv6 reverse-DNS zone generator
+    functions-type6.php         ← IPv6 address-type classification
+    functions-zone6.php         ← IPv6 zone-ID parsing (fe80::1%eth0)
+    functions-mapped6.php       ← IPv4-mapped IPv6 (::ffff:a.b.c.d)
+    functions-nat64.php         ← RFC 6052/6146 NAT64 PLAT/CLAT
+    functions-6to4.php          ← RFC 3056
+    functions-teredo.php        ← RFC 4380
+    functions-isatap.php        ← RFC 5214
+    functions-6rd.php           ← RFC 5969
+    functions-embedded-v4.php   ← detect embedded-IPv4 in IPv6
+    functions-embedded-rp6.php  ← RFC 3956 embedded-RP multicast
+    functions-multicast6.php    ← RFC 4291/3306 multicast decoder
+    functions-ssm6.php          ← unicast-prefix-based multicast
+    functions-pmtu6.php         ← IPv6 PMTU/fragment helper
+    functions-prefix-plan6.php  ← /48 → /56 → /64 nibble planner
+    functions-nibble6.php       ← nibble-boundary arithmetic
+    functions-rfc3531.php       ← RFC 3531 reversible address-block allocation
+    functions-slaac6.php        ← SLAAC EUI-64 / RFC 7217 / RFC 4941 privacy
+    functions-derive6.php       ← derive IPv6 from MAC / interface ID
+    functions-session.php       ← shareable-session CRUD (SQLite)
+    functions-apikeys.php       ← API key issuance + auth
+    functions-audit.php         ← admin audit log
+    functions-admin-auth.php    ← admin login (TOTP)
+    functions-admin-session.php ← admin cookie sessions (SQLite)
+    functions-admin-totp.php    ← TOTP helpers (RFC 6238)
+    functions-admin-settings.php← persisted operator settings
+    functions-admin-wizard.php  ← first-run setup
+    functions-util.php          ← help_bubble(), badge helpers
+  templates/                    ← HTML; web-blocked
+    layout.php                  ← page chrome + tab panels (~950 lines after T2)
+    _tools/<slug>.php           ← 35 per-drawer partials (one per tool)
+    _tree_editor.php            ← tree editor partial
+  api/
+    openapi.yaml                ← OpenAPI 3.1 spec
+    v1/
+      index.php                 ← router
+      helpers.php               ← auth, rate-limit, CORS, json envelope (blocked)
+      .htaccess                 ← front-controller rewrite
+      handlers/<name>.php       ← one per endpoint
+  admin/                        ← operator console (TOTP-gated)
+    index.php, login.php, logout.php, totp.php, totp-verify.php,
+    settings.php, keys.php, audit.php, _wizard.php, _sidebar.php
+  assets/                       ← public, long-cached
+    app.css, app.js, logo.{webp,png}, favicon-32.{webp,png},
+    vendor/xlsx/xlsx.full.min.js (SRI-verified, defer-loaded)
+  data/                         ← SQLite DB; web-blocked; git-ignored
+
+docs/                           ← MkDocs Material (user-facing, GH Pages)
+docs/internal/                  ← internal specs + this design doc
+docs/superpowers/               ← per-release plans + living docs
+testing/
+  unit/                         ← PHPUnit 11 (785 tests / 1771 assertions @ v3.7.0)
+  scripts/playwright_test.py    ← ~2763 Playwright assertions
+  snapshots/                    ← Pillow visual regression baselines
+  fixtures/                     ← test fixtures incl. iframe-test.html
+releases/                       ← versioned tarballs
+.github/workflows/              ← CI: php.yml (3-version matrix), docs.yml
+.semgrep/rules.yml              ← custom Semgrep rules
+.claude/                        ← agent skills + hooks
+```
+
+---
+
+## 4. Code methodology
+
+### 4.1 Pure-function core
+
+Every `includes/functions-*.php` file:
+
+- Starts with `declare(strict_types=1);`
+- Exports pure functions (no globals, no I/O except inside the dedicated `functions-session.php` / admin files).
+- Takes typed scalars or arrays; returns typed scalars or associative arrays.
+- Throws `InvalidArgumentException` for caller-provided bad input. Never returns `false`/`null` to signal "invalid" — the type system carries the contract.
+
+**Why:** the same function powers the web form, the API handler, the unit test, and the Playwright assertion. If a function had side effects or globals, those four call sites would drift.
+
+### 4.2 IPv4 arithmetic discipline
+
+PHP's `ip2long()` returns a **signed** integer on 64-bit systems. After every bitwise op, mask with `& 0xFFFFFFFF`. This is the #1 historical bug source in this codebase. Any new IPv4 math must follow the same convention; the existing helpers (`cidr_to_mask`, `network_address`, etc.) already do.
+
+### 4.3 IPv6 arithmetic discipline
+
+**Always GMP.** Never PHP signed-int math. The standard pipeline is:
+
+```
+inet_pton($addr) → bin2hex() → gmp_init($hex, 16) → gmp_*() ops →
+gmp_strval($gmp, 16) → str_pad(…, 32, '0', STR_PAD_LEFT) → hex2bin() → inet_ntop()
+```
+
+Subnet counts ≥ 2^63 are represented as the **string** `"2^N"` — never a PHP int. The VLSM6 allocator and `calculate_subnet6()` both honour this convention; new IPv6 code must too.
+
+### 4.4 Strict typing + PHPStan L9
+
+The whole tree (excluding admin templates) passes PHPStan **level 9** with `--memory-limit=512M`. Level 9 forbids `mixed` returns and enforces array shapes. Don't downgrade to silence errors; fix the type.
+
+### 4.5 Input validation surface
+
+All caller-controlled input is validated **at the boundary** (`request.php` for web, the handler file for API). Pure functions trust their inputs because the boundary already validated them. This is enforced by:
+
+1. Boundary validators throw `InvalidArgumentException`.
+2. Web boundary catches → renders error banner.
+3. API boundary catches → emits `json_err(400, ...)`.
+4. Pure functions assume preconditions hold.
+
+### 4.6 No silent fallbacks
+
+If a feature can't run (missing GMP, missing SQLite, Turnstile keys absent), surface it explicitly. Never silently degrade — the v3.6.2 `cidrs_overlap` bug shipped for 5+ months because broken code coincidentally produced correct output for the test fixtures. Surface failures loudly.
+
+### 4.7 Shareable URL symmetry (`sc_run_*` helpers)
+
+Every tool that supports shareable URLs uses a single helper in `request.php` (`sc_run_lookup`, `sc_run_diff`, `sc_run_split`, etc.) that handles **both** POST submission and GET hydration. The template renders identically for either method. Never split POST and GET into separate code paths — they will drift.
+
+### 4.8 No new design tokens without explicit approval
+
+CSS custom properties (`--color-*`, spacing scale, type scale) are frozen except by formal style-guide updates (v2.9.0 baseline). New components reuse existing tokens.
+
+### 4.9 Comments policy
+
+Default to none. Comments are only for non-obvious WHY: hidden constraints, subtle invariants, workarounds for specific bugs, behaviour that would surprise a reader. Never restate WHAT the code does. Never reference issue numbers in comments — those rot.
+
+---
+
+## 5. Key invariants (load-bearing — break these and things explode)
+
+| # | Invariant | Lives at | Why |
+|---|---|---|---|
+| I1 | IPv4 bitwise results masked with `& 0xFFFFFFFF` | every `functions-ipv4.php` op | `ip2long` is signed on 64-bit |
+| I2 | IPv6 arithmetic uses GMP exclusively | every `functions-*6.php` | 128-bit overflows PHP signed int |
+| I3 | IPv6 subnet/host counts ≥ 2^63 are string `"2^N"` | `calculate_subnet6`, `vlsm6_allocate` | int overflow |
+| I4 | `--color-bg` CSS custom property must keep that exact name | `app.css`, `app.js` iframe API | iframe consumers call `style.setProperty('--color-bg', …)` |
+| I5 | `--color-btn-text` stays dark for teal buttons | `app.css` both themes | WCAG AA contrast with teal background |
+| I6 | `.card` uses `overflow-x: clip` base, full `clip` only ≤480px | `app.css` | preserves vertically-escaping tooltips on desktop |
+| I7 | CSP nonce on every inline `<style>`/`<script>` | `index.php` headers + `layout.php` | strict CSP forbids unnonced inline |
+| I8 | Anchored rsync excludes for production deploy | `/release` skill | unanchored `config.php` matches bundled defaults too (v3.5.0 lesson) |
+| I9 | `sleep 3` after `systemctl restart lsws` | deploy runbooks | OPcache settle time (v3.6.3 lesson) |
+| I10 | Bump `CACHE_NAME` in `sw.js` every release | release checklist | service worker activate handler only purges on constant change (v3.2.2 lesson) |
+| I11 | `admin/_test-drain.php` excluded from release tarballs | tarball build command | test-rig only (#324) |
+| I12 | `htmlspecialchars()` always uses `ENT_QUOTES` | every template echo | single-quoted attribute safety |
+| I13 | Page landmark is `<main id="main-content">` on the outermost card | `layout.php` | skip link + iframe consumers target this |
+| I14 | Help bubbles use `tabindex="0" role="button" aria-label="Help"` | `help_bubble()` in `functions-util.php` | keyboard focus reveals tooltip via existing `:focus-within` CSS |
+| I15 | `subnet_diff()` normalises CIDRs to canonical form before comparing | `functions-diff.php` | `10.0.0.5/24` and `10.0.0.0/24` are the same network |
+| I16 | Web UI + REST API call the same pure functions | enforced by handler imports | one source of truth for behaviour |
+| I17 | Boundary validates; pure functions trust | `request.php` + `api/v1/handlers/*.php` | avoids double-validation drift |
+| I18 | `cidrs_overlap` uses `min($px_a, $px_b)` for shared-prefix test | `functions-ipv4.php` / `-ipv6.php` | broader mask is the correct comparator (v3.6.2 P1 fix) |
+| I19 | PMTU `payload_size ≤ 65535`, `fragment_count ≤ 4096` | `functions-pmtu6.php` | DoS prevention (v3.6.3) |
+| I20 | Session IDs are 16 hex chars (not 8) | `functions-session.php` | entropy widening (v3.6.4) |
+| I21 | `:focus-visible` (not `:focus`) for focus rings | `app.css` | no sticky mouse-click outline (v3.7.0 T5) |
+| I22 | Each `_tools/<slug>.php` partial reads via existing template globals | `templates/_tools/*.php` | no new data flow introduced by T2 refactor |
+
+When in doubt, search this table before changing the affected file.
+
+---
+
+## 6. Design decisions and their rationale
+
+### 6.1 Why a PHP monolith and not a framework
+
+Operator audience: small/medium network teams who already run LAMP. Drop-in tarball install on any shared host. No composer dependency at runtime (composer is dev-only — PHPUnit/PHPStan/PHPCS). No build step. The whole app is `unzip; chmod; done`.
+
+### 6.2 Why no JS framework
+
+Same audience reason, plus: the calculator output is deterministic from request input — there's nothing to "react" to. A 2845-line `app.js` handles drawers, theme, copy, iframe resize, and tool-group persistence. That's plenty.
+
+### 6.3 Why single-page tabs and not multi-page
+
+Sharing. A single URL with query params shares any tool's exact state across teams. Multi-page would fragment the shareable surface. The IPv6 wall-of-buttons UX cost (v3.7.0 T3 mitigated via collapsible groups) was the tradeoff.
+
+### 6.4 Why tool drawers instead of separate pages
+
+Same: keeps every tool one click from the calculator, sharing the IPv4/IPv6/VLSM result above. The `data-tool="<slug>"` markup convention is the contract; T2 (v3.7.0) extracted these into `_tools/<slug>.php` partials so future tools touch one file plus a one-line include.
+
+### 6.5 Why SQLite for sessions, API keys, admin auth
+
+Zero external dependencies. File-based; backup is `cp data/*.sqlite`. No SQL injection risk because there's no user-controllable SQL surface — all queries are parameterised and table contents are write-only by trusted code paths (admin TOTP-gated, sessions are server-generated IDs).
+
+### 6.6 Why GMP and not BCMath
+
+GMP is faster, supports bitwise ops natively (BCMath does not), and is a standard PHP extension on every modern distro. The session-start hook installs `php-gmp` automatically on the dev server.
+
+### 6.7 Why we ship a service worker
+
+Pure cache-first offline shell. Zero network code (no Background Sync, no Push). Bumping `CACHE_NAME` per release is the only maintenance cost. The v3.2.2 release shipped specifically to recover from missed bumps accumulating from v2.7.0 → v3.2.1 — never skip this.
+
+### 6.8 Why CSP with per-request nonce
+
+Strict CSP without `unsafe-inline`. Theme-init inline script and conditional `bg_override_style` inline styles use the per-request nonce. CSP also blocks the most common XSS payload patterns even if a future `htmlspecialchars()` slip got past CodeQL/Semgrep.
+
+### 6.9 Why we don't trust CI solely (v3.6.2 lesson)
+
+CI gates (PHPUnit, PHPStan, PHPCS, Spectral, Semgrep, Playwright) are necessary but **not sufficient**. The `cidrs_overlap` bug shipped for 5+ months because all tests used `10.0.0.0/X` pairs where both networks coincidentally produced correct results despite broken `max()` masking. Manual production regression on every release with Playwright + `ui-ux-pro-max` is mandatory now.
+
+### 6.10 Why anchored rsync excludes (v3.5.0 lesson)
+
+Unanchored `--exclude='config.php'` matches **both** the operator's local `config.php` (correct — preserve) and the bundled `includes/config.php` (wrong — would be skipped, breaking the install). Always anchor: `--exclude='/config.php' --exclude='/data/'`.
+
+### 6.11 Why `sleep 3` after `systemctl restart lsws` (v3.6.3 lesson)
+
+OPcache takes ~1–2 seconds to settle after lsws restart. The first PMTU smoke test after v3.6.3 deploy returned the pre-fix 39.6MB response because OPcache served stale bytecode briefly. Three-second sleep eliminates the race entirely.
+
+### 6.12 Why per-tool URL routes (`?tool=<slug>`)
+
+Locked from v3.4.0 T7. Deep-linking into a specific drawer means support docs can include a one-click link to "the wildcard tool" or "the PMTU calculator." Each new drawer registers in the lookup map. URL state survives reloads and is included in shareable URLs.
+
+### 6.13 Why `help_bubble()` instead of `title` attributes
+
+`title` is mouse-only and unstyled. `help_bubble()` emits an icon with `tabindex="0" role="button" aria-label="Help"` and the existing `:focus-within` CSS reveals a styled tooltip on keyboard focus without any JS. Inherits a11y from v2.5.0.
+
+### 6.14 Why we keep PHP 8.1 runtime support but require 8.2+ in CI
+
+Dev tools (PHPUnit 11, PHPStan 2) need 8.2+. App runtime code uses only 8.1-compatible syntax. Shared hosts on 8.1 can still install; PRs are validated against 8.2/8.3/8.4. Drop 8.1 runtime support when we adopt readonly classes or other 8.2+ syntax.
+
+### 6.15 Why CodeRabbit reviews even though we run multiple linters
+
+CodeRabbit catches conventions and naming consistency that ASTs don't model. Treat its nitpicks as "consider"; treat its actionable findings as "fix before merge unless explicitly deferred."
+
+### 6.16 Why the Memory MCP graph is project-scoped
+
+Each release entity (`project:subnet-calculator:release:vX.Y.Z`) accumulates observations during work: SHA, files touched, test results, gate outcomes. Cross-release relations (`predecessor-of`, `is-regression-of`) preserve the chain of "what changed and why." Re-derivable from git, but the graph is the fast working layer.
+
+---
+
+## 7. Feature catalogue (by tab)
+
+### 7.1 IPv4 tab
+
+Calculator + 5 drawer tools:
+- **Split** — divide a parent CIDR into N equal subnets (count or new prefix).
+- **VLSM** — variable-length allocator from a host-count list; exports CSV/JSON/XLSX.
+- **Supernet / summarise** — find common supernet for a CIDR list.
+- **Range → CIDR** — inverse: minimum CIDR list covering an arbitrary range.
+- **Overlap / multi-CIDR check** — pairwise or N-way overlap detection.
+- **Wildcard ↔ CIDR** — ACL helper. Accepts string or int (v2.10.0 widening).
+- **Lookup** — IP + arbitrary mask → CIDR.
+- **Diff** — before/after CIDR list with added/removed/changed/unchanged categories; canonical-form normalisation (v2.11.0).
+- **Tree** — hierarchical allocation tree with gap detection; named presets; tree-level diff in the editor.
+
+### 7.2 IPv6 tab
+
+Calculator + **19 drawer tools** organised into 5 collapsible groups (v3.7.0 T3):
+- **Foundational** (4): split6, ula (RFC 4193), range6, supernet6.
+- **Address utilities** (4): zone-id, derive (MAC/IFID → IPv6), slaac (EUI-64 + RFC 7217 + RFC 4941), rdns6.
+- **Transition** (6): mapped6/nat64 (RFC 6052/6146), embedded-v4 detect, 6to4 (RFC 3056), teredo (RFC 4380), isatap (RFC 5214), 6rd (RFC 5969).
+- **Prefix planning** (3): prefix-plan6 (/48→/56→/64), nibble6, rfc3531.
+- **Multicast** (4): multicast6 scope decoder (RFC 4291/3306), ssm6 (unicast-prefix-based), embedded-rp6 (RFC 3956), pmtu6.
+
+### 7.3 VLSM tab
+
+IPv4 VLSM planner; shareable URL; CSV/JSON/XLSX export; utilisation summary; session TTL notice.
+
+### 7.4 VLSM IPv6 tab
+
+GMP-based IPv6 VLSM (v2.11.0). Host counts may be int or `"2^N"` string. No broadcast/network reservation (RFC 4291 unicast).
+
+### 7.5 Admin console
+
+TOTP-gated. Manage operator settings, API keys (issuance + revocation + per-key rate limits), audit log, first-run wizard.
+
+---
+
+## 8. REST API surface
+
+OpenAPI 3.1 at `api/openapi.yaml`. Spectral-linted on every PR.
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/v1/meta` | GET | Version, capabilities |
+| `/api/v1/changelog` | GET | Parsed CHANGELOG.md |
+| `/api/v1/openapi` | GET | Spec itself |
+| `/api/v1/schemas` | GET | JSON Schemas |
+| `/api/v1/ipv4`, `/ipv6` | POST | Calculator |
+| `/api/v1/split`, `/split6` | POST | Splitter |
+| `/api/v1/vlsm`, `/vlsm6` | POST | VLSM |
+| `/api/v1/supernet`, `/supernet6` | POST | Summarisation |
+| `/api/v1/ula` | POST | RFC 4193 generation |
+| `/api/v1/range`, `/range6` | POST | Range → CIDR |
+| `/api/v1/overlap` | POST | N-way overlap |
+| `/api/v1/wildcard` | POST | Wildcard ↔ CIDR |
+| `/api/v1/lookup` | POST | Inverse lookup |
+| `/api/v1/diff` | POST | CIDR-list diff |
+| `/api/v1/rdns`, `/rdns6` | POST | Reverse zone |
+| `/api/v1/tree` | POST | Allocation tree |
+| `/api/v1/tree-presets` | GET | Named templates |
+| `/api/v1/zone-id` | POST | IPv6 zone-ID |
+| `/api/v1/derive` | POST | MAC/IFID → IPv6 |
+| `/api/v1/slaac-privacy` | POST | SLAAC variants |
+| `/api/v1/mapped6`, `/nat64`, `/6to4`, `/teredo`, `/isatap`, `/6rd`, `/embedded-v4` | POST | Transition decoders |
+| `/api/v1/multicast6`, `/ssm6`, `/embedded-rp6`, `/pmtu6` | POST | Multicast + PMTU |
+| `/api/v1/prefix-plan6`, `/nibble6`, `/rfc3531` | POST | Prefix planning |
+| `/api/v1/bulk` | POST | Batch multiple ops in one request |
+| `/api/v1/sessions` | GET/POST | Shareable session store |
+| `/api/v1/admin/keys` | various | API key admin (auth-gated) |
+
+**Auth modes:** anonymous (rate-limited), API key (`Authorization: Bearer <key>`; per-key rate limit), admin (cookie session, TOTP).
+
+**Envelope:** `{ok: true, data: …}` or `{ok: false, error: {code, message}}` via `json_ok()`/`json_err()` in `helpers.php`.
+
+---
+
+## 9. Testing topology
+
+| Layer | Tool | Where | Scale @ v3.7.0 |
+|---|---|---|---|
+| Unit | PHPUnit 11 | `testing/unit/` | 785 tests / 1771 assertions |
+| E2E browser | Playwright (Docker) | `testing/scripts/playwright_test.py` | ~135 test groups / 2763 assertions |
+| Visual regression | Pillow snapshots | `testing/snapshots/` | committed PNGs, diffed on snapshot runs |
+| Static analysis | PHPStan L9 | `phpstan.neon` | enforced in CI |
+| Lint | PHPCS PSR-12 | `.phpcs.xml`, `.phpcs-admin.xml` | CI gate |
+| Security | Semgrep | `.semgrep/rules.yml` + OWASP top-ten + sql-injection | CI gate + pre-tool hook |
+| OpenAPI | Spectral | `api/openapi.yaml` | CI gate |
+| JS/CSS | ESLint + Stylelint | `package.json` | CI gate |
+| **Manual** | **Production regression** | **`ui-ux-pro-max` + Playwright** | **Mandatory every release** |
+
+The manual production regression gate is non-negotiable after the v3.6.2 lesson (see §6.9).
+
+---
+
+## 10. Release engineering
+
+### 10.1 Branching model
+
+**Single source of truth for branching.** `coding-guide.md` and `CLAUDE.md` point here.
+
+#### Long-lived branches
+
+- **`main`** — the release branch. Tags live here. Every commit on `main` is shipped to production. PRs only land via merge (no direct pushes). Always green.
+- **`dev`** — historically the active-development integration branch. In current practice (v3.x), feature work tends to branch directly off `main` or off the active `release/vX.Y.Z`. `dev` is preserved but not load-bearing; do not block on it.
+
+#### Per-release branches
+
+- **`release/vX.Y.Z`** — integration branch for an in-flight release. Cut from `main` at release kickoff (T1). All feature/task branches for that release PR **into** this branch. When the release is ready, a single PR `release/vX.Y.Z → main` ships it. Tag `vX.Y.Z` after the merge.
+
+#### Short-lived branches
+
+| Prefix | Branched from | Merges into | Used for |
+|---|---|---|---|
+| `feature/v<X.Y.Z>-<slug>` | active `release/vX.Y.Z` (or `main` if no release is open) | the release branch it was cut from | Per-task work inside a release (e.g. `feature/v3.7.0-a11y-polish`) |
+| `fix/<slug>` | the tag of the broken release (e.g. `v3.6.0`) | new `release/vX.Y.Z+1` branch | Patch fixes — see "Patch releases" below |
+| `chore/<slug>` | `main` | `main` directly via PR | Dependabot bumps, CI tweaks, doc-only changes that don't need a release |
+| `hotfix/<slug>` | `main` | `main` directly via PR, then cherry-pick to active `release/*` if open | Urgent production fix that cannot wait — see "Hotfixes" below |
+
+Branch names use lowercase, hyphens, no spaces.
+
+#### Patch releases (vX.Y.Z+1)
+
+When a bug ships to production and needs to go out independently of the next minor:
+
+1. Branch `release/vX.Y.Z+1` from the **`vX.Y.Z` tag** (not from `main`, which may have un-shipped work).
+2. Cherry-pick or write the fix on a `fix/<slug>` branch off the new release branch.
+3. PR `fix/<slug> → release/vX.Y.Z+1`.
+4. Run the release checklist (§10.2) including the manual regression gate.
+5. PR `release/vX.Y.Z+1 → main`, merge, tag.
+6. If a higher in-flight release branch exists (e.g., `release/v3.8.0`), the fix is forward-ported to it via a separate cherry-pick PR. Don't let the in-flight minor regress on a fix the patch shipped.
+
+#### Hotfixes
+
+For genuine production emergencies (security, availability) that cannot wait for the next scheduled release:
+
+1. Branch `hotfix/<slug>` from `main`.
+2. Fix, test, PR to `main`. Merge with operator approval; CodeRabbit may be `--admin`-bypassed if review is blocking and the fix is small and obvious.
+3. Tag the resulting commit as `vX.Y.Z+1` (still a patch release — increment patch).
+4. Deploy via the normal release runbook (anchored rsync, `sleep 3`, Cloudflare purge, smoke).
+5. Cherry-pick to any open `release/*` branches.
+
+Hotfixes are rare. The default is "ship a patch release through the normal flow." Hotfix is for "production is on fire right now."
+
+#### Merge style
+
+- **Always `--merge` (true merge commit) for `release/* → main`.** The repo policy disallows squash; the merge commit is the readable record that "release vX.Y.Z landed here."
+- **`--merge` is also the default for feature branches into a release branch.** Preserves task-level history.
+- **`--admin` only when CodeRabbit posted stale CHANGES_REQUESTED** on early task commits and the operator has approved the merge. Document the override in the PR description.
+- **Never `--squash`** — the repo will reject it.
+- **Never force-push to `main` or `release/*`.** Force-push is fine on `feature/*` and `fix/*` before they're merged (rebase to keep history tidy).
+
+#### Cleanup
+
+- **After a feature/fix/chore branch merges:** delete the remote branch (GitHub usually offers "Delete branch" on the merged PR — accept). Delete local branches with `git branch -d <name>` once you confirm GitHub has the merge.
+- **After a release ships:** keep `release/vX.Y.Z` for ~30 days (useful for cherry-picks if a regression appears immediately). Delete after that. The tag is the durable record.
+- **Stale branches:** the `/commit-commands:clean_gone` skill clears local branches whose remote is gone. Run it periodically.
+
+#### Naming guarantees
+
+The following names are reserved with the meanings above:
+- `main` — release branch.
+- `dev` — historical dev branch (low-load-bearing).
+- `release/v*`, `feature/v*`, `fix/*`, `hotfix/*`, `chore/*` — see table.
+
+Other names (e.g., `wip/`, `experiment/`) are operator-discretionary and should not be PR'd to `main`.
+
+### 10.2 Release checklist (locked)
+
+1. Bump `$app_version` in `Subnet-Calculator/includes/config.php`.
+2. **Bump `CACHE_NAME` in `Subnet-Calculator/sw.js`** to `sc-vX.Y.Z` (I10).
+3. Update `CHANGELOG.md` with `## [X.Y.Z]` section.
+4. Add row to `README.md` downloads table.
+5. Update `mkdocs.yml` `extra.version`; update tarball filename in `docs/index.md`.
+6. Build tarball:
+   ```bash
+   cp CHANGELOG.md Subnet-Calculator/CHANGELOG.md
+   gtar --owner=0 --group=0 --numeric-owner \
+        --exclude='admin/_test-drain.php' \
+        -czf releases/subnet-calculator-X.Y.Z.tar.gz \
+        -C Subnet-Calculator .
+   rm Subnet-Calculator/CHANGELOG.md
+   ```
+7. Commit, push, open PR `release/vX.Y.Z → main`.
+8. Merge with `--merge` (not `--squash` — repo policy) or `--admin` if CodeRabbit is stale.
+9. Tag `vX.Y.Z` and push tag.
+10. Deploy to production via anchored rsync (I8).
+11. `sleep 3` after `systemctl restart lsws` (I9).
+12. Run smoke tests against production.
+13. Cloudflare zone purge.
+14. Manual Playwright + `ui-ux-pro-max` regression.
+15. **Sync internal docs.** For each spec/plan implemented in this release:
+    - Update `design-document.md`: new invariants → §5, new design decisions → §6, new tools → §7, new endpoints → §8, scale numbers (test counts, line counts) → §3/§9.
+    - Update `design-guide.md` if a new UX pattern landed.
+    - Update `coding-guide.md` if a convention changed.
+    - Update `api-contract.md` if a new error code or breaking change shipped.
+    - Update `data-dictionary.md` if any table, column, index, migration, or DB-path config changed.
+    - Update `config-reference.md` if any operator-tunable variable was added, removed, renamed, or had its default changed.
+    - Update `security-model.md` if the threat surface changed.
+    - Update `runbooks.md` if a new incident class was learned this cycle.
+    - Bump "Last updated" headers on every doc touched.
+16. Close milestone, record observations in Memory MCP entity.
+
+Or run `/release` to automate steps 1–7 and prompt for step 15.
+
+### 10.3 Production targets
+
+- **Origin:** OpenLiteSpeed at `root@192.168.80.23:/usr/local/lsws/vhosts/subnetcalculator.app/html/`
+- **CDN:** Cloudflare (zone purge via API on every release)
+- **Dev:** `root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/`
+
+---
+
+## 11. Security posture
+
+### 11.1 Headers (set by `index.php`)
+
+- `Content-Security-Policy` with per-request nonce; no `unsafe-inline`.
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: SAMEORIGIN` (iframe consumers use same-origin embedding via `<iframe src="…">`)
+- `Permissions-Policy: …` deny-all for unused features.
+- `Referrer-Policy: strict-origin-when-cross-origin`
+
+### 11.2 Input handling
+
+- Web boundary: `request.php` validates, throws on bad input, renders error banner.
+- API boundary: each handler validates, emits `json_err(400, …)` on bad input.
+- `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` on every echoed user-controlled value (I12).
+- SQL: parameterised PDO throughout. No user-controlled table or column names anywhere.
+- Sessions: 16-hex-char IDs (I20), CSPRNG via `random_bytes()`.
+- API keys: stored hashed; never logged.
+- TOTP for admin (RFC 6238); rate-limited login.
+
+### 11.3 DoS hardening
+
+- PMTU: `payload_size ≤ 65535`, `fragment_count ≤ 4096` (I19).
+- Splitter: `$split_max_subnets` operator-configurable; default 1024.
+- VLSM: bounded by input list length.
+- Rate limits: anonymous + per-API-key; see `helpers.php`.
+
+### 11.4 Form protection
+
+Honeypot (default) + optional Cloudflare Turnstile (operator config). Both checked before calculation.
+
+### 11.5 Audit log
+
+Admin actions append to `data/audit.sqlite` via `functions-audit.php`. Tamper-evident? No — operator owns the file. Goal is operational forensics, not non-repudiation.
+
+---
+
+## 12. Performance & caching
+
+- **Assets:** long-cache via `.htaccess` (`Cache-Control: public, max-age=31536000, immutable`).
+- **HTML:** no cache; CSP nonce changes per request anyway.
+- **Service worker:** cache-first shell; `CACHE_NAME` bump per release invalidates.
+- **OPcache:** assumed enabled in production; release deploys `sleep 3` after restart.
+- **GMP:** chosen over BCMath partly for speed (10–100× on large numbers).
+
+No known hot spots. Lighthouse work is explicitly out of scope unless a signal warrants it.
+
+---
+
+## 13. Accessibility commitments
+
+- WCAG AA contrast on all text + interactive elements (I5 protects this).
+- Skip link → `#main-content` (I13).
+- Help bubbles keyboard-reachable + screen-reader-labeled (I14).
+- `:focus-visible` for focus rings — no sticky mouse outline (I21).
+- `prefers-reduced-motion` respected in CSS.
+- Toast notifications use `aria-live="polite"`.
+- Tab order strictness asserted in Playwright per drawer (v3.7.0 T7).
+
+---
+
+## 14. Known constraints & deliberate non-features
+
+- **No SaaS mode.** Self-host only.
+- **No user accounts.** Admin TOTP is operator-only; end users are anonymous.
+- **No persistent calculator history.** Shareable URLs cover this need.
+- **No telemetry.** No analytics. No phone-home.
+- **No background jobs / queues.** Every request is synchronous.
+- **No IPv4/IPv6 routing simulation.** Calculator only.
+
+---
+
+## 15. Forward-looking notes (not commitments)
+
+These are observed possibilities, not roadmap:
+
+- **v4.0.0** — `ul_bit_flipped` field rename (RFC 4193 wording correction). Deferred from v3.x because it's an API-shape change.
+- **API DX polish** — OpenAPI example consistency, `X-RateLimit-*` response headers, deprecation header pattern, API-key dashboard polish. Save for "v3.8.0 if API DX becomes the theme."
+- **Performance / Lighthouse** — separate future minor if signal warrants.
+- **Cloudflare Workers + KV port** — discussed 2026-05-13. Filed as curiosity, not roadmap. Traffic too low to justify the rewrite.
+- **v2.9.0 UI/UX style guide v2** — if visual debt accumulates beyond what per-release polish absorbs.
+
+---
+
+## 16. Where to look for what
+
+| Question | File(s) |
+|---|---|
+| "Why does this code look weird?" | This document §5, §6 |
+| "How do I add a new tool?" | §6.4 + look at any `_tools/<slug>.php` partial + matching `functions-*.php` + `handlers/<name>.php` + OpenAPI entry + Playwright group |
+| "Why does CI accept this?" | `.github/workflows/php.yml` + `phpstan.neon` + `.semgrep/rules.yml` |
+| "What changed in vX.Y.Z?" | `CHANGELOG.md` + Memory MCP entity `project:subnet-calculator:release:vX.Y.Z` |
+| "Why is this gate in the release checklist?" | §10.2 + §5 (invariants link to lessons learned) |
+| "What does this API endpoint accept?" | `api/openapi.yaml` |
+| "Where's the input validation?" | `request.php` (web) or `api/v1/handlers/<name>.php` (API) |
+| "How do production deploys work?" | §10.2 + `/release` skill + I8/I9 |
+
+---
+
+## 17. Update protocol for this document
+
+When you ship a release or make an architectural change:
+
+1. If a new invariant emerges, add a row to §5.
+2. If a design decision is made, add a subsection to §6.
+3. If a tool is added/removed, update §7 and §8.
+4. If a release-engineering rule changes, update §10.
+5. Bump the "Last updated" header.
+6. Commit with the related PR — don't let this doc drift from reality.
+
+Anything that future-you would have to rediscover by reading commits is fair game to record here.

--- a/docs/internal/design-guide.md
+++ b/docs/internal/design-guide.md
@@ -1,5 +1,6 @@
 # Design Guide
 
+**Last updated:** 2026-05-13 (app v3.7.0)
 **Audience:** Developer / future-agent making UX or visual decisions.
 **Companions:**
 - `docs/superpowers/style-guide.md` — visual identity (logo, colours, typography, spacing tokens). The source of truth for *what things look like*.
@@ -158,7 +159,7 @@ When a UX call isn't obvious:
 2. **Does this break a principle above?** → Reconsider. The principles are load-bearing; deviating costs more than the feature is worth.
 3. **Does the user actually need this on the calculator page?** → If no, it doesn't belong here. We don't have an admin panel for end-user features. The calculator is the page.
 4. **Will this make sense to someone landing cold via a shareable URL?** → If no, the shareability principle is broken.
-5. **What does `ui-ux-pro-max` say?** → For any non-trivial UI change, consult before AND after the edit. This is a release gate (see `design-document.md` §6.x).
+5. **What does `ui-ux-pro-max` say?** → For any non-trivial UI change, consult before AND after the edit. This is a release gate (see [`design-document.md`](design-document.md) §6.9 — the manual-regression mandate that introduced the consult pattern).
 
 ---
 

--- a/docs/internal/design-guide.md
+++ b/docs/internal/design-guide.md
@@ -1,0 +1,226 @@
+# Design Guide
+
+**Audience:** Developer / future-agent making UX or visual decisions.
+**Companions:**
+- `docs/superpowers/style-guide.md` — visual identity (logo, colours, typography, spacing tokens). The source of truth for *what things look like*.
+- `docs/superpowers/plans/2026-04-25-v2.9.0-ui-ux-style-guide.md` — detailed UI/UX style guide from v2.9.0. The source of truth for *which patterns to use*.
+
+**This document** captures the *design philosophy* — the principles that drive the visual + UX decisions. When the existing patterns don't cover a situation, this is what you reason from.
+
+---
+
+## Core principles
+
+### 1. The calculator is the page
+
+Everything else is a tool that augments calculator output. No drawer, tab, or modal should make the calculator harder to reach. If a new feature pushes the calculator below the fold on mobile, the feature is wrong.
+
+This drove:
+- The wall-of-buttons problem (v3.6.4) → 5 collapsible IPv6 tool groups (v3.7.0 T3).
+- The decision to keep tools as drawers rather than separate pages.
+- The "Copy All" + per-field copy convenience — read the calculator output, share it, stay on page.
+
+### 2. Zero install, zero JS dependency
+
+End users get a single PHP tarball. No build step. No SaaS account. No JS framework. `app.js` is 2845 lines of vanilla JS. The app must work with JS disabled for everything except clipboard, iframe resize, and tool-group `localStorage` persistence.
+
+Implication: every new feature must degrade gracefully when JS is off. Form submissions are HTML-form-first; JS enhances but never replaces.
+
+### 3. Shareability over persistence
+
+Users don't have accounts. There's no history, no saved workspaces, no "my calculations." Instead, every tool result is in a **shareable URL** — paste it, share it, bookmark it. The `sc_run_*` helpers in `request.php` make POST and GET produce identical state.
+
+Implication: any new tool with non-trivial input must support `?tool=<slug>&...` hydration. Don't add a tool that only works via POST — half its utility is gone.
+
+### 4. Operator self-host first
+
+The audience runs LAMP shared hosts. Drop-in tarball install on PHP 8.1+. No required external services. Cloudflare, Turnstile, etc. are all optional.
+
+Implication: don't add hard runtime deps. If a feature needs a JS library, it ships in `assets/vendor/` with SRI hashes. If it needs a PHP extension beyond GMP and pdo_sqlite, it's optional and degrades gracefully.
+
+### 5. Network engineers, not first-time users
+
+The audience already knows what a CIDR is. We don't explain it. We don't onboard. We expose dense controls with help bubbles for the genuinely ambiguous details (e.g., "what does the wildcard mask mean here?"). Every help-bubble click costs the user time; only add them where a knowledgeable engineer might still be uncertain.
+
+### 6. Density over whitespace
+
+Calculator result panels show 15+ fields at once. That's intentional. Network engineers scanning a result want everything in view, not a paginated wizard. Use the existing `.result-grid` density.
+
+### 7. Keyboard first, mouse second, touch third
+
+Mouse is the lowest-friction input for casual use but the slowest for power users. Every drawer trigger has `tabindex="0"` and responds to Enter. Every help bubble is keyboard-reachable. Tab order is asserted in Playwright per drawer (v3.7.0 T7).
+
+Touch users are real but rare for this audience — the mobile UX (v3.7.0 T4) is supportive, not primary.
+
+### 8. Don't surprise the user with hiding
+
+When the IPv6 wall-of-buttons UX problem (#420) was solved with collapsible groups, the call was: **all groups default-open on first visit, user-collapse state persists in `localStorage`**. Never default-hide content that was previously visible. The "look at all this!" → "where did everything go?" reaction is design failure.
+
+### 9. WCAG AA contrast is non-negotiable
+
+`--color-btn-text` stays dark on teal because white-on-teal fails AA (this is invariant I5). Any new colour pairing must hit AA contrast for normal text (4.5:1) and AA for non-text UI (3:1). Run the actual contrast check; don't eyeball it.
+
+### 10. Reduced motion is a real preference
+
+`prefers-reduced-motion` respected throughout. Drawer slide animations have reduced-motion equivalents. New animations must too.
+
+---
+
+## UX patterns to reuse (don't reinvent)
+
+### Drawers (tool entry points)
+
+- Markup convention: `<button data-tool="<slug>">` triggers; `<div class="drawer" data-tool="<slug>">` panels.
+- One file per drawer at `templates/_tools/<slug>.php` (post v3.7.0 T2 refactor).
+- Open: click or Enter. Close: Escape, click outside, or click trigger again.
+- Focus returns to the trigger on close (v3.7.0 T7).
+- Drawer panels use the result-grid pattern for output. They're not modal; the calculator above remains visible.
+
+### Forms
+
+- All forms are HTML-form-first. POST to `index.php` (web) or `/api/v1/<name>` (programmatic).
+- Validation server-side; JS-side is a UX hint only.
+- Errors render in a banner above the form. Don't pop modals.
+- CIDR auto-detect: both server-side (`strpos($input, '/')`) and client-side (JS `blur` event) — covers the Enter-without-blur case.
+
+### Result panels
+
+- Use `.result-grid` for label/value pairs.
+- Each field is independently copyable via a per-field copy button.
+- "Copy All" button on every tab — pre-formatted plain text.
+- "Copy as Markdown" and "Copy as Cisco" available for select tools (v2.11.0).
+
+### Help bubbles
+
+- Use `help_bubble($text)` from `functions-util.php`.
+- Auto-inherits `tabindex="0" role="button" aria-label="Help"`.
+- `:focus-within` CSS reveals the tooltip on keyboard focus — no JS needed.
+- Placement: immediately after the label, before the input. Right side of the line.
+
+### Shareable URLs
+
+- Use a `sc_run_*` helper in `request.php`. One helper handles both POST and GET hydration.
+- URL shape: `?tool=<slug>&<param>=<value>&<param>=<value>`.
+- Template renders identically for POST and GET. No duplicate code paths.
+
+### Toasts
+
+- For ephemeral feedback ("Copied!", "Session saved"). Not for errors.
+- `aria-live="polite"`. Auto-dismiss after 2 seconds.
+- Don't nest toasts; the latest replaces the previous.
+
+### Theme toggle
+
+- Light/dark via `html[data-theme="light"]`.
+- Persisted in `localStorage`.
+- Theme-init `<script>` runs in `<head>` before paint to avoid FOUC. **Don't move it.**
+- Print stylesheet redefines tokens for dark-mode printing (`@media print` block).
+
+---
+
+## What NOT to do
+
+### Don't add new tabs
+
+Four top-level tabs (IPv4, IPv6, VLSM, VLSM IPv6). The IPv6 surface is feature-complete per the original 4-release roadmap. New tools go into existing tabs as drawers, not new top-level tabs.
+
+### Don't add new design tokens
+
+Reuse the existing `--color-*`, spacing scale, and type scale. New tokens only land via a formal style-guide bump (and `--color-bg` cannot be renamed — invariant I4).
+
+### Don't add modal dialogs
+
+We use drawers and inline result panels. Modals trap focus, demand dismissal, and break the "calculator stays visible" principle. No modal has ever been justified yet.
+
+### Don't add onboarding / tooltips-on-first-visit
+
+The audience doesn't need a tour. If a feature is unintuitive, fix the feature, don't paper over it with a tour.
+
+### Don't add toast notifications for normal flow
+
+Toasts are for unexpected success (copied to clipboard, session saved). Don't toast on calculator submit — the result panel IS the feedback.
+
+### Don't reinvent visual patterns
+
+If you find yourself writing new card / panel / button CSS, stop. Read the existing `app.css`. The pattern probably exists; if it doesn't, propose adding it to the style guide before using it.
+
+### Don't add a JS framework
+
+Vanilla JS handles everything. The vendored SheetJS is the only third-party JS lib, and it's there because writing XLSX export from scratch isn't worth it. Anything beyond that requires a very high bar.
+
+---
+
+## Decision-making framework
+
+When a UX call isn't obvious:
+
+1. **Does an existing pattern cover this?** → Use it. Even if it's "good enough" — pattern consistency is worth more than local optimisation.
+2. **Does this break a principle above?** → Reconsider. The principles are load-bearing; deviating costs more than the feature is worth.
+3. **Does the user actually need this on the calculator page?** → If no, it doesn't belong here. We don't have an admin panel for end-user features. The calculator is the page.
+4. **Will this make sense to someone landing cold via a shareable URL?** → If no, the shareability principle is broken.
+5. **What does `ui-ux-pro-max` say?** → For any non-trivial UI change, consult before AND after the edit. This is a release gate (see `design-document.md` §6.x).
+
+---
+
+## Mobile-specific notes
+
+The mobile UX baseline (v3.7.0 T4):
+- 375px is the narrowest viewport we explicitly target.
+- 480px breakpoint flips the tab strip into a 2×2 grid.
+- 480px breakpoint switches `.card` to `overflow: clip` (containing the bottom-sheet drawer); desktop uses `overflow-x: clip` only (preserves tooltips escaping vertically).
+- Header h1 may wrap at <480px rather than truncate.
+- Drawer panels are bottom-sheet-style on mobile, side-drawer on desktop.
+
+These rules are in `app.css` and are part of invariant I6.
+
+---
+
+## Iframe consumers
+
+Subnet Calculator is embeddable. Consumers:
+
+- Auto-detected via `window.self !== window.top`, adding `in-iframe` to `<html>`.
+- Receive height updates via `postMessage` (via `ResizeObserver`).
+- Target origin uses `window.location.ancestorOrigins[0]` (Chrome/Edge) with `sessionStorage` fallback (Firefox). **Not** `document.referrer` — it breaks after same-origin form-submit navigations.
+- Can customise background via `?bg=…` query param or `postMessage`. This works by setting `--color-bg` on `documentElement.style`. **This token name is invariant I4.**
+- See `testing/fixtures/iframe-test.html` for the canonical consumer example.
+
+Don't break the iframe contract without a major version bump.
+
+---
+
+## Adding a new tool — design checklist
+
+Before writing code:
+
+- [ ] Which tab does it belong to? (Reuse, don't add.)
+- [ ] Which group within the IPv6 tab? (If IPv6, pick one of: foundational, address utilities, transition, prefix planning, multicast.)
+- [ ] What's the drawer trigger label? Short, clear, scannable.
+- [ ] What inputs does it need? (Validate the boundary; trust the function.)
+- [ ] What does the result panel look like? (Reuse `.result-grid`.)
+- [ ] Is the result panel copyable? Add copy button(s).
+- [ ] Does it need a shareable URL? (Default: yes.) Wire `sc_run_<name>` in `request.php`.
+- [ ] Does it have help bubbles where a network engineer might still be uncertain?
+- [ ] What's the API surface? Add to `api/openapi.yaml` + `api/v1/handlers/<name>.php`.
+- [ ] What's the Playwright assertion plan? (See `testing-guide.md`.)
+- [ ] Has `ui-ux-pro-max` reviewed the markup + CSS before push?
+
+If any of these are missing, the tool isn't done.
+
+---
+
+## Update protocol
+
+Update this guide when:
+1. A new principle emerges that wasn't documented.
+2. An anti-pattern is added or removed.
+3. The mobile baseline changes.
+4. The iframe contract changes.
+5. A new reusable UX pattern lands and should be standardised.
+
+Bump the "Last updated" header.
+
+Do **not** update this guide for:
+- Per-tool styling tweaks (visual style guide handles those).
+- Per-release content changes.
+- Bug fixes that don't change design intent.

--- a/docs/internal/runbooks.md
+++ b/docs/internal/runbooks.md
@@ -1,0 +1,183 @@
+# Production Runbooks
+
+**Audience:** Operator (Sean) + future-agent picking up an incident.
+**Scope:** Anything that can go wrong in production at https://subnetcalculator.app/ and how to triage it.
+**Update protocol:** Every incident adds (or amends) a runbook here. Capture the smell, the check, the fix. Drop runbooks that haven't applied in a year.
+
+Production targets:
+- **Origin:** OpenLiteSpeed at `root@192.168.80.23:/usr/local/lsws/vhosts/subnetcalculator.app/html/`
+- **CDN:** Cloudflare in front (zone purge required after deploys)
+
+---
+
+## Quick reference
+
+| Symptom | Jump to |
+|---|---|
+| Site returns 5xx | [R1](#r1--site-returning-5xx) |
+| Site returns old/stale content after deploy | [R2](#r2--stale-content-after-deploy) |
+| Service worker serving old shell | [R3](#r3--service-worker-serving-stale-shell) |
+| Smoke test fails immediately after `systemctl restart lsws` | [R4](#r4--first-smoke-test-fails-after-lsws-restart) |
+| `config.php` got overwritten by a deploy | [R5](#r5--operator-configphp-overwritten) |
+| API returns 401/403 unexpectedly | [R6](#r6--api-auth-failure-after-key-rotation) |
+| Rate-limit triggering on legitimate traffic | [R7](#r7--rate-limit-false-positive) |
+| Session DB locked / corrupt | [R8](#r8--sqlite-session-db-locked-or-corrupt) |
+| GMP missing on host | [R9](#r9--gmp-extension-missing) |
+| Cloudflare returning stale despite purge | [R10](#r10--cloudflare-stale-after-purge) |
+| Need to roll back a release | [R11](#r11--rollback-a-release) |
+
+---
+
+## R1 — Site returning 5xx
+
+1. SSH to origin: `ssh root@192.168.80.23`.
+2. Check OLS error log: `tail -n 200 /usr/local/lsws/logs/error.log`.
+3. Check PHP error log (path varies by vhost; typically next to OLS logs).
+4. Most common cause: PHP fatal from a missing extension (`gmp`, `pdo_sqlite`) — see R9.
+5. Second-most-common: file ownership wrong after rsync — `chown -R nobody:nogroup /usr/local/lsws/vhosts/subnetcalculator.app/html/`.
+6. Restart lsws after fix: `systemctl restart lsws && sleep 3`.
+7. Smoke test from local: `curl -sSI https://subnetcalculator.app/ | head -5`.
+
+If the fix isn't obvious in < 5 min, **roll back (R11)** then triage offline.
+
+---
+
+## R2 — Stale content after deploy
+
+1. Verify the deploy actually wrote files: `ssh root@192.168.80.23 'ls -lt /usr/local/lsws/vhosts/subnetcalculator.app/html/includes/config.php'` — mtime should be recent.
+2. Check `$app_version` in the deployed file matches the release: `ssh root@192.168.80.23 'grep app_version /usr/local/lsws/vhosts/subnetcalculator.app/html/includes/config.php'`.
+3. If file is fresh but version on the wire is old → OPcache holding stale bytecode. Run `systemctl restart lsws && sleep 3`.
+4. If origin shows new version but Cloudflare returns old → see R10.
+5. If browser still shows old after CF purge → service worker (R3).
+
+---
+
+## R3 — Service worker serving stale shell
+
+Symptom: user reports "I'm on version X.Y.Z" but the version pill in the footer disagrees with the actual release.
+
+1. Confirm `CACHE_NAME` in `Subnet-Calculator/sw.js` was bumped for this release. If not, ship a patch release that bumps it. (This is invariant I10. v3.2.2 shipped specifically to recover from this drift.)
+2. Tell affected users: hard refresh (`Cmd+Shift+R`) or DevTools → Application → Service Workers → Unregister.
+3. Long-term: never skip the `CACHE_NAME` bump. The `/release` skill handles it; if doing manually, it's step 2 of the release checklist.
+
+---
+
+## R4 — First smoke test fails after `lsws restart`
+
+Symptom: smoke test immediately after `systemctl restart lsws` returns pre-fix behaviour, but a retry 5 seconds later passes. (This was the v3.6.3 deploy bug.)
+
+**Root cause:** OPcache takes ~1–2 s to settle. The first request after restart can serve stale bytecode.
+
+**Fix:** Always `sleep 3` between `systemctl restart lsws` and the first smoke test. This is invariant I9 and lives in the `/release` skill.
+
+If you hit this in the wild after a deploy, just wait 3 seconds and re-test before assuming a real bug.
+
+---
+
+## R5 — Operator `config.php` overwritten
+
+Symptom: after deploy, operator overrides (custom `$turnstile_*` keys, `$canonical_url`, etc.) are gone.
+
+**Root cause:** unanchored rsync exclude. `--exclude='config.php'` matches both `Subnet-Calculator/config.php` (operator override — must preserve) AND `Subnet-Calculator/includes/config.php` (defaults — must ship). When unanchored, both get excluded; tarball install left a broken includes.
+
+**Recovery:**
+1. Restore operator `config.php` from the latest backup (`/opt/backups/...` per host policy).
+2. If no backup: copy `config.php.example` to `config.php` and re-enter operator settings from password manager.
+3. Verify `includes/config.php` shipped correctly: `grep app_version /usr/local/lsws/vhosts/subnetcalculator.app/html/includes/config.php`.
+
+**Prevention:** anchored excludes only — `--exclude='/config.php' --exclude='/data/'`. This is invariant I8.
+
+---
+
+## R6 — API auth failure after key rotation
+
+Symptom: API client reports 401 after a key was rotated in the admin console.
+
+1. Verify the key's status in admin: `https://subnetcalculator.app/admin/keys.php` (TOTP-gated).
+2. If the key was revoked: confirm with the operator that the revocation was intentional. Issue a new key if not.
+3. If the key is active but auth still fails: check `Authorization: Bearer <key>` header is exact (no whitespace, no quotes).
+4. Check `data/audit.sqlite` for `auth.fail` events: `sqlite3 data/audit.sqlite 'SELECT * FROM audit ORDER BY ts DESC LIMIT 20'`.
+
+---
+
+## R7 — Rate-limit false positive
+
+Symptom: legitimate user/automation hitting rate-limit (`429 Too Many Requests`).
+
+1. Check the rate-limit config in admin (`settings.php`) — confirm per-key limit matches intended use.
+2. Anonymous rate-limits are tighter than keyed; suggest the user provision an API key.
+3. If the limit is wrong for everyone, adjust in admin and document the change in `CHANGELOG.md` under the next release.
+4. **Do not disable rate-limiting** — it's a DoS control (invariant I19's neighbour).
+
+---
+
+## R8 — SQLite session DB locked or corrupt
+
+Symptom: shareable-URL feature returns 500; error log shows `database is locked` or `database disk image is malformed`.
+
+1. SSH to origin.
+2. Check disk space: `df -h /usr/local/lsws/vhosts/subnetcalculator.app/html/data/`. SQLite locks if disk is full.
+3. Check file perms: `ls -la data/*.sqlite` — must be writable by `nobody`.
+4. If locked but no other process: stop lsws, remove `*.sqlite-journal` / `*.sqlite-wal` files, restart.
+5. If corrupt: sessions are non-critical user data (shareable URLs only). Move the corrupt DB aside, let the app re-create on next request. Notify users that old shareable links are gone.
+6. **Admin and API-key DBs are critical** — restore from backup, do not wipe.
+
+---
+
+## R9 — GMP extension missing
+
+Symptom: PHP fatal on any IPv6 calculation: `Call to undefined function gmp_init()`.
+
+1. `ssh root@192.168.80.23 'php -m | grep -i gmp'` — empty means missing.
+2. Install: `apt-get install -y php8.x-gmp` (match host PHP version) or distro equivalent.
+3. Restart lsws: `systemctl restart lsws && sleep 3`.
+4. Smoke test: `curl -s 'https://subnetcalculator.app/api/v1/ipv6' -d 'address=2001:db8::1&prefix=64'`.
+
+GMP is a hard dependency (invariant I2). The dev-server session-start hook auto-installs it; production is operator-managed.
+
+---
+
+## R10 — Cloudflare stale after purge
+
+Symptom: ran zone purge but old content still served.
+
+1. Confirm purge happened: Cloudflare dashboard → Caching → Configuration → Purge log.
+2. Check from a different network (mobile hotspot) — local DNS / ISP cache could be at play.
+3. Cloudflare edge propagation takes up to 30 s in practice. Wait, retest.
+4. If still stale after 60 s: hit the origin directly to confirm it's fresh: `curl -sI -H 'Host: subnetcalculator.app' https://192.168.80.23/`. If origin is fresh and CF is stale, open a CF support ticket.
+5. Last resort: bump the CSS/JS asset filenames (forces re-fetch). Don't habit-form this — fix CF properly.
+
+---
+
+## R11 — Rollback a release
+
+Pre-conditions: previous release tarball exists in `releases/`.
+
+1. Identify the last known-good release: `ls -t releases/ | head -5`.
+2. SSH to origin: `ssh root@192.168.80.23`.
+3. Extract the previous tarball over the docroot (anchored excludes preserve operator config):
+   ```bash
+   cd /usr/local/lsws/vhosts/subnetcalculator.app/html/
+   tar -xzf /path/to/subnet-calculator-X.Y.Z.tar.gz \
+       --exclude='./config.php' --exclude='./data/'
+   chown -R nobody:nogroup .
+   ```
+4. `systemctl restart lsws && sleep 3`.
+5. Smoke test (curl version pill).
+6. Purge Cloudflare.
+7. **File a regression issue** describing what shipped wrong and link to the post-mortem.
+8. Optionally: tag a `vX.Y.Z+rollback` annotation on the git tag for visibility.
+
+Do not delete the broken release tarball — keep it for forensics.
+
+---
+
+## Post-incident checklist
+
+After resolving any incident:
+
+1. Capture the timeline + root cause in a one-paragraph Memory MCP observation under the relevant release entity.
+2. If a new failure mode emerged, add a runbook section here.
+3. If a new invariant emerged, add a row to `design-document.md` §5.
+4. If the fix is a code change, follow the normal release process (don't hot-patch production).
+5. If the fix is a process change (e.g., the `sleep 3` rule), update both the `/release` skill and this runbook.

--- a/docs/internal/security-model.md
+++ b/docs/internal/security-model.md
@@ -1,5 +1,6 @@
 # Security Model
 
+**Last updated:** 2026-05-13 (app v3.7.0)
 **Audience:** Developer / future-agent reasoning about threats or reviewing security-sensitive changes.
 **Companion to:** `design-document.md` §11 (controls inventory).
 **Premise:** This document explains *what* we defend against and *why* — the controls in §11 explain *how*. Both must move together.

--- a/docs/internal/security-model.md
+++ b/docs/internal/security-model.md
@@ -1,0 +1,175 @@
+# Security Model
+
+**Audience:** Developer / future-agent reasoning about threats or reviewing security-sensitive changes.
+**Companion to:** `design-document.md` §11 (controls inventory).
+**Premise:** This document explains *what* we defend against and *why* — the controls in §11 explain *how*. Both must move together.
+
+---
+
+## Trust boundaries
+
+```mermaid
+flowchart LR
+    User["Internet user<br/>(untrusted)"]
+    CF["Cloudflare edge<br/>(semi-trusted infra)"]
+    OLS["Origin: OpenLiteSpeed<br/>(operator-controlled)"]
+    PHP["PHP app<br/>(operator-controlled)"]
+    SQLite[("SQLite DBs<br/>(operator-controlled)")]
+    Admin["Admin operator<br/>(trusted)"]
+
+    User -- HTTPS --> CF
+    CF -- HTTPS --> OLS
+    OLS --> PHP
+    PHP --> SQLite
+    Admin -- TOTP login --> PHP
+```
+
+Every arrow is a trust boundary. Input crossing right-to-left is sanitised; input crossing left-to-right is validated.
+
+**Implication:** the boundary the app most defends is the User → PHP path. The operator → PHP path is trusted (operator has shell on the box already; defending against them is theatre).
+
+---
+
+## Threat model (what we defend against)
+
+| # | Threat | Vector | Control | Residual risk |
+|---|---|---|---|---|
+| T1 | XSS — reflected | Calculator inputs echoed into result panels | `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` on every echo; CSP with per-request nonce blocks unnonced inline | Low. CSP defence-in-depth. |
+| T2 | XSS — stored | Operator session note, API key label | Same as T1 + admin is single-operator, so attacker would need TOTP first | Negligible |
+| T3 | CSRF | Form submissions to `request.php` | Honeypot field + optional Turnstile; SameSite=Lax cookies; admin actions require TOTP-verified session | Low (calculator forms are idempotent; admin is hard-gated) |
+| T4 | SQL injection | User-supplied input reaching SQLite | All queries parameterised PDO; no user-controlled table/column names anywhere | Negligible |
+| T5 | Command injection | Inputs reaching `shell_exec`/`system` | App never executes shell commands at runtime | Negligible |
+| T6 | Path traversal | Input mapping to filesystem paths | App never opens files based on user input (templates/includes are static `require` paths) | Negligible |
+| T7 | DoS — splitter explosion | `?ip=10.0.0.0/8&new_prefix=32` requests 16M subnets | `$split_max_subnets` cap (default 1024); enforced in `functions-split.php` | Low |
+| T8 | DoS — VLSM list bomb | Submit a 100K-entry requirements list | Bounded by input parsing; PHP `memory_limit` is the last-resort cap | Medium. Consider explicit list-length cap in v3.8.0. |
+| T9 | DoS — PMTU payload bomb | `payload_size=2^31`, `fragment_count=…` | Hard caps: `payload_size ≤ 65535`, `fragment_count ≤ 4096` (invariant I19, added v3.6.3 after smoke test caught 39.6 MB response) | Negligible |
+| T10 | DoS — anonymous flood | Burst requests | Per-IP rate limit on anonymous; per-key limit on API users | Low. Cloudflare absorbs volumetric. |
+| T11 | IDOR — session leak | Guess another user's shareable-session URL | 16-hex-char random IDs (96 bits — invariant I20, widened from 8 chars in v3.6.4); sessions are write-once read-many | Low |
+| T12 | API key theft | Exfiltrate a Bearer token | Keys stored hashed (Argon2id); never logged; rotation via admin console; per-key audit log | Medium (no expiry-by-default; consider in v3.8.0 API DX work) |
+| T13 | Admin compromise | Operator credential theft | TOTP required (no password-only); login rate-limited; audit log for every admin action | Low (relies on operator hygiene) |
+| T14 | Iframe clickjacking | Embed app in malicious frame | `X-Frame-Options: SAMEORIGIN`; iframe consumers use same-origin embedding | Negligible |
+| T15 | MITM | Network attacker intercepting traffic | HSTS with preload; Cloudflare TLS termination + origin TLS | Negligible (modern TLS) |
+| T16 | Supply chain — vendor JS | Compromised SheetJS in `assets/vendor/xlsx/` | SRI-verified `<script>` tag; defer-loaded; SheetJS pinned to 0.20.3 | Low. Audit on every SheetJS bump. |
+| T17 | Supply chain — composer deps | Compromised PHPUnit / PHPStan / etc. | Dev-only deps (`composer.json` `require-dev`); never run in production; lockfile committed | Negligible |
+| T18 | Supply chain — PHP itself | Compromised PHP runtime | Operator-managed; outside app boundary | Accepted. Operator patches. |
+| T19 | SSRF | Force the app to fetch attacker-chosen URLs | App's only outbound network call is Turnstile verify (fixed hostname) and DNS resolution for `resolve_ipv4_input` / `resolve_ipv6_input` (limited to PHP's `dns_get_record` against the operator's resolver) | Low |
+| T20 | Information disclosure — error messages | Stack traces leaking paths/config | `display_errors=0` in production; PHP error log is operator-only | Negligible |
+| T21 | Information disclosure — direct file access | Fetch `includes/config.php` or `data/*.sqlite` over HTTP | `.htaccess` blocks at every level (includes, templates, api/v1/helpers.php, data); separate test in Playwright suite | Negligible |
+
+---
+
+## What we explicitly do *not* defend against
+
+These are out of scope, on purpose. Future work that changes the boundary should re-evaluate.
+
+| # | Non-threat | Why |
+|---|---|---|
+| N1 | Operator with shell access | Operator owns the box. Defending here is theatre. |
+| N2 | Malicious tarball install | The tarball IS the operator's chosen artifact. If untrusted, the operator already lost. |
+| N3 | Subnet calculation results being "leaked" | Calculator output is deterministic from inputs. There's no secret to leak. |
+| N4 | Persistent user identity | We have no user accounts. There's nothing to defend. |
+| N5 | Audit log tamper-evidence | Operator owns the audit DB. Goal is operational forensics, not non-repudiation. Cryptographic logging is out of scope. |
+| N6 | Side-channel timing on TOTP verification | Library handles constant-time comparison; we don't second-guess it. |
+| N7 | DoS protection against a determined attacker | That's Cloudflare's job. App-layer caps are for accidents, not adversaries. |
+
+---
+
+## Authentication & authorisation
+
+### Anonymous users
+- Default surface. All calculator routes and most API endpoints.
+- Rate-limited by source IP.
+- No persistent state except the optional shareable session (write-once-read-many, 16-hex-char ID).
+
+### API key users
+- `Authorization: Bearer <key>` header.
+- Keys are issued via the admin console (`/admin/keys.php`).
+- Per-key rate limit (configurable, default higher than anonymous).
+- Per-key audit log.
+- **No expiry by default** — known gap, candidate for v3.8.0.
+
+### Admin
+- TOTP-required login. No password-only mode.
+- Login rate-limited (5 failures → 15 min cooldown per IP).
+- Cookie-based session in `data/admin-sessions.sqlite`; 24-hour idle timeout.
+- Every admin action writes an `audit.action` row to `data/audit.sqlite`.
+
+### Authorisation model
+- **Two principals only:** anonymous and operator. No multi-tenant, no role hierarchy.
+- API key inherits anonymous permissions but with a relaxed rate limit. Keys cannot perform admin actions.
+
+---
+
+## Cryptographic choices
+
+| Use | Algorithm | Library |
+|---|---|---|
+| TOTP | RFC 6238 (HMAC-SHA1, 30s step) | Built-in (`hash_hmac`) per RFC implementation in `functions-admin-totp.php` |
+| API key hashing | Argon2id | `password_hash(..., PASSWORD_ARGON2ID)` |
+| Session ID generation | CSPRNG | `random_bytes(8)` → `bin2hex()` → 16-char hex |
+| ULA prefix generation (user-facing tool) | SHA-1 per RFC 4193 | Built-in (`sha1`) — RFC mandates SHA-1 here; not a security boundary |
+| SLAAC RFC 7217 stable interface IDs | F() = SHA-256 | `hash('sha256', ...)` |
+| TLS | Operator + Cloudflare | Not app's concern |
+
+No homegrown crypto. No custom XOR shenanigans. If you need a new primitive, propose adding a vetted library (libsodium is built into PHP 7.2+; use that before anything else).
+
+---
+
+## Input validation
+
+All caller-controlled input is validated at the boundary (`request.php` for web, the handler file for API):
+- Length-bounded.
+- Pattern-matched where appropriate (`filter_var(FILTER_VALIDATE_IP, ...)`, regex for CIDR, etc.).
+- Rejected with `InvalidArgumentException` (web → error banner; API → `json_err(400, ...)`).
+
+Pure functions trust their inputs (per the methodology in `design-document.md` §4.5). This is deliberate — double-validation drift was a real bug source in earlier versions.
+
+---
+
+## Headers (set by `index.php`)
+
+See `design-document.md` §11.1 for the inventory. The justification for each:
+
+- **CSP with per-request nonce** — blocks the broadest class of XSS payloads even if a future `htmlspecialchars()` slip occurs. Nonce per request prevents replay.
+- **HSTS with preload** — eliminates SSL-stripping; preload list ensures first-visit safety.
+- **`X-Content-Type-Options: nosniff`** — prevents MIME confusion attacks on user-uploaded content (none here, but defence-in-depth).
+- **`X-Frame-Options: SAMEORIGIN`** — clickjacking. (We allow same-origin iframe consumers; CSP `frame-ancestors` could replace this in a future cleanup.)
+- **`Referrer-Policy: strict-origin-when-cross-origin`** — minimises shareable-URL leakage to third-party trackers.
+- **`Permissions-Policy`** — deny-all for camera/mic/geolocation/payment/USB. We don't need any of them.
+
+---
+
+## Incident response
+
+See `runbooks.md`. Specifically:
+- R6 for API auth failures.
+- R7 for rate-limit triage (don't disable; tune).
+- R8 for SQLite session issues (sessions are non-critical; admin DB is critical).
+
+If a vulnerability is reported: triage with `SECURITY.md` process. If actively exploited, ship a patch release within 24 hours; if not actively exploited, fold into the next scheduled minor.
+
+---
+
+## Audit & review cadence
+
+| Activity | Cadence |
+|---|---|
+| Semgrep + OWASP rule scan | Every PR (CI gate) |
+| Dependency review (composer audit, npm audit) | Monthly + on Dependabot PRs |
+| Manual security review of new endpoints | At PR review time |
+| Broader application security review | Once per major release theme |
+| Threat-model refresh (this document) | Every major release or whenever the trust boundary changes |
+| Cryptographic primitive review | Annually or when CVEs land |
+
+---
+
+## When this model is wrong
+
+Update protocol:
+1. New threat emerges → add a row to the threat table with control and residual risk.
+2. New non-threat justified → add a row to the non-threats table with the reasoning.
+3. Boundary moves (e.g., we add a queue worker → trust diagram changes) → update the Mermaid diagram first, then re-walk the threat table.
+4. Cryptographic choice changes → update the table + cite the RFC/library/CVE that motivated the change.
+5. Bump the "Last updated" header at the top.
+
+If you're unsure whether something is a real threat, file it as one with a "Negligible" residual rating until proven otherwise. Better to over-document and trim than under-document and miss.

--- a/docs/internal/testing-guide.md
+++ b/docs/internal/testing-guide.md
@@ -1,0 +1,189 @@
+# Testing Guide
+
+**Audience:** Developer / future-agent adding code to this project.
+**Companion to:** `design-document.md` §9 (testing topology).
+**Premise:** CI is necessary but not sufficient. Manual regression is mandatory on every release (v3.6.2 lesson).
+
+---
+
+## The five layers
+
+| Layer | Tool | Speed | When to add |
+|---|---|---|---|
+| Unit | PHPUnit 11 | ~1 s | Every new pure function in `includes/functions-*.php` |
+| Static | PHPStan L9 / PHPCS / Semgrep | ~5–10 s | Automatic on every PHP edit (PostToolUse hook) |
+| API | PHPUnit + curl from Playwright | ~30 s | Every new API endpoint or response-shape change |
+| E2E | Playwright (Docker) | ~3–5 min | Every new UI surface or user-visible behaviour change |
+| Visual | Pillow snapshots | ~30 s on opt-in | Every CSS change that affects layout or colour |
+| **Manual** | **You + Playwright + `ui-ux-pro-max`** | **15–30 min** | **Every release. No exceptions.** |
+
+---
+
+## When to add what
+
+### Adding a new pure function
+
+→ **Unit test required.** Test happy path + every documented error case + IPv4/IPv6 edge values (0.0.0.0, 255.255.255.255, ::, ffff:…, /0, /32, /128).
+
+For IPv4: also test values that trigger sign-bit (anything ≥ 128.0.0.0 / `0x80000000`). The `& 0xFFFFFFFF` mask is the load-bearing detail — if a test passes only with values < 128.0.0.0, it's not really testing the bitwise correctness.
+
+For IPv6: test values requiring GMP (≥ 2^63 host count), and values that triggered the `"2^N"` string convention.
+
+### Adding a new API endpoint
+
+→ **Unit test the handler's pure function, then Playwright covers the HTTP surface.**
+
+The Playwright test pattern:
+```python
+def test_new_endpoint(page):
+    resp = page.request.post(f"{BASE}/api/v1/<name>", data={"input": "..."})
+    assert resp.status == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["data"]["expected_field"] == "expected_value"
+```
+
+Cover: happy path, 400 on bad input, 405 on wrong method, auth-required endpoints with and without a key.
+
+Also update `api/openapi.yaml` — Spectral lint will fail CI if the new endpoint isn't documented.
+
+### Adding a new tool drawer
+
+→ **Both unit + Playwright.** The unit test covers the pure function; the Playwright test covers:
+1. Trigger button exists and is keyboard-focusable.
+2. Drawer opens on click + on Enter.
+3. Drawer closes on Escape + on outside click.
+4. Form submission produces the expected output cell.
+5. Shareable URL hydration works (`?tool=<slug>&...` reproduces the result).
+6. Focus returns to the trigger button on close (v3.7.0 T7).
+7. Tab order through the drawer is sensible.
+8. Help-bubble tooltips reveal on keyboard focus.
+
+### Adding a CSS rule
+
+→ **Visual snapshot test.** Snapshots live in `testing/snapshots/`. Run `SKIP_SNAPSHOTS=1 make test-docker` for normal runs; do an explicit snapshot capture run when intentionally changing visuals. Review the diff before committing the new baseline.
+
+### Adding form-protection logic / auth / rate-limiting
+
+→ **Semgrep custom rule** in `.semgrep/rules.yml` if the pattern is repeatable, plus Playwright covering both the positive (legitimate request succeeds) and negative (attack/abuse blocked) paths.
+
+---
+
+## Running tests locally
+
+```bash
+# Unit tests (fast — run constantly)
+vendor/bin/phpunit
+
+# A single unit test file
+vendor/bin/phpunit testing/unit/Vlsm6Test.php
+
+# Static analysis
+phpstan analyse --no-progress --memory-limit=512M
+
+# Linters (PHP)
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+vendor/bin/phpcs --standard=.phpcs-admin.xml Subnet-Calculator/admin/
+
+# Linters (JS/CSS)
+npm run lint
+
+# OpenAPI
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+
+# Security
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten \
+        --config p/sql-injection --error \
+        Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+
+# E2E via Docker (preferred — no dev server needed; SKIP_SNAPSHOTS=1 is set automatically)
+make test-docker
+```
+
+Run all of these green before pushing any PR.
+
+---
+
+## Manual production regression (mandatory per release)
+
+This is the gate that catches what CI doesn't. The v3.6.2 `cidrs_overlap` bug shipped for 5+ months because every existing test used `10.0.0.0/X` pairs where the broken `max()` masking coincidentally produced correct results.
+
+**Why coverage alone fails here:** structural CI catches bugs the test set anticipates. The blind spot is the test set's own bias. Manual regression with a human + an LLM consultant looking at real production explores spaces no automated test was written for.
+
+### Pattern
+
+1. Spin up a Playwright session against **production** (https://subnetcalculator.app/).
+2. **Single agent, fetch-only, tightly scoped.** Don't parallelise — the first attempt at parallel browser-screenshot agents locked up Playwright for 2+ hours.
+3. Hit every endpoint with diverse inputs (not just `10.0.0.0/24`). Use `192.168.1.0/24`, `172.16.5.0/28`, `203.0.113.128/29`, etc. — any time the inputs all share a prefix base, you're vulnerable to the v3.6.2 class of bug.
+4. For UI: invoke `ui-ux-pro-max` to inspect each tab + every drawer. Note any visual or interaction issue, even if minor.
+5. File findings as GitHub issues with milestone-appropriate labels.
+
+### What to test every release
+
+- Calculator (IPv4, IPv6) at /24, /16, /30, /32, /128, /48, /0.
+- Every drawer tool with at least one non-default input.
+- Shareable URL on every supporting tool.
+- API: `GET /api/v1/meta` returns the new version. Then a handful of POST endpoints with diverse inputs.
+- Security headers: HSTS present, CSP nonce changes per request.
+- Service worker: footer version pill matches `$app_version`.
+- Theme toggle works without FOUC.
+- iframe consumer (`testing/fixtures/iframe-test.html` deployed to dev) still functional.
+
+If anything looks wrong, **don't ship the release**. File the bug, ship a patch first.
+
+---
+
+## Snapshot workflow
+
+Visual regression baselines live in `testing/snapshots/` as committed PNGs.
+
+```bash
+# Normal run: snapshots skipped (docker test harness sets SKIP_SNAPSHOTS=1)
+make test-docker
+
+# Capture/update snapshots: run via dev server flow with snapshots enabled
+# (See playwright_test.py for the exact env wiring.)
+```
+
+When intentionally changing visuals:
+1. Run the snapshot capture mode.
+2. Review the diff visually — *don't blindly accept*. A failing snapshot can mean intended change or unintended regression. You must look.
+3. Commit the new baseline with the same PR as the CSS change.
+
+---
+
+## Anti-patterns (don't do these)
+
+- **Tests that assert on `htmlspecialchars()` output character-by-character.** Brittle. Assert on the visible text or the rendered DOM structure.
+- **Tests that hardcode an entire JSON response.** Use specific field assertions so the test survives benign envelope changes.
+- **Skipping tests for "experimental" code.** Either the code ships or it doesn't. Experimental code that's running on production needs the same coverage.
+- **One test per HTTP status code.** Test the *behaviour*, not the status code. The status code is one assertion among several.
+- **Mocking pure functions.** They're pure — call them directly.
+- **`@dataProvider` exploding into thousands of micro-cases without testing the boundaries.** Five well-chosen boundary cases beat 5000 random cases.
+
+---
+
+## CI configuration
+
+`.github/workflows/php.yml` — 3-version PHP matrix (8.2, 8.3, 8.4) running:
+- PHPUnit (`--testdox` for readable output)
+- PHPStan L9 (`--memory-limit=512M`)
+- PHPCS PSR-12 (includes + api) + admin ruleset
+- Spectral on `openapi.yaml`
+
+On every PR and push to `main`/`dev`/`release/*`.
+
+`.github/workflows/docs.yml` — MkDocs build + GitHub Pages deploy on push to `main`.
+
+CodeRabbit posts reviews on every PR. Treat actionable findings as required fixes; nitpicks may be deferred only with explicit operator approval.
+
+---
+
+## Adding a new test layer
+
+Don't, casually. The layers above represent five years of learning what catches bugs cheaply. New layers (e.g., property-based testing, fuzzing) are worth considering only when:
+1. An incident occurs that *no existing layer would have caught*.
+2. The new layer is genuinely orthogonal (not a slow re-run of an existing one).
+3. The maintenance cost is bounded (the layer itself doesn't become tech debt).
+
+If you do add a layer, update this guide and `design-document.md` §9 in the same PR.


### PR DESCRIPTION
## Summary

- Create eight long-lived internal docs under `docs/internal/` (design-document, design-guide, coding-guide, testing-guide, security-model, api-contract, data-dictionary, config-reference, runbooks) plus an index README — captures the "why" behind every load-bearing choice so future sessions don't have to re-derive it from git archaeology.
- Trim `CLAUDE.md` from 222 → ~80 lines: remove stale facts (wrong test counts, duplicate file listings, drifted release checklist), replace with routing pointers to the new docs. Keep 7 hot invariants agents must hold in working memory; full 22-invariant table moves to `design-document.md` §5.
- Wire the docs into the maintenance loop: release checklist step 15 + `/release` skill step 8 sync internal docs per release; `coding-guide.md` gates PRs touching schema/config on updating `data-dictionary.md` / `config-reference.md` in the same PR. Branching, QA-gate commands, and release checklist consolidated to single sources of truth; other docs point in.

## What's in each doc

- `design-document.md` — architecture, 22 invariants table, design decisions w/ lessons learned (v3.5.0 deploy bug, v3.6.2 cidrs_overlap, v3.6.3 OPcache race), branching model, release checklist, feature catalogue, API surface, testing topology, security posture, accessibility commitments
- `design-guide.md` — 10 UX principles, patterns to reuse, what NOT to do, mobile + iframe notes, new-tool design checklist
- `coding-guide.md` — PHP/JS/CSS conventions, strict typing, IPv4/IPv6 arithmetic discipline, validation at the boundary, output escaping, schema + config update gates
- `testing-guide.md` — five test layers, when to add what, manual production regression mandate (v3.6.2 lesson), snapshot workflow, anti-patterns
- `security-model.md` — trust diagram (mermaid), 21 threats with controls + residual risk, 7 explicit non-threats with rationale, authn/authz, cryptographic choices, audit cadence
- `api-contract.md` — versioning, breaking-change taxonomy, response envelope, stable error codes, deprecation policy (RFC 8594)
- `data-dictionary.md` — all 7 SQLite tables enumerated (sessions, api_keys, admin_audit, admin_sessions, auth_rate_limit, admin_recovery_codes, admin_state) + migration policy + history
- `config-reference.md` — ~35 operator variables grouped into 9 categories + two override-pattern templates
- `runbooks.md` — 11 production-incident playbooks with quick-reference symptom→runbook map

## Test plan

- [x] Verified the chore branch landed on GitHub (commit 925eec1)
- [x] All internal cross-references use relative markdown links and resolve
- [x] CLAUDE.md routing table covers every doc in `docs/internal/`
- [x] No commands duplicated between `CLAUDE.md` and `testing-guide.md` (single source)
- [x] No branching info duplicated outside `design-document.md` §10.1 (single source)
- [x] `/release` skill + `design-document.md` §10.2 step 15 both enumerate the same internal docs to sync per release
- [ ] CI green (PHP matrix, docs build) — this PR touches docs only; CI should pass trivially
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive internal docs covering system design, API contract, coding standards, config reference, data dictionary, testing guide, security model, and runbooks.
  * Rewrote the agent quick-reference to point to internal docs and condensed developer guidance.
  * Release checklist updated to require an internal-docs sync and “last updated” header bumps when appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Subnet-Calculator/pull/435)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->