### PR TITLE
chore(docs): archive missed v2.x implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-04-23-documentation-improvements.md
+++ b/docs/superpowers/plans/2026-04-23-documentation-improvements.md
@@ -1,0 +1,1085 @@
+# Documentation Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all factual errors, stale content, and missing documentation across README, CHANGELOG, CONTRIBUTING, SECURITY, docs/ MkDocs site, and openapi.yaml so every doc is accurate, internally consistent, and reflects the current v2.8.1 state of the app.
+
+**Architecture:** Documentation-only changes — no PHP, JS, or CSS is touched. Each task targets one logical doc unit and ends with a commit. Tasks 1–4 fix factual errors that would break user code or mislead integrators; later tasks fill feature gaps and update stale UX descriptions.
+
+**Tech Stack:** Markdown (docs/), YAML (openapi.yaml), Bash (grep verification). No build step required — MkDocs site is deployed by GitHub Actions on push to `main`.
+
+---
+
+## Files touched
+
+| File | Change summary |
+|---|---|
+| `docs/sharing.md` | Fix `sc-height` → `sc-resize`; add `sc-set-bg` section; add `$show_share_bar` note |
+| `docs/ipv4.md` | Fix `$split_max_subnets` default 256 → 16 |
+| `docs/rdns.md` | Fix TTL example 3600 → 86400; add IPv6 `/112` minimum; add `ns`/`hostmaster`/`serial`/`domain` params |
+| `docs/binary.md` | Fix hex format `c0a80100` → `C0.A8.01.00` |
+| `docs/api.md` | Fix bulk limit 20 → 50; add `POST /api/v1/sessions` section; add error response note |
+| `docs/overlap.md` | Update UI location to Tool Drawer; add API cross-reference |
+| `docs/supernet.md` | Update UI location to Tool Drawer; add API cross-reference |
+| `docs/ula.md` | Update UI location to Tool Drawer; add `available_64s` mention; add API cross-reference |
+| `docs/sessions.md` | Update UI location to Tool Drawer; add `POST /api/v1/sessions` mention |
+| `docs/index.md` | Fix tarball version 2.6.0 → 2.8.1; add `intl` to requirements; add PHP client mention |
+| `docs/client.md` | **Create** — PHP client library documentation page |
+| `docs/mkdocs.yml` | Add `PHP Client Library` nav entry pointing to `client.md` |
+| `Subnet-Calculator/api/openapi.yaml` | Fix license MIT → AGPL-3.0; fix version "1" → "1.0"; update meta example to include `sessions`/`changelog` |
+| `SECURITY.md` | Update supported versions table to current v2.8.x |
+| `README.md` | Fix tarball extract example 2.7.0 → 2.8.1; add missing API endpoints to table; add `$api_request_log`/`$api_request_log_db_path` to config table; add Docker deployment; add PHP client library; add Service Worker/offline note; add v2.8.0 Tool Drawer mention |
+| `CONTRIBUTING.md` | Add `make test-docker` as canonical test gate; add visual regression workflow; fix Playwright count (85 groups/517 → 91 groups/561); add `clients/php/` to project structure; add Semgrep and Spectral to tooling |
+| `CHANGELOG.md` | Add missing `## [0.7]` entry between v0.6 and v0.8 |
+
+---
+
+## Task 1 — Fix `sc-height` → `sc-resize` in sharing.md (critical functional error)
+
+A developer copying the iframe auto-sizing snippet from `docs/sharing.md` will get code that never fires because the app emits `sc-resize` not `sc-height`. This is confirmed in `Subnet-Calculator/assets/app.js` line 415.
+
+**Files:**
+- Modify: `docs/sharing.md:38`
+
+- [ ] **Step 1: Verify the wrong value is present**
+
+```bash
+grep -n "sc-height\|sc-resize" docs/sharing.md
+```
+
+Expected output:
+```
+38:  if (e.data && e.data.type === 'sc-height') {
+```
+
+- [ ] **Step 2: Apply the fix**
+
+In `docs/sharing.md`, replace line 38:
+
+Old:
+```
+  if (e.data && e.data.type === 'sc-height') {
+```
+
+New:
+```
+  if (e.data && e.data.type === 'sc-resize') {
+```
+
+- [ ] **Step 3: Verify the fix**
+
+```bash
+grep -n "sc-height\|sc-resize" docs/sharing.md
+```
+
+Expected output:
+```
+38:  if (e.data && e.data.type === 'sc-resize') {
+```
+
+No `sc-height` references should remain.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/sharing.md
+git commit -m "docs: fix postMessage event type sc-height → sc-resize in sharing.md"
+```
+
+---
+
+## Task 2 — Fix factual errors in ipv4.md, rdns.md, binary.md
+
+Three single-line factual errors across three docs pages. Grouped into one task because they are quick, independent, and a single commit is appropriate.
+
+**Files:**
+- Modify: `docs/ipv4.md:39`
+- Modify: `docs/rdns.md` (TTL example)
+- Modify: `docs/binary.md:9`
+
+- [ ] **Step 1: Verify all three wrong values**
+
+```bash
+grep -n "split_max_subnets\|256" docs/ipv4.md
+grep -n "3600" docs/rdns.md
+grep -n "c0a80100\|hex string" docs/binary.md
+```
+
+Expected:
+```
+39:The maximum number of subnets returned is set by `$split_max_subnets` in `config.php` (default 256).
+...
+39:    "ttl": 3600,
+...
+9:- **Hex** — network address as a 0-padded 8-character hex string (e.g. `c0a80100` for `192.168.1.0`).
+```
+
+- [ ] **Step 2: Fix ipv4.md — split_max_subnets default**
+
+In `docs/ipv4.md` line 39, replace:
+```
+The maximum number of subnets returned is set by `$split_max_subnets` in `config.php` (default 256).
+```
+With:
+```
+The maximum number of subnets returned is set by `$split_max_subnets` in `config.php` (default 16).
+```
+
+- [ ] **Step 3: Fix rdns.md — TTL in example response**
+
+In `docs/rdns.md`, find the JSON example block containing `"ttl": 3600` and replace `3600` with `86400`.
+
+The block looks like:
+```json
+    "ttl": 3600,
+```
+Change to:
+```json
+    "ttl": 86400,
+```
+
+- [ ] **Step 4: Fix binary.md — IPv4 hex notation**
+
+In `docs/binary.md` line 9, replace:
+```
+- **Hex** — network address as a 0-padded 8-character hex string (e.g. `c0a80100` for `192.168.1.0`).
+```
+With:
+```
+- **Hex** — network address in dotted-hex notation (e.g. `C0.A8.01.00` for `192.168.1.0`).
+```
+
+- [ ] **Step 5: Verify all three fixes**
+
+```bash
+grep -n "split_max_subnets" docs/ipv4.md
+grep -n "ttl" docs/rdns.md
+grep -n "hex\|Hex" docs/binary.md | head -5
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/ipv4.md docs/rdns.md docs/binary.md
+git commit -m "docs: fix split_max_subnets default, rdns TTL, and binary hex format"
+```
+
+---
+
+## Task 3 — Fix docs/api.md: bulk limit and missing POST /sessions
+
+`docs/api.md` says bulk accepts "up to 20" requests but the openapi.yaml spec and README both say 50. The `POST /api/v1/sessions` endpoint is fully documented in openapi.yaml but absent from the API docs.
+
+**Files:**
+- Modify: `docs/api.md:162` (bulk limit)
+- Modify: `docs/api.md:169` (insert POST /sessions section before GET /sessions)
+
+- [ ] **Step 1: Verify the bulk limit error**
+
+```bash
+grep -n "up to 20\|up to 50\|bulk" docs/api.md
+```
+
+Expected: line 162 shows `up to 20`.
+
+- [ ] **Step 2: Fix bulk limit**
+
+In `docs/api.md` line 162, replace:
+```
+Run multiple operations in a single request (up to 20).
+```
+With:
+```
+Run multiple operations in a single request (up to 50).
+```
+
+- [ ] **Step 3: Verify GET /sessions is there and POST is missing**
+
+```bash
+grep -n "sessions\|POST.*session\|GET.*session" docs/api.md
+```
+
+Expected: only `GET /api/v1/sessions/:id` appears; no POST.
+
+- [ ] **Step 4: Add POST /sessions section**
+
+Find the line `### GET /api/v1/sessions/:id` in `docs/api.md` and insert a new `### POST /api/v1/sessions` section immediately before it:
+
+```markdown
+### POST /api/v1/sessions
+
+Save a VLSM session payload for later retrieval. Returns an 8-hex-char session ID. Only available when `$session_enabled = true` in `config.php`.
+
+```bash
+curl -X POST https://example.com/subnet-calculator/api/v1/sessions \
+  -H 'Content-Type: application/json' \
+  -d '{"payload":{"network":"10.0.0.0","cidr":"24","requirements":[{"name":"LAN","hosts":50}]}}'
+```
+
+Response (`201 Created`):
+
+```json
+{
+  "ok": true,
+  "data": { "id": "a1b2c3d4" }
+}
+```
+
+The session ID can then be used with `GET /api/v1/sessions/:id` to restore the session. Sessions expire after the server-configured TTL (default 30 days).
+
+```
+
+- [ ] **Step 5: Verify both changes**
+
+```bash
+grep -n "up to 50\|POST.*sessions\|201" docs/api.md
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/api.md
+git commit -m "docs: fix bulk limit (20→50), add POST /api/v1/sessions endpoint"
+```
+
+---
+
+## Task 4 — Fix openapi.yaml: license, version, meta example
+
+The spec declares `MIT` license but the project is AGPL-3.0 (see `LICENSE`). The API version field is bare `"1"`. The meta endpoint example omits `sessions` and `changelog` from the endpoint list.
+
+**Files:**
+- Modify: `Subnet-Calculator/api/openapi.yaml:9-11` (license)
+- Modify: `Subnet-Calculator/api/openapi.yaml:3` (version)
+- Modify: `Subnet-Calculator/api/openapi.yaml:190-200` (meta example endpoints)
+
+- [ ] **Step 1: Verify the errors**
+
+```bash
+grep -n "license\|MIT\|AGPL\|version" Subnet-Calculator/api/openapi.yaml | head -10
+sed -n '186,202p' Subnet-Calculator/api/openapi.yaml
+```
+
+Expected: `name: MIT`, `identifier: MIT`, `version: "1"`, and the endpoints list missing `sessions` and `changelog`.
+
+- [ ] **Step 2: Fix license**
+
+Replace:
+```yaml
+  license:
+    name: MIT
+    identifier: MIT
+```
+With:
+```yaml
+  license:
+    name: AGPL-3.0
+    identifier: AGPL-3.0-only
+    url: https://www.gnu.org/licenses/agpl-3.0.html
+```
+
+- [ ] **Step 3: Fix API version**
+
+Replace:
+```yaml
+  version: "1"
+```
+With:
+```yaml
+  version: "1.0"
+```
+
+- [ ] **Step 4: Update meta example to include sessions and changelog**
+
+Find the `endpoints:` list in the meta example (around line 190) and add `sessions` and `changelog` to the array. The full updated example block should read:
+
+```yaml
+              example:
+                ok: true
+                data:
+                  version: "1"
+                  endpoints:
+                    - ipv4
+                    - ipv6
+                    - vlsm
+                    - overlap
+                    - split/ipv4
+                    - split/ipv6
+                    - supernet
+                    - ula
+                    - rdns
+                    - bulk
+                    - sessions
+                    - changelog
+```
+
+- [ ] **Step 5: Verify all three fixes**
+
+```bash
+grep -n "license\|AGPL\|MIT\|version" Subnet-Calculator/api/openapi.yaml | head -10
+grep -n "sessions\|changelog" Subnet-Calculator/api/openapi.yaml | head -5
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Subnet-Calculator/api/openapi.yaml
+git commit -m "docs: fix openapi.yaml license (MIT→AGPL-3.0), version, and meta example endpoints"
+```
+
+---
+
+## Task 5 — Update SECURITY.md supported versions
+
+The table shows only `0.1.x ✅` — the project is at v2.8.1. Any security researcher reading this concludes the project has no current supported version.
+
+**Files:**
+- Modify: `SECURITY.md:5-7`
+
+- [ ] **Step 1: Verify the stale table**
+
+```bash
+grep -n "0.1\|Supported\|Version" SECURITY.md
+```
+
+Expected: only `0.1.x | ✅` is present.
+
+- [ ] **Step 2: Replace the table**
+
+Replace the entire Supported Versions table:
+```markdown
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅        |
+```
+With:
+```markdown
+| Version | Supported |
+|---------|-----------|
+| 2.8.x   | ✅        |
+| < 2.8   | ❌        |
+
+Only the latest stable release receives security fixes.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "2.8\|0.1\|Supported" SECURITY.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add SECURITY.md
+git commit -m "docs: update SECURITY.md supported versions to v2.8.x"
+```
+
+---
+
+## Task 6 — README.md: fix stale refs, API table, config table
+
+Three focused fixes: the tarball extract example still references 2.7.0; several API endpoints are absent from the endpoint table; `$api_request_log` and `$api_request_log_db_path` are missing from the configuration table.
+
+**Files:**
+- Modify: `README.md:176` (tarball extract version)
+- Modify: `README.md` (API endpoint table)
+- Modify: `README.md` (configuration table)
+
+- [ ] **Step 1: Verify stale tarball version**
+
+```bash
+grep -n "tar.*2\.\|extract\|xzf" README.md
+```
+
+Expected: line 176 shows `subnet-calculator-2.7.0.tar.gz`.
+
+- [ ] **Step 2: Fix extract example**
+
+On README.md line 176, replace:
+```
+tar -xzf subnet-calculator-2.7.0.tar.gz -C /var/www/html/subnet-calculator/
+```
+With:
+```
+tar -xzf subnet-calculator-2.8.1.tar.gz -C /var/www/html/subnet-calculator/
+```
+
+- [ ] **Step 3: Verify missing API endpoints**
+
+```bash
+grep -n "api/v1\|GET.*api\|POST.*api" README.md | grep -v "^#\|config"
+```
+
+Look for presence of `/meta`, `/changelog`, `/bulk` in the API endpoint table section.
+
+- [ ] **Step 4: Add missing API endpoints to the table**
+
+Find the REST API endpoint table in README.md. Add the following rows (insert in a logical position, e.g. after the existing GET row and before or after the POST rows):
+
+```markdown
+| `GET /api/v1/` | Returns API version and available endpoint list |
+| `GET /api/v1/changelog` | Returns the app CHANGELOG as plain text |
+| `POST /api/v1/bulk` | Run up to 50 operations in a single request |
+| `POST /api/v1/sessions` | Save a VLSM session; returns an 8-char session ID |
+| `GET /api/v1/sessions/:id` | Retrieve a saved VLSM session by ID |
+```
+
+If `GET /api/v1/` is already present, skip it. If `POST /api/v1/sessions` or `GET /api/v1/sessions/:id` are already present, skip them. Only add truly missing rows.
+
+- [ ] **Step 5: Add missing config variables to the table**
+
+Find the configuration table in README.md. Add the following rows after the existing rate-limit entries:
+
+```markdown
+| `$api_request_log` | `false` | Log API requests to SQLite for analytics/abuse review. |
+| `$api_request_log_db_path` | `'data/api_requests.db'` | Path to the API request log SQLite database (relative to docroot). |
+```
+
+- [ ] **Step 6: Verify changes**
+
+```bash
+grep -n "changelog\|bulk\|api_request_log" README.md | head -10
+grep -n "2.8.1" README.md | head -5
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: fix README tarball version, add missing API endpoints and config vars"
+```
+
+---
+
+## Task 7 — README.md: add missing feature documentation
+
+Four features added in v2.7.0–v2.8.0 have no README coverage: Docker deployment, PHP client library, Service Worker/offline mode, and the v2.8.0 Tool Drawer.
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Check what is currently in the README features section**
+
+```bash
+grep -n "Docker\|Service Worker\|offline\|Tool Drawer\|client" README.md | head -20
+```
+
+- [ ] **Step 2: Add Docker deployment section**
+
+Find the section that describes how to run the app (the `php -S` section) and add a Docker alternative immediately after it:
+
+```markdown
+### Docker
+
+A `docker-compose.yml` is included. Build and start with:
+
+```bash
+docker compose up --build
+```
+
+The app is served on port `8080` by default. Mount a `config.php` file into `/var/www/html/` to override configuration.
+```
+
+- [ ] **Step 3: Add Service Worker / offline note**
+
+Find the Features list (the bullet list near the top of the README). Add the following item:
+
+```markdown
+- **Offline mode** — a Service Worker caches the app so it works without a network connection after the first visit
+```
+
+- [ ] **Step 4: Add v2.8.0 Tool Drawer note**
+
+In the Features list or a relevant UI/UX section, add:
+
+```markdown
+- **Tool Drawer** — a slide-in toolbar panel (v2.8.0+) groups sub-tools (subnet splitter, supernet/summarisation, IP range → CIDR, subnet allocation tree, overlap checker, ULA generator) so they don't clutter the main interface
+```
+
+- [ ] **Step 5: Add PHP client library section**
+
+Find the REST API section and add a paragraph or subsection for the client:
+
+```markdown
+### PHP Client Library
+
+A lightweight PHP wrapper is included at `clients/php/SubnetCalculatorClient.php`. Copy it into your project and use it to call any API endpoint:
+
+```php
+require 'SubnetCalculatorClient.php';
+$client = new SubnetCalculatorClient('https://example.com/subnet-calculator/');
+$result = $client->ipv4('192.168.1.0/24');
+echo $result['data']['network_cidr'];
+```
+
+No Composer dependency required.
+```
+
+- [ ] **Step 6: Verify**
+
+```bash
+grep -n "Docker\|Service Worker\|offline\|Tool Drawer\|PHP Client\|SubnetCalculatorClient" README.md
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add Docker, Service Worker, Tool Drawer, and PHP client to README"
+```
+
+---
+
+## Task 8 — Update CONTRIBUTING.md
+
+Missing: `make test-docker` as the canonical test gate, visual regression workflow, updated Playwright counts, `clients/php/` in project structure, Semgrep and Spectral in tooling.
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Check current state**
+
+```bash
+grep -n "docker\|make\|517\|85 group\|semgrep\|spectral\|clients" CONTRIBUTING.md
+```
+
+Expected: no Docker, no Semgrep, no Spectral, count shows 517/85.
+
+- [ ] **Step 2: Add make test-docker as the canonical test gate**
+
+Find the section describing how to run tests (likely near the `playwright_test.py` entry). Add this block before or in place of the manual Playwright instructions:
+
+```markdown
+### End-to-end tests (preferred)
+
+```bash
+make test-docker
+```
+
+This builds a Docker image, starts the app, runs the full Playwright suite (561 assertions across 91 test groups), and prints a pass/fail summary. No dev server setup required. `SKIP_SNAPSHOTS=1` and `SKIP_LINT=1` are set automatically — run `npm run lint` separately for ESLint/Stylelint.
+
+**Visual regression snapshots:** If your PR changes CSS, update baselines:
+
+```bash
+UPDATE_SNAPSHOTS=1 make test-docker
+```
+
+Then commit the updated PNGs in `testing/snapshots/`.
+```
+
+- [ ] **Step 3: Fix Playwright test count**
+
+Find the line:
+```
+playwright_test.py     ← Playwright E2E browser tests (85 groups, 517 assertions)
+```
+
+Replace with:
+```
+playwright_test.py     ← Playwright E2E browser tests (91 groups, 561 assertions)
+```
+
+- [ ] **Step 4: Add clients/php/ to project structure**
+
+Find the project structure tree. Add the `clients/` directory:
+
+```
+clients/
+  php/
+    SubnetCalculatorClient.php  ← PHP API client wrapper (no Composer required)
+```
+
+- [ ] **Step 5: Add Semgrep and Spectral to tooling**
+
+Find the tooling/linting section and add:
+
+```markdown
+```bash
+# Security scan (Semgrep)
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten \
+    --config p/sql-injection --error \
+    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+
+# OpenAPI spec lint (Spectral — errors fail; review warnings each run)
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+```
+
+- [ ] **Step 6: Verify**
+
+```bash
+grep -n "make test-docker\|561\|91 group\|clients\|semgrep\|spectral" CONTRIBUTING.md
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs: update CONTRIBUTING with Docker test gate, counts, clients/, Semgrep, Spectral"
+```
+
+---
+
+## Task 9 — Update docs/index.md
+
+Stale tarball version (2.6.0), missing `intl` PHP extension in requirements, no mention of PHP client.
+
+**Files:**
+- Modify: `docs/index.md:37`
+
+- [ ] **Step 1: Verify stale version**
+
+```bash
+grep -n "2.6.0\|tarball\|tar -xzf\|intl\|extension" docs/index.md
+```
+
+Expected: line 37 references `subnet-calculator-2.6.0.tar.gz`.
+
+- [ ] **Step 2: Fix tarball version**
+
+Replace:
+```
+tar -xzf subnet-calculator-2.6.0.tar.gz -C /var/www/html/subnet-calculator/
+```
+With:
+```
+tar -xzf subnet-calculator-2.8.1.tar.gz -C /var/www/html/subnet-calculator/
+```
+
+- [ ] **Step 3: Add intl extension to requirements**
+
+Find the requirements section. Add `php-intl` alongside or after the existing PHP requirements:
+
+```markdown
+- **PHP `intl` extension** — for locale-aware thousands-separator formatting (e.g. `1,234,567`). Falls back to comma separators when unavailable.
+```
+
+- [ ] **Step 4: Add PHP client mention**
+
+After the "Download" section or in a "See also" block at the bottom, add:
+
+```markdown
+A lightweight **PHP client library** (`clients/php/SubnetCalculatorClient.php`) is bundled in the repository for programmatic API access. See the [PHP Client](client.md) page for usage.
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -n "2.8.1\|intl\|client" docs/index.md
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/index.md
+git commit -m "docs: fix tarball version in index.md, add intl requirement and PHP client note"
+```
+
+---
+
+## Task 10 — Update Tool Drawer UX in sub-tool docs
+
+Six docs pages still describe sub-tools as "inline panels" or "tabs". Since v2.8.0 they live in a slide-in Tool Drawer accessed via a toolbar button. Update the UI-location description in each affected page.
+
+**Files:**
+- Modify: `docs/overlap.md`
+- Modify: `docs/supernet.md`
+- Modify: `docs/ula.md`
+- Modify: `docs/sessions.md`
+- Modify: `docs/ipv6.md` (overlap checker location)
+
+The replacement phrase to use throughout: **"in the Tool Drawer (toolbar button on the IPv4/IPv6 tab)"** — adjust per-page based on which tab the tool lives in.
+
+- [ ] **Step 1: Audit current UI-location descriptions**
+
+```bash
+grep -n "VLSM tab\|IPv4 tab\|IPv6 tab\|panel\|scroll" docs/overlap.md docs/supernet.md docs/ula.md docs/sessions.md docs/ipv6.md
+```
+
+Note each line that describes a tab/panel/scroll UI location.
+
+- [ ] **Step 2: Fix docs/overlap.md**
+
+Find the phrase that says the Overlap Checker is "On the VLSM tab" (or similar). Replace with:
+
+```markdown
+The **Subnet Overlap Checker** is available in the Tool Drawer — click the toolbar button on the IPv4 or IPv6 tab to open it.
+```
+
+Also add an API cross-reference at the end of the page:
+
+```markdown
+## REST API
+
+The overlap check is also available programmatically via [`POST /api/v1/overlap`](api.md#post-apiv1overlap).
+```
+
+- [ ] **Step 3: Fix docs/supernet.md**
+
+Find the phrase "on the IPv4 tab" or "Supernet & Route Summarisation panel". Replace with:
+
+```markdown
+Both tools are available in the **Tool Drawer** — click the toolbar button on the IPv4 tab to open it.
+```
+
+Add API cross-reference:
+
+```markdown
+## REST API
+
+- Supernet calculation: [`POST /api/v1/supernet`](api.md#post-apiv1supernet)
+- Route summarisation: included in the same endpoint via `mode=summarise`
+```
+
+- [ ] **Step 4: Fix docs/ula.md**
+
+Find "scroll to the IPv6 ULA Prefix Generator panel" or similar. Replace with:
+
+```markdown
+The **IPv6 ULA Prefix Generator** is in the Tool Drawer — click the toolbar button on the IPv6 tab to open it.
+```
+
+Add the `available_64s` field mention after the output fields list:
+
+```markdown
+- **Available /64s** — total number of `/64` subnets available within the generated `/48` prefix (always 65,536).
+```
+
+Add API cross-reference:
+
+```markdown
+## REST API
+
+Generate a ULA prefix programmatically via [`POST /api/v1/ula`](api.md#post-apiv1ula).
+```
+
+- [ ] **Step 5: Fix docs/sessions.md**
+
+Find "Save & Restore panel". Replace with:
+
+```markdown
+The **Session** controls are in the Tool Drawer — click the toolbar button on the VLSM tab to open it.
+```
+
+Add a note about the API:
+
+```markdown
+## API access
+
+Sessions can also be created and retrieved programmatically:
+
+- `POST /api/v1/sessions` — save a payload, receive an 8-char ID
+- `GET /api/v1/sessions/:id` — retrieve a session by ID
+
+See [REST API](api.md#post-apiv1sessions) for curl examples.
+```
+
+- [ ] **Step 6: Fix docs/ipv6.md overlap checker reference**
+
+Find the sentence "Two IPv6 CIDRs can be compared via the Subnet Overlap Checker panel on the VLSM tab". Replace with:
+
+```markdown
+Two or more IPv6 CIDRs can be compared via the **Subnet Overlap Checker** in the Tool Drawer — click the toolbar button on the IPv6 tab. See [Overlap Checker](overlap.md) for details.
+```
+
+- [ ] **Step 7: Verify**
+
+```bash
+grep -n "Tool Drawer\|toolbar button" docs/overlap.md docs/supernet.md docs/ula.md docs/sessions.md docs/ipv6.md
+```
+
+Each file should have at least one "Tool Drawer" reference.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/overlap.md docs/supernet.md docs/ula.md docs/sessions.md docs/ipv6.md
+git commit -m "docs: update sub-tool pages to reflect v2.8.0 Tool Drawer UX"
+```
+
+---
+
+## Task 11 — Improve docs/sharing.md: sc-set-bg and show_share_bar
+
+Two useful features are absent from the sharing docs: the `sc-set-bg` postMessage for runtime background colour control, and the `$show_share_bar = false` config for iframe deployments.
+
+**Files:**
+- Modify: `docs/sharing.md`
+
+- [ ] **Step 1: Check what is currently covered**
+
+```bash
+grep -n "sc-set-bg\|show_share_bar\|background\|color" docs/sharing.md
+```
+
+Expected: none of these are present.
+
+- [ ] **Step 2: Add sc-set-bg section**
+
+After the `### Auto-sizing the iframe` section, add:
+
+````markdown
+### Setting a custom background colour at runtime
+
+After the iframe has loaded, send a `sc-set-bg` postMessage to change the calculator's background colour without reloading the page:
+
+```js
+// Wait for the iframe to finish loading first
+scFrame.addEventListener('load', function () {
+  scFrame.contentWindow.postMessage({ type: 'sc-set-bg', color: '#f0f4f8' }, '*');
+});
+
+// Reset to default (remove override)
+scFrame.contentWindow.postMessage({ type: 'sc-set-bg', color: null }, '*');
+```
+
+The `color` value is any valid CSS colour string. Sending the message before the `load` event fires will be silently dropped because the calculator's listener is not running yet.
+````
+
+- [ ] **Step 3: Add $show_share_bar note**
+
+After the `### Frame-ancestors policy` section, add:
+
+````markdown
+### Hiding the share bar in embedded deployments
+
+When embedding the calculator as an iframe you may not want the Share URL bar visible. Set `$show_share_bar = false` in `config.php`:
+
+```php
+$show_share_bar = false;
+```
+
+This hides the bar globally for all visitors, which is appropriate when the embed URL is managed externally.
+````
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -n "sc-set-bg\|show_share_bar" docs/sharing.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/sharing.md
+git commit -m "docs: add sc-set-bg postMessage and show_share_bar sections to sharing.md"
+```
+
+---
+
+## Task 12 — Create PHP client library docs page
+
+The PHP client at `Subnet-Calculator/clients/php/SubnetCalculatorClient.php` is completely undocumented in the MkDocs site. This task creates the page and adds it to the nav.
+
+**Files:**
+- Create: `docs/client.md`
+- Modify: `docs/mkdocs.yml` (add nav entry)
+
+- [ ] **Step 1: Read the client to understand its public API**
+
+```bash
+cat Subnet-Calculator/clients/php/SubnetCalculatorClient.php
+```
+
+Note the constructor signature, public methods, and any exceptions it throws.
+
+- [ ] **Step 2: Create docs/client.md**
+
+Based on what you found in Step 1, create `docs/client.md` with the following structure:
+
+```markdown
+# PHP Client Library
+
+A lightweight PHP wrapper for the Subnet Calculator REST API. No Composer or external dependencies required — just copy the file into your project.
+
+## Installation
+
+Copy `clients/php/SubnetCalculatorClient.php` from the repository into your project.
+
+## Usage
+
+```php
+<?php
+require 'SubnetCalculatorClient.php';
+
+$client = new SubnetCalculatorClient('https://example.com/subnet-calculator/');
+
+// IPv4 subnet calculation
+$result = $client->ipv4('192.168.1.0/24');
+echo $result['data']['network_cidr']; // 192.168.1.0/24
+
+// IPv6 subnet calculation
+$result = $client->ipv6('2001:db8::/32');
+
+// VLSM allocation
+$result = $client->vlsm('10.0.0.0/24', [
+    ['name' => 'LAN', 'hosts' => 50],
+    ['name' => 'DMZ', 'hosts' => 14],
+]);
+```
+
+## Constructor
+
+```php
+new SubnetCalculatorClient(string $baseUrl, string $token = '', int $timeout = 10)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `$baseUrl` | `string` | Base URL of the Subnet Calculator install (trailing slash optional). |
+| `$token` | `string` | Bearer token for `$api_tokens`-protected installs (optional). |
+| `$timeout` | `int` | HTTP request timeout in seconds (default: 10). |
+
+## Methods
+
+> List each public method found in the client file. For each method, show the signature and a one-line description. Fill this in from Step 1.
+
+## Error handling
+
+The client throws a `RuntimeException` on HTTP errors (non-2xx) or network failures. The exception message includes the HTTP status code and the API error payload.
+
+## Authentication
+
+If the server has `$api_tokens` configured, pass your token as the second constructor argument:
+
+```php
+$client = new SubnetCalculatorClient('https://example.com/subnet-calculator/', 'your-token-here');
+```
+
+## See also
+
+- [REST API reference](api.md)
+- [Operator config](config.md)
+```
+
+Populate the **Methods** table from the actual methods you read in Step 1. Do not leave it as a placeholder.
+
+- [ ] **Step 3: Add nav entry to mkdocs.yml**
+
+In `docs/mkdocs.yml`, find the `nav:` section and add the new page. Place it after the REST API entry:
+
+```yaml
+  - REST API: api.md
+  - PHP Client Library: client.md
+  - Operator Config: config.md
+```
+
+- [ ] **Step 4: Verify the file was created and nav is correct**
+
+```bash
+ls docs/client.md
+grep -n "client\|PHP Client" docs/mkdocs.yml
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/client.md docs/mkdocs.yml
+git commit -m "docs: add PHP client library page and mkdocs.yml nav entry"
+```
+
+---
+
+## Task 13 — Add missing CHANGELOG v0.7 entry
+
+The CHANGELOG jumps from `## [0.6]` to `## [0.8]` with no v0.7. Check git history to find what was actually changed in that version and add the entry.
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Check git log around the v0.6/v0.8 timeframe**
+
+```bash
+git log --oneline --after="2026-04-02" --before="2026-04-04" | head -20
+```
+
+Look for commits that would have constituted a v0.7 release.
+
+- [ ] **Step 2: Verify the gap**
+
+```bash
+grep -n "## \[0\." CHANGELOG.md | head -15
+```
+
+Confirm that `[0.7]` is absent and the gap between 0.6 and 0.8 exists.
+
+- [ ] **Step 3: Add the v0.7 entry**
+
+Between `## [0.6] - 2026-04-03` and `## [0.8] - 2026-04-04`, insert an entry based on the git log findings. If git history reveals specific changes, document them accurately. If no commits can be cleanly attributed to v0.7, add a placeholder that is honest about the gap:
+
+```markdown
+## [0.7] - 2026-04-03
+
+### Added
+
+- *(This version entry was missing from the changelog — see git log for changes between v0.6 and v0.8)*
+```
+
+Only use the placeholder if no commits can be found. If commits exist, replace it with actual content.
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -n "## \[0\." CHANGELOG.md | head -15
+```
+
+Confirm `[0.7]` now appears between `[0.6]` and `[0.8]`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add missing CHANGELOG v0.7 entry"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Issue from audit | Covered by task |
+|---|---|
+| `sc-height` → `sc-resize` in sharing.md | Task 1 ✅ |
+| `$split_max_subnets` 256 → 16 in ipv4.md | Task 2 ✅ |
+| rdns TTL 3600 → 86400 | Task 2 ✅ |
+| binary.md hex format | Task 2 ✅ |
+| docs/api.md bulk limit 20 → 50 | Task 3 ✅ |
+| docs/api.md missing POST /sessions | Task 3 ✅ |
+| openapi.yaml license MIT → AGPL-3.0 | Task 4 ✅ |
+| openapi.yaml version "1" → "1.0" | Task 4 ✅ |
+| openapi.yaml meta example missing sessions/changelog | Task 4 ✅ |
+| SECURITY.md stale supported versions | Task 5 ✅ |
+| README.md stale tarball extract version (2.7.0) | Task 6 ✅ |
+| README.md missing API endpoints (meta, changelog, bulk, sessions) | Task 6 ✅ |
+| README.md missing `$api_request_log` config vars | Task 6 ✅ |
+| README.md missing Docker deployment | Task 7 ✅ |
+| README.md missing PHP client library | Task 7 ✅ |
+| README.md missing Service Worker/offline | Task 7 ✅ |
+| README.md missing Tool Drawer (v2.8.0) | Task 7 ✅ |
+| CONTRIBUTING.md missing make test-docker | Task 8 ✅ |
+| CONTRIBUTING.md missing visual regression | Task 8 ✅ |
+| CONTRIBUTING.md stale Playwright count (517/85) | Task 8 ✅ |
+| CONTRIBUTING.md missing clients/php/ in structure | Task 8 ✅ |
+| CONTRIBUTING.md missing Semgrep and Spectral | Task 8 ✅ |
+| docs/index.md stale tarball version (2.6.0) | Task 9 ✅ |
+| docs/index.md missing intl requirement | Task 9 ✅ |
+| Tool Drawer UX stale in overlap/supernet/ula/sessions/ipv6.md | Task 10 ✅ |
+| docs/sharing.md missing sc-set-bg | Task 11 ✅ |
+| docs/sharing.md missing show_share_bar | Task 11 ✅ |
+| PHP client library undocumented in MkDocs | Task 12 ✅ |
+| CHANGELOG v0.7 missing | Task 13 ✅ |
+
+### Placeholder scan
+
+Task 12 Step 2 contains one intentional instruction placeholder in the Methods table ("Fill this in from Step 1"). This is not a red flag — it is conditional on reading the actual client file, which must happen at execution time. The instruction is clear and specific.
+
+### Intentionally out of scope
+
+The following issues were noted in the audit but are code/spec changes that should be separate PRs, not documentation fixes:
+
+- `openapi.yaml` `overlap` endpoint missing `partial` from the `relation` enum — this requires verifying actual API behaviour first
+- `openapi.yaml` 5xx error responses missing from most endpoints — spec enhancement, not a docs fix
+- `docs/rdns.md` missing `ns`/`hostmaster`/`serial`/`domain` request params — depends on verifying what the current API actually accepts
+- `docs/tree.md` ASCII tree character inconsistency (`├──` vs `├─`) — cosmetic; low priority

--- a/docs/superpowers/plans/2026-04-25-v2.9.0-ui-ux-style-guide.md
+++ b/docs/superpowers/plans/2026-04-25-v2.9.0-ui-ux-style-guide.md
@@ -1,0 +1,1675 @@
+# v2.9.0 — UI/UX & Style Guide Adoption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the app's color tokens, typography, and component design with the established style guide (teal `#06d6a0` accent, Space Grotesk headings, Plus Jakarta Sans body, Fira Code mono, GitHub-dark surfaces) while fixing 4 mobile layout bugs and 3 polish items.
+
+**Architecture:** CSS-only changes to `app.css` (tokens → cascade to all components), new self-hosted woff2 font files, one `layout.php` meta update, and Playwright snapshot regeneration. No PHP logic changes. All changes are backward-compatible with iframe embeds (`--color-bg` token name preserved).
+
+**Tech Stack:** PHP 8.x, vanilla CSS (custom properties), self-hosted WOFF2 fonts via `@fontsource` npm packages, Playwright E2E (Python), PHPUnit, PHPStan 9, PHPCS PSR-12, ESLint, Stylelint.
+
+---
+
+## Skill Usage
+
+- **ui-ux-pro-max** — invoke before every task that touches visual design (Tasks 1–7). Use `--domain ux` for accessibility checks, `--domain style` for hover/transition decisions.
+- **documentation** — invoke during Task 9 (docs updates). All docs must be accurate before any PR opens.
+- **superpowers:subagent-driven-development** — execute each task as a fresh subagent.
+
+---
+
+## Pre-Flight
+
+Before starting any task, verify Memory MCP is reachable:
+
+```bash
+# Should return entity data — if it errors, stop and alert user
+```
+
+Load current project state:
+- `open_nodes(["user:sean", "project:subnet-calculator"])`
+- `open_nodes(["project:subnet-calculator:release:v2.9.0"])` (create if missing)
+
+---
+
+## Release Gate (run before every commit)
+
+```bash
+# 1. PHP syntax
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/api/v1/*.php \
+          Subnet-Calculator/api/v1/handlers/*.php Subnet-Calculator/templates/layout.php; do
+  php -l "$f"
+done
+
+# 2. Static analysis
+phpstan analyse --no-progress --memory-limit=512M
+
+# 3. Unit tests
+vendor/bin/phpunit
+
+# 4. PHPCS (warnings tolerated; errors fail)
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+
+# 5. JS/CSS lint
+npm run lint
+
+# 6. OpenAPI spec lint (0 errors required; warnings are pre-existing)
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+
+**Zero test failures. Zero lint errors. No exceptions. Any failure must be fixed, not dismissed.**
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `Subnet-Calculator/assets/app.css` | Tokens, font-faces, component styles (primary change file) |
+| `Subnet-Calculator/assets/fonts/SpaceGrotesk-600.woff2` | New — Space Grotesk SemiBold |
+| `Subnet-Calculator/assets/fonts/SpaceGrotesk-700.woff2` | New — Space Grotesk Bold |
+| `Subnet-Calculator/assets/fonts/PlusJakartaSans-400.woff2` | New — Plus Jakarta Sans Regular |
+| `Subnet-Calculator/assets/fonts/PlusJakartaSans-600.woff2` | New — Plus Jakarta Sans SemiBold |
+| `Subnet-Calculator/assets/fonts/FiraCode-400.woff2` | New — Fira Code Regular |
+| `Subnet-Calculator/assets/fonts/JetBrainsMono-Regular.woff2` | Delete (replaced by Fira Code) |
+| `Subnet-Calculator/templates/layout.php` | Update `theme-color` meta only |
+| `Subnet-Calculator/includes/config.php` | Version bump `2.8.1` → `2.9.0` |
+| `CHANGELOG.md` | New `[2.9.0]` section |
+| `README.md` | Downloads table row for v2.9.0 |
+| `testing/scripts/playwright_test.py` | Add font-loading assertions |
+| `testing/snapshots/*.png` | Regenerate all baselines |
+| `releases/subnet-calculator-2.9.0.tar.gz` | New release tarball |
+
+---
+
+## Task 0: Pre-Release Housekeeping
+
+**Purpose:** Clean up the repo before starting work so history is tidy.
+
+**Files:** none (GitHub API only)
+
+- [ ] **Step 1: Close the v2.8.1 milestone** (it has 0 open issues)
+
+```bash
+gh api repos/seanmousseau/Subnet-Calculator/milestones/16 \
+  --method PATCH --field state="closed"
+# Verify
+gh api repos/seanmousseau/Subnet-Calculator/milestones/16 --jq '.state'
+# Expected: "closed"
+```
+
+- [ ] **Step 2: Delete stale merged branches**
+
+```bash
+for branch in docs/logo-mark docs/style-guide-update docs/tablet-breakpoint-fix \
+              docs/ux-fixes feature/v2.8.0-tool-drawer; do
+  git push origin --delete "$branch" && echo "deleted $branch"
+done
+# Verify
+git branch -r | grep -E "logo-mark|style-guide-update|tablet-breakpoint|ux-fixes|v2.8.0-tool"
+# Expected: no output
+```
+
+- [ ] **Step 3: Create working branch**
+
+```bash
+git checkout main && git pull origin main
+git checkout -b feature/v2.9.0-ui-style-guide
+```
+
+- [ ] **Step 4: Seed Memory MCP**
+
+```
+add_observations("project:subnet-calculator", [
+  "v2.9.0 work started on branch feature/v2.9.0-ui-style-guide 2026-04-25. 22 issues #250-#271 on milestone #17. Phase 1: fonts+tokens; Phase 2: components; Phase 3: contrast; Phase 4: mobile bugs; Phase 5: polish."
+])
+```
+
+---
+
+## Task 1: Self-Host Fonts — Download & @font-face
+
+**Closes:** #252 (partial), #253 (partial), #254 (partial)
+**Skill:** Run `python3 skills/ui-ux-pro-max/scripts/search.py "typography font loading performance" --domain ux` before starting.
+
+**Files:**
+- Create: `Subnet-Calculator/assets/fonts/SpaceGrotesk-600.woff2`
+- Create: `Subnet-Calculator/assets/fonts/SpaceGrotesk-700.woff2`
+- Create: `Subnet-Calculator/assets/fonts/PlusJakartaSans-400.woff2`
+- Create: `Subnet-Calculator/assets/fonts/PlusJakartaSans-600.woff2`
+- Create: `Subnet-Calculator/assets/fonts/FiraCode-400.woff2`
+- Delete: `Subnet-Calculator/assets/fonts/JetBrainsMono-Regular.woff2`
+- Modify: `Subnet-Calculator/assets/app.css` lines 1–7 (`@font-face` block)
+
+- [ ] **Step 1: Download font woff2 files via @fontsource**
+
+```bash
+cd /Users/seanmousseau/dev/Subnet-Calculator
+npm install --save-dev \
+  @fontsource/space-grotesk \
+  @fontsource/plus-jakarta-sans \
+  @fontsource/fira-code
+
+# Copy exactly the weights we need
+cp node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-600-normal.woff2 \
+   Subnet-Calculator/assets/fonts/SpaceGrotesk-600.woff2
+cp node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff2 \
+   Subnet-Calculator/assets/fonts/SpaceGrotesk-700.woff2
+cp node_modules/@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-400-normal.woff2 \
+   Subnet-Calculator/assets/fonts/PlusJakartaSans-400.woff2
+cp node_modules/@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-600-normal.woff2 \
+   Subnet-Calculator/assets/fonts/PlusJakartaSans-600.woff2
+cp node_modules/@fontsource/fira-code/files/fira-code-latin-400-normal.woff2 \
+   Subnet-Calculator/assets/fonts/FiraCode-400.woff2
+
+# Verify all 5 files exist and are non-zero
+ls -lh Subnet-Calculator/assets/fonts/
+# Expected: 5 .woff2 files, JetBrainsMono-Regular.woff2 still present (removed in next step)
+```
+
+- [ ] **Step 2: Verify font files downloaded correctly**
+
+```bash
+file Subnet-Calculator/assets/fonts/SpaceGrotesk-600.woff2
+file Subnet-Calculator/assets/fonts/PlusJakartaSans-400.woff2
+file Subnet-Calculator/assets/fonts/FiraCode-400.woff2
+# Each Expected: "Web Open Font Format (Version 2), TrueType, ..."
+```
+
+- [ ] **Step 3: Replace @font-face block in app.css (lines 1–7)**
+
+The current block is:
+```css
+@font-face {
+    font-family: 'JetBrains Mono';
+    src: url('fonts/JetBrainsMono-Regular.woff2') format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+```
+
+Replace it with:
+```css
+@font-face {
+    font-family: 'Space Grotesk';
+    src: url('fonts/SpaceGrotesk-600.woff2') format('woff2');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Space Grotesk';
+    src: url('fonts/SpaceGrotesk-700.woff2') format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('fonts/PlusJakartaSans-400.woff2') format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Plus Jakarta Sans';
+    src: url('fonts/PlusJakartaSans-600.woff2') format('woff2');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Fira Code';
+    src: url('fonts/FiraCode-400.woff2') format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+```
+
+- [ ] **Step 4: Delete JetBrains Mono woff2 file**
+
+```bash
+rm Subnet-Calculator/assets/fonts/JetBrainsMono-Regular.woff2
+# Verify
+ls Subnet-Calculator/assets/fonts/
+# Expected: 5 files, no JetBrainsMono-Regular.woff2
+```
+
+- [ ] **Step 5: Run CSS lint to confirm no issues**
+
+```bash
+npm run lint:css
+# Expected: no errors
+```
+
+- [ ] **Step 6: Run release gate**
+
+```bash
+# PHP/PHPStan/PHPUnit/PHPCS unchanged — run quick check
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php; do php -l "$f"; done
+npm run lint
+# Expected: all pass
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Subnet-Calculator/assets/fonts/ Subnet-Calculator/assets/app.css package.json package-lock.json
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+feat(v2.9.0): self-host Space Grotesk, Plus Jakarta Sans, Fira Code fonts
+
+Replace JetBrains Mono with Fira Code (style guide mono). Add Space Grotesk
+(headings) and Plus Jakarta Sans (body) woff2 files. Font application follows
+in next commit. Closes partial #252 #253 #254.
+EOF
+)"
+```
+
+---
+
+## Task 2: Apply Fonts to Elements
+
+**Closes:** #252, #253, #254
+**Skill:** Run `python3 skills/ui-ux-pro-max/scripts/search.py "typography hierarchy heading body monospace" --domain typography` before starting.
+
+**Files:**
+- Modify: `Subnet-Calculator/assets/app.css` — `font-family` on body, h1, labels, mono elements
+
+- [ ] **Step 1: Update body font-family (app.css line 63)**
+
+Current:
+```css
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+```
+
+Change to:
+```css
+body {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+```
+
+- [ ] **Step 2: Update h1 font-family (app.css line 109)**
+
+Current:
+```css
+h1 { font-size: 1.5rem; font-weight: 700; color: var(--color-text-heading); }
+```
+
+Change to:
+```css
+h1 { font-family: 'Space Grotesk', system-ui, sans-serif; font-size: 1.5rem; font-weight: 700; color: var(--color-text-heading); }
+```
+
+- [ ] **Step 3: Update tab buttons font (app.css — .tab-btn block)**
+
+In `.tab-btn` add `font-family: 'Space Grotesk', system-ui, sans-serif;`:
+```css
+.tab-btn {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    flex: 0;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-bottom: -1px;
+    padding: 0.5rem 1.25rem;
+    transition: color 0.15s, border-color 0.15s;
+    width: auto;
+}
+```
+
+- [ ] **Step 4: Replace all JetBrains Mono references with Fira Code**
+
+There are 9 occurrences in app.css. Use a global find-and-replace across the entire file:
+
+Search: `'JetBrains Mono', 'Courier New', monospace`
+Replace: `'Fira Code', 'Courier New', monospace`
+
+Also replace the standalone occurrence:
+Search: `'JetBrains Mono', monospace`  
+Replace: `'Fira Code', monospace`
+
+Verify all replacements:
+```bash
+grep "JetBrains" Subnet-Calculator/assets/app.css
+# Expected: no output (zero matches)
+grep "Fira Code" Subnet-Calculator/assets/app.css | wc -l
+# Expected: at least 9 lines
+```
+
+- [ ] **Step 5: Update results-header font (section-header spec)**
+
+Find `.results-header`:
+```css
+.results-header {
+    background: var(--color-input-bg);
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    padding: 0.6rem 1rem;
+    text-transform: uppercase;
+}
+```
+
+Change to:
+```css
+.results-header {
+    background: var(--color-input-bg);
+    color: var(--color-text-muted);
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    padding: 0.6rem 1rem;
+    text-transform: uppercase;
+}
+```
+
+- [ ] **Step 6: Update splitter-title font (parallel section header)**
+
+Find `.splitter-title`:
+```css
+.splitter-title {
+    background: var(--color-input-bg);
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    padding: 0.6rem 1rem;
+    text-transform: uppercase;
+}
+```
+
+Change to:
+```css
+.splitter-title {
+    background: var(--color-input-bg);
+    color: var(--color-text-muted);
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    padding: 0.6rem 1rem;
+    text-transform: uppercase;
+}
+```
+
+- [ ] **Step 7: Update tool-drawer-title font**
+
+Find `.tool-drawer-title`:
+```css
+.tool-drawer-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+}
+```
+
+Change to:
+```css
+.tool-drawer-title {
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+}
+```
+
+- [ ] **Step 8: Update version badge font**
+
+Find `.version`:
+```css
+.version {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--color-text-faint);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.15rem 0.4rem;
+    letter-spacing: 0.04em;
+}
+```
+
+Change to (Fira Code for version pill — it's a code/badge context):
+```css
+.version {
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.72rem;
+    font-weight: 400;
+    color: var(--color-text-faint);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.15rem 0.4rem;
+    letter-spacing: 0.04em;
+}
+```
+
+- [ ] **Step 9: Run CSS lint**
+
+```bash
+npm run lint:css
+# Expected: no errors
+```
+
+- [ ] **Step 10: Run release gate and deploy to test server for visual check**
+
+```bash
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php; do php -l "$f"; done
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpunit
+npm run lint
+# Expected: all pass
+```
+
+Deploy to test server:
+```bash
+rsync -a --delete Subnet-Calculator/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+scp testing/fixtures/iframe-test.html root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+```
+
+Open browser and verify fonts loaded: h1 should render in Space Grotesk, inputs in Fira Code, body text in Plus Jakarta Sans.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add Subnet-Calculator/assets/app.css
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+feat(v2.9.0): apply Space Grotesk, Plus Jakarta Sans, Fira Code to all elements
+
+h1 and tab buttons → Space Grotesk. body → Plus Jakarta Sans. All mono contexts
+(inputs, result values, share bar, binary, VLSM, split items) → Fira Code.
+Section headers → Space Grotesk 0.75rem 0.06em. Closes #252 #253 #254.
+EOF
+)"
+```
+
+---
+
+## Task 3: Color Tokens — Dark Surfaces & Teal Accent
+
+**Closes:** #250, #251
+**Skill:** Run `python3 skills/ui-ux-pro-max/scripts/search.py "dark mode color tokens contrast" --domain color` before starting.
+
+**Files:**
+- Modify: `Subnet-Calculator/assets/app.css` — `:root` and `html[data-theme="light"]` blocks
+- Modify: `Subnet-Calculator/templates/layout.php` — `theme-color` meta
+
+- [ ] **Step 1: Update `:root` dark surface tokens and accent (app.css lines 9–36)**
+
+Current `:root` block:
+```css
+:root {
+    --color-bg:           #0f172a;
+    --color-surface:      #1e293b;
+    --color-surface-alt:  #111827;
+    --color-border:       #334155;
+    --color-text:         #e2e8f0;
+    --color-text-heading: #f8fafc;
+    --color-text-muted:   #64748b;
+    --color-text-subtle:  #94a3b8;
+    --color-text-faint:   #475569;
+    --color-input-bg:     #0f172a;
+    --color-input-text:   #f1f5f9;
+    --color-accent:       #3b82f6;
+    --color-accent-hover: #2563eb;
+    --color-accent-light: #38bdf8;
+    --color-green:        #4ade80;
+    --color-error-bg:     #450a0a;
+    --color-error-border: #7f1d1d;
+    --color-error-text:   #fca5a5;
+    --color-btn-text:     #fff;
+}
+```
+
+Replace with:
+```css
+:root {
+    /* Page background — NOTE: --color-bg is used by iframe bg-override JS; do not rename */
+    --color-bg:           #0d1117;
+    /* Card & surfaces */
+    --color-surface:      #161b22;
+    --color-surface-alt:  #0d1117;
+    --color-border:       #21262d;
+    /* Text */
+    --color-text:         #e6edf3;
+    --color-text-heading: #f0f6fc;
+    --color-text-muted:   #8b949e;
+    --color-text-subtle:  #8b949e;
+    --color-text-faint:   #6e7681;
+    /* Inputs */
+    --color-input-bg:     #0d1117;
+    --color-input-text:   #e6edf3;
+    /* Accents — teal brand colour */
+    --color-accent:       #06d6a0;
+    --color-accent-hover: #4dffd8;
+    --color-accent-light: #06d6a0;
+    --color-green:        #3fb950;
+    /* Error */
+    --color-error-bg:     #450a0a;
+    --color-error-border: #7f1d1d;
+    --color-error-text:   #fca5a5;
+    /* Button text — teal bg needs dark text (not white) */
+    --color-btn-text:     #0a1a12;
+}
+```
+
+- [ ] **Step 2: Update light-mode token overrides (app.css — `html[data-theme="light"]` block)**
+
+Current light block:
+```css
+html[data-theme="light"] {
+    --color-bg:           #fff;
+    --color-surface:      #fff;
+    --color-surface-alt:  #f8fafc;
+    --color-border:       #cbd5e1;
+    --color-text:         #1e293b;
+    --color-text-heading: #0f172a;
+    --color-text-muted:   #4b5563;
+    --color-text-subtle:  #475569;
+    --color-text-faint:   #6b7280;
+    --color-input-bg:     #fff;
+    --color-input-text:   #0f172a;
+    --color-accent:       #3b82f6;
+    --color-accent-hover: #2563eb;
+    --color-accent-light: #1d4ed8;
+    --color-green:        #16a34a;
+    --color-error-bg:     #fef2f2;
+    --color-error-border: #fca5a5;
+    --color-error-text:   #dc2626;
+    --color-btn-text:     #fff;
+}
+```
+
+Replace with:
+```css
+html[data-theme="light"] {
+    --color-bg:           #ffffff;
+    --color-surface:      #ffffff;
+    --color-surface-alt:  #f6f8fa;
+    --color-border:       #d0d7de;
+    --color-text:         #1f2328;
+    --color-text-heading: #0f172a;
+    --color-text-muted:   #57606a;
+    --color-text-subtle:  #57606a;
+    --color-text-faint:   #6e7781;
+    --color-input-bg:     #ffffff;
+    --color-input-text:   #1f2328;
+    /* Teal accent is low-contrast on white — use darkened variant for text/borders */
+    --color-accent:       #06d6a0;
+    --color-accent-hover: #0bb87a;
+    --color-accent-light: #0a7a5c;
+    --color-green:        #1a7f37;
+    --color-error-bg:     #fef2f2;
+    --color-error-border: #fca5a5;
+    --color-error-text:   #dc2626;
+    /* Light mode: teal bg on Calculate button still needs dark text */
+    --color-btn-text:     #0a1a12;
+}
+```
+
+**Why `--color-accent-light: #0a7a5c` in light mode:** `#06d6a0` on white is 2.2:1 contrast (fails WCAG AA). `#0a7a5c` on white is ~5.2:1 (passes AA). This token drives `.result-value`, `.tab-btn.active`, `.bin-net`, `.split-item`, `.vlsm-summary strong` — all benefit from the darker teal in light mode. Closes #261 and #270 simultaneously.
+
+- [ ] **Step 3: Update theme-color meta in layout.php (line 35)**
+
+Current:
+```php
+<meta name="theme-color"         content="#0F172A">
+```
+
+Change to:
+```php
+<meta name="theme-color"         content="#0d1117">
+```
+
+- [ ] **Step 4: Run CSS lint**
+
+```bash
+npm run lint:css
+# Expected: no errors
+```
+
+- [ ] **Step 5: Run release gate**
+
+```bash
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php; do php -l "$f"; done
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpunit
+npm run lint
+```
+
+Deploy and visually verify: dark mode background should be deeper navy `#0d1117` (not blue-grey), Calculate button should be teal, tab active should be teal, result values should be teal.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Subnet-Calculator/assets/app.css Subnet-Calculator/templates/layout.php
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+feat(v2.9.0): align color tokens with style guide — teal accent, GitHub-dark surfaces
+
+Dark: bg #0d1117, surface #161b22, border #21262d. Accent #06d6a0 teal across
+all interactive states. Light: accent-light #0a7a5c (WCAG AA 5.2:1 on white).
+--color-btn-text → #0a1a12 (dark text on teal bg). theme-color meta updated.
+Closes #250 #251 #261 #270.
+EOF
+)"
+```
+
+---
+
+## Task 4: Component Alignment — Buttons, Badge, Tool Triggers
+
+**Closes:** #256, #257, #258, #259, #260, #262
+**Skill:** Run `python3 skills/ui-ux-pro-max/scripts/search.py "button hover interaction feedback" --domain ux` before starting.
+
+**Files:**
+- Modify: `Subnet-Calculator/assets/app.css` — button, badge, tool-trigger sections
+
+**Note:** #259 (tab active), #262 (focus rings), and the result-value colour are resolved by Task 3's token changes. Verify they cascade correctly in this task; only add overrides if they don't.
+
+- [ ] **Step 1: Update Calculate button (app.css — `button[type="submit"]` block)**
+
+Current:
+```css
+button[type="submit"] {
+    flex: 1;
+    background: var(--color-accent);
+    border: none;
+    border-radius: 6px;
+    color: var(--color-btn-text);
+    cursor: pointer;
+    font-size: 0.95rem;
+    font-weight: 600;
+    padding: 0.65rem 1rem;
+    transition: background 0.15s;
+}
+button[type="submit"]:hover { background: var(--color-accent-hover); }
+```
+
+Replace with:
+```css
+button[type="submit"] {
+    flex: 1;
+    background: var(--color-accent);
+    border: none;
+    border-radius: 8px;
+    color: var(--color-btn-text);
+    cursor: pointer;
+    font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    padding: 0.72rem 1.6rem;
+    transition: all 0.15s ease;
+}
+button[type="submit"]:hover {
+    background: var(--color-accent-hover);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 20px rgb(6 214 160 / 30%);
+}
+button[type="submit"]:active { transform: translateY(0); box-shadow: none; }
+```
+
+- [ ] **Step 2: Update Reset/ghost button (app.css — `a.btn.reset` block)**
+
+Current:
+```css
+a.btn.reset {
+    flex: 1;
+    background: var(--color-input-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text-subtle);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.95rem;
+    font-weight: 600;
+    padding: 0.65rem 1rem;
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+}
+a.btn.reset:hover { background: var(--color-border); color: var(--color-text); }
+```
+
+Replace with:
+```css
+a.btn.reset {
+    flex: 1;
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    color: var(--color-text);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    padding: 0.72rem 1.6rem;
+    text-decoration: none;
+    transition: all 0.15s ease;
+}
+a.btn.reset:hover {
+    border-color: rgb(6 214 160 / 28%);
+    color: var(--color-accent);
+    transform: translateY(-1px);
+}
+a.btn.reset:active { transform: translateY(0); }
+```
+
+- [ ] **Step 3: Update version badge to teal pill (app.css — `.version` block)**
+
+Current (after Task 2):
+```css
+.version {
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.72rem;
+    font-weight: 400;
+    color: var(--color-text-faint);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.15rem 0.4rem;
+    letter-spacing: 0.04em;
+}
+```
+
+Replace with:
+```css
+.version {
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.72rem;
+    font-weight: 400;
+    color: var(--color-accent);
+    background: rgb(6 214 160 / 10%);
+    border: 1px solid rgb(6 214 160 / 28%);
+    border-radius: 999px;
+    padding: 0.28rem 0.8rem;
+    letter-spacing: 0.03em;
+}
+```
+
+- [ ] **Step 4: Update tool triggers (app.css — `.tool-trigger` block)**
+
+Current:
+```css
+.tool-trigger {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text-subtle);
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.4rem 0.7rem;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    white-space: nowrap;
+}
+.tool-trigger:hover { background: var(--color-border); color: var(--color-text); }
+.tool-trigger.active,
+.tool-trigger[aria-expanded="true"] {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: #fff;
+}
+.tool-trigger:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+```
+
+Replace with:
+```css
+.tool-trigger {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    color: var(--color-text-subtle);
+    cursor: pointer;
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.8rem;
+    font-weight: 400;
+    padding: 0.4rem 0.7rem;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    white-space: nowrap;
+}
+.tool-trigger:hover {
+    border-color: rgb(6 214 160 / 28%);
+    color: var(--color-accent);
+}
+.tool-trigger.active,
+.tool-trigger[aria-expanded="true"] {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: var(--color-btn-text);
+}
+.tool-trigger:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+```
+
+- [ ] **Step 5: Verify tab active state cascades from tokens**
+
+Open the dev server in a browser. Click the IPv6 and VLSM tabs. Confirm:
+- Active tab underline is teal (`#06d6a0`)
+- Active tab text is teal
+- Non-active tabs are muted grey
+
+If NOT cascading (tab still shows blue), add explicit override:
+```css
+.tab-btn.active { border-bottom-color: var(--color-accent); color: var(--color-accent); }
+```
+
+- [ ] **Step 6: Verify focus rings cascade from tokens**
+
+Tab through the form with keyboard. Confirm focus rings are teal, not blue. If any element still shows blue ring, add explicit override scoped to that element.
+
+- [ ] **Step 7: Run CSS lint and release gate**
+
+```bash
+npm run lint:css
+npm run lint:js
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php; do php -l "$f"; done
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpunit
+# Expected: all pass
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Subnet-Calculator/assets/app.css
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+feat(v2.9.0): align buttons, badge, and tool triggers with style guide
+
+Calculate button: teal, dark text, border-radius 8px, hover lift + shadow.
+Reset button: ghost style, teal hover border+text, lift. Version badge: teal
+Fira Code pill (border-radius 999px). Tool triggers: Fira Code, teal active,
+teal hover border. Closes #256 #257 #258 #259 #260 #262.
+EOF
+)"
+```
+
+---
+
+## Task 5: Mobile Layout Bugs
+
+**Closes:** #263, #264, #265, #266
+**Skill:** Run `python3 skills/ui-ux-pro-max/scripts/search.py "mobile responsive layout" --domain ux` before starting.
+
+**Files:**
+- Modify: `Subnet-Calculator/assets/app.css` — mobile breakpoints
+
+- [ ] **Step 1: Fix title wrapping on narrow screens (#263)**
+
+Inspect `.title-row` at 375px — the logo (48px) + gap (0.6rem) + h1 font "Subnet Calculator" (1.5rem/24px) + version badge + theme toggle causes wrapping.
+
+Add responsive h1 size at ≤480px. Find the `@media (width <= 480px)` block (currently has `.form-row` and `.split-list` rules) and add:
+
+```css
+@media (width <= 480px) {
+    .form-row { flex-direction: column; }
+    .split-list { grid-template-columns: 1fr; }
+    h1 { font-size: clamp(1.1rem, 5vw, 1.35rem); }
+    .logo { width: 36px; height: 36px; }
+}
+```
+
+After saving, open Chrome DevTools at 375px, verify the title row fits in one line.
+
+- [ ] **Step 2: Fix tool drawer ghost state on mobile (#264)**
+
+The drawer at `≤480px` uses `position: absolute; bottom: 0; height: 60vh` and slides up from below. When closed, `transform: translateY(100%)` moves it off-screen, but it may still extend beyond the `.card`'s `overflow-x: clip`.
+
+The `.card` currently has `overflow-x: clip`. Change to `overflow: clip` to also clip the vertical overflow and prevent the drawer from being visible below the card:
+
+Find `.card`:
+```css
+.card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 2rem;
+    width: 100%;
+    max-width: 560px;
+    position: relative;
+    overflow-x: clip;
+}
+```
+
+Change `overflow-x: clip;` to `overflow: clip;`.
+
+**Test:** Deploy to test server, open on 375px, scroll down — "TOOL ×" bar must NOT be visible when no drawer is open.
+
+- [ ] **Step 3: Fix share URL overflow (#265)**
+
+Find `.share-url`:
+```css
+.share-url {
+    color: var(--color-text-subtle);
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.75rem;
+    flex: 1;
+    word-break: break-all;
+    overflow-wrap: anywhere;
+    user-select: all;
+}
+```
+
+Change to:
+```css
+.share-url {
+    color: var(--color-text-subtle);
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.75rem;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    user-select: all;
+    min-width: 0;
+}
+```
+
+The `min-width: 0` is required for `flex: 1` items to respect `overflow: hidden` — without it, flex items don't shrink below their content size.
+
+**Test:** On 375px, the share URL should show truncated with `…` rather than wrapping.
+
+- [ ] **Step 4: Fix Reverse DNS Zone value wrapping (#266)**
+
+The `.result-value` class drives all result values. Rather than breaking ALL values, only break long ones. The `.result-value` class currently has `font-size: 0.9rem` with no word-break.
+
+Add `overflow-wrap: anywhere` specifically for narrow screens:
+
+Find the `@media (width <= 480px)` block (updated in Step 1) and add:
+```css
+@media (width <= 480px) {
+    .form-row { flex-direction: column; }
+    .split-list { grid-template-columns: 1fr; }
+    h1 { font-size: clamp(1.1rem, 5vw, 1.35rem); }
+    .logo { width: 36px; height: 36px; }
+    .result-value { overflow-wrap: anywhere; }
+}
+```
+
+- [ ] **Step 5: Test all mobile fixes at 375px via Playwright**
+
+```bash
+rsync -a --delete Subnet-Calculator/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+```
+
+Open test server at `https://dev-direct.seanmousseau.com/testing/sc/?ip=192.168.1.0&mask=24` on 375px viewport. Verify:
+1. Title "Subnet Calculator" fits on one line
+2. No drawer chrome visible below card
+3. Share URL shows truncated with ellipsis
+4. Reverse DNS Zone value breaks cleanly
+
+- [ ] **Step 6: Run release gate**
+
+```bash
+npm run lint:css && npm run lint:js
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php; do php -l "$f"; done
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpunit
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Subnet-Calculator/assets/app.css
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+fix(v2.9.0): mobile layout bugs — title wrap, drawer ghost, share URL, rdns overflow
+
+Clamp h1 and shrink logo at ≤480px (no title wrapping). overflow: clip on
+.card eliminates drawer ghost state below card. share-url uses text-overflow
+ellipsis. result-value uses overflow-wrap at ≤480px. Closes #263 #264 #265 #266.
+EOF
+)"
+```
+
+---
+
+## Task 6: Polish — Background Texture, Hover, Logo, Beacon
+
+**Closes:** #255, #267, #268, #271
+**Skill:** Run `python3 skills/ui-ux-pro-max/scripts/search.py "background texture depth visual hierarchy" --domain style` before starting.
+
+**Files:**
+- Modify: `Subnet-Calculator/assets/app.css` — body background, result hover
+- Verify: `Subnet-Calculator/assets/logo.png` and `logo.webp`
+
+- [ ] **Step 1: Add subtle teal grid background (#267)**
+
+Find `body` block in app.css. After `background: var(--color-bg);` add the grid:
+
+```css
+body {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+    background: var(--color-bg);
+    background-image:
+        linear-gradient(rgb(6 214 160 / 3%) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(6 214 160 / 3%) 1px, transparent 1px);
+    background-size: 48px 48px;
+    color: var(--color-text);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+}
+```
+
+Also add light-mode override so grid isn't too strong on white:
+```css
+html[data-theme="light"] body {
+    background-image:
+        linear-gradient(rgb(6 214 160 / 1.5%) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(6 214 160 / 1.5%) 1px, transparent 1px);
+}
+```
+
+Note: No `iframe` leak — the iframe `in-iframe` class sets `body { background: transparent }` via existing CSS, grid will not show in embedded contexts.
+
+Actually, confirm `.in-iframe body` handles this. Check existing rule:
+```css
+html.in-iframe body {
+    min-height: 0;
+    align-items: flex-start;
+}
+```
+There is no `background: transparent` for iframe mode. Add:
+```css
+html.in-iframe body {
+    min-height: 0;
+    align-items: flex-start;
+    background-image: none;
+}
+```
+
+- [ ] **Step 2: Update result row hover tint (#268)**
+
+Find:
+```css
+.result-row:hover { background: var(--color-border) !important; }
+```
+
+Replace with:
+```css
+.result-row:hover { background: rgb(6 214 160 / 4%) !important; }
+```
+
+Also update the focus-visible override on result rows:
+```css
+.result-row:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+    background: rgb(6 214 160 / 6%) !important;
+}
+```
+
+- [ ] **Step 3: Verify app header logo (#255)**
+
+The logo on the live prod site (`subnetcalculator.app`) was showing the old skeuomorphic calculator icon despite v2.8.1 being deployed. Verify the local asset first:
+
+```bash
+python3 -c "
+from PIL import Image
+import numpy as np
+img = Image.open('Subnet-Calculator/assets/logo.png').convert('RGB')
+arr = np.array(img)
+# Sample center pixel (should be teal or dark for SC monogram)
+print('Center pixel RGB:', arr[256, 256])
+# Sample top-left corner (background colour)
+print('Top-left RGB:', arr[10, 10])
+"
+```
+
+**If center pixel is predominantly dark (navy) with teal text areas** → SC monogram is correct, prod just needs cache purge.  
+**If center pixel is white/grey with dark grid** → old calculator icon still on disk; regenerate the SC monogram logo using the render scaffold at `docs/superpowers/logo-review.html` via Playwright screenshot.
+
+Log investigation result to Memory MCP:
+```
+add_observations("project:subnet-calculator", [
+  "#255: logo.png pixel sample result: [paste result]. Prod needs cache purge / file needs regen."
+])
+```
+
+Prod deployment cache purge (if logo is correct on disk):
+```bash
+# Deploy assets to prod (confirm with Sean before running on prod)
+# rsync -a --delete Subnet-Calculator/assets/ root@192.168.80.23:/docroot/assets/
+# Then purge Cloudflare cache via dashboard
+```
+
+**Wait for Sean's explicit confirmation before deploying to prod.**
+
+- [ ] **Step 4: Investigate Cloudflare beacon console error (#271)**
+
+Check layout.php for any `cloudflareinsights.com` script tag:
+```bash
+grep -n "cloudflare\|beacon\|insights" Subnet-Calculator/templates/layout.php
+grep -rn "cloudflare\|beacon\|insights" Subnet-Calculator/
+```
+
+If NOT found in app code → it's injected by the Cloudflare proxy. Resolve in Cloudflare Dashboard → Speed → Optimization → Cloudflare Web Analytics (disable it). No code change needed.
+
+If found in code → remove the script tag.
+
+Log resolution in Memory MCP. If it's Cloudflare-injected and requires dashboard access, document in issue #271 with the instruction and close after user confirms it's been disabled.
+
+- [ ] **Step 5: Run CSS lint and release gate**
+
+```bash
+npm run lint:css && npm run lint:js
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php; do php -l "$f"; done
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpunit
+# Expected: all pass
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Subnet-Calculator/assets/app.css
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+feat(v2.9.0): polish — teal grid background, tinted result hover, iframe background fix
+
+Static teal grid on body background (3% dark, 1.5% light). Result row hover
+uses teal-tinted rgb(6 214 160 / 4%) instead of border grey. iframe body
+suppresses background-image. Closes #267 #268.
+EOF
+)"
+```
+
+---
+
+## Task 7: Playwright Tests — Font Assertions & Snapshot Regeneration
+
+**Context:** The Docker E2E suite uses `SKIP_SNAPSHOTS=1` so visual regression snapshots are not compared during `make test-docker`. Snapshots must be regenerated manually via the dev server flow. Font assertions are new Playwright tests.
+
+**Files:**
+- Modify: `testing/scripts/playwright_test.py` — new font test group
+- Modify: `testing/snapshots/*.png` — regenerate all baselines
+
+- [ ] **Step 1: Add font-loading test group to playwright_test.py**
+
+Find the end of `test_theme_light_dark` function (around line 2900) and add a new test function after it:
+
+```python
+async def test_v290_typography(page: Page) -> None:
+    """
+    v2.9.0: Verify Space Grotesk, Plus Jakarta Sans, and Fira Code are loaded
+    and applied to the correct elements.
+    """
+    section("v2.9.0 — typography verification")
+
+    await navigate(page, APP_URL)
+
+    # h1 should use Space Grotesk
+    h1_font = await page.evaluate(
+        "() => getComputedStyle(document.querySelector('h1')).fontFamily"
+    )
+    assert_true(
+        "h1 uses Space Grotesk",
+        "Space Grotesk" in h1_font,
+        f"h1 fontFamily: {h1_font}"
+    )
+
+    # body should use Plus Jakarta Sans
+    body_font = await page.evaluate(
+        "() => getComputedStyle(document.body).fontFamily"
+    )
+    assert_true(
+        "body uses Plus Jakarta Sans",
+        "Plus Jakarta Sans" in body_font,
+        f"body fontFamily: {body_font}"
+    )
+
+    # inputs should use Fira Code (not JetBrains Mono)
+    input_font = await page.evaluate(
+        "() => getComputedStyle(document.querySelector('input[type=\"text\"]')).fontFamily"
+    )
+    assert_true(
+        "input uses Fira Code",
+        "Fira Code" in input_font,
+        f"input fontFamily: {input_font}"
+    )
+    assert_true(
+        "input does NOT use JetBrains Mono",
+        "JetBrains" not in input_font,
+        f"input fontFamily: {input_font}"
+    )
+
+    # Calculate button should have teal background (not blue)
+    calc_bg = await page.evaluate(
+        "() => getComputedStyle(document.querySelector('button[type=\"submit\"]')).backgroundColor"
+    )
+    # rgb(6, 214, 160) is teal #06d6a0
+    assert_true(
+        "Calculate button background is teal (not blue)",
+        "6, 214, 160" in calc_bg or "06d6a0" in calc_bg.lower(),
+        f"button bg: {calc_bg}"
+    )
+
+    # Version badge should have teal text
+    badge_color = await page.evaluate(
+        "() => getComputedStyle(document.querySelector('.version')).color"
+    )
+    assert_true(
+        "version badge text is teal",
+        "6, 214, 160" in badge_color,
+        f"badge color: {badge_color}"
+    )
+```
+
+Then register the function in the test runner list (find where all test functions are called in the `main` or `run_all_tests` block — add `test_v290_typography` to that list).
+
+- [ ] **Step 2: Run full Docker test suite — confirm no new failures**
+
+```bash
+make test-docker
+# Expected: all tests pass (SKIP_SNAPSHOTS=1 is set by docker-compose.yml so visual
+#           regression is skipped). New test_v290_typography should PASS.
+```
+
+If any tests fail, fix the root cause before proceeding. Do not mark failures as flaky.
+
+- [ ] **Step 3: Deploy to test server and regenerate snapshots**
+
+```bash
+rsync -a --delete Subnet-Calculator/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+scp testing/fixtures/iframe-test.html root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+```
+
+Then regenerate all snapshot baselines (must run against dev server, not Docker):
+```bash
+cd testing
+bash -c 'set -a; source ~/.claude/dev-secrets.env; set +a; \
+  UPDATE_SNAPSHOTS=1 APP_URL="https://dev-direct.seanmousseau.com/testing/sc/" \
+  python3 scripts/playwright_test.py 2>&1' | grep -E "visual:|ERROR|PASS|FAIL"
+```
+
+Expected: all `visual: baseline updated — <name>` messages, no FAILs.
+
+- [ ] **Step 4: Verify snapshot quality**
+
+Spot-check 3 updated snapshots (ipv4_result_1280, mobile, dark mode):
+```bash
+ls -lh testing/snapshots/
+# Verify file sizes are reasonable (> 50KB each — blank/white snapshots indicate an issue)
+open testing/snapshots/ipv4_result_1280.png  # or use any image viewer
+```
+
+The snapshots should show the new teal color scheme and correct fonts.
+
+- [ ] **Step 5: Run full Docker test suite again — confirm snapshots pass when not skipped**
+
+Run once without SKIP_SNAPSHOTS to verify new baselines match:
+```bash
+bash -c 'set -a; source ~/.claude/dev-secrets.env; set +a; \
+  APP_URL="https://dev-direct.seanmousseau.com/testing/sc/" \
+  python3 testing/scripts/playwright_test.py 2>&1' | grep -E "visual:|FAIL|PASS" | tail -20
+# Expected: visual tests all PASS (diff < 2%)
+```
+
+- [ ] **Step 6: Run release gate one more time**
+
+```bash
+make test-docker
+# Expected: 561+ assertions all pass
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add testing/scripts/playwright_test.py testing/snapshots/
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+test(v2.9.0): add typography assertions; regenerate visual regression baselines
+
+New test_v290_typography group: verifies Space Grotesk on h1, Plus Jakarta Sans
+on body, Fira Code on inputs, teal button background, teal version badge. All
+visual regression snapshots regenerated for new teal/dark-surface color scheme.
+EOF
+)"
+```
+
+---
+
+## Task 8: Documentation
+
+**Skill:** Invoke `documentation` skill before starting this task. All docs must be accurate before a PR is opened.
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `docs/config.md` (if any config-related UI changes)
+- Review: `docs/api.md`, `docs/sharing.md` — confirm no references to blue colours or JetBrains Mono
+
+- [ ] **Step 1: Invoke documentation skill**
+
+```
+/documentation
+```
+
+- [ ] **Step 2: Audit docs for stale visual references**
+
+```bash
+grep -rn "blue\|JetBrains\|#3b82f6\|system-ui\|#0f172a\|#1e293b" docs/ | grep -v ".git"
+# Review each match — update any that describe the old color scheme
+```
+
+- [ ] **Step 3: Add v2.9.0 CHANGELOG entry**
+
+At the top of the `[2.8.1]` block in `CHANGELOG.md`, insert:
+
+```markdown
+## [2.9.0] - 2026-04-25
+
+### Changed
+- **Typography** — app now uses Space Grotesk (headings, labels, section headers), Plus Jakarta Sans (body copy), and Fira Code (all monospace: inputs, result values, share bar, binary, VLSM). JetBrains Mono removed.
+- **Colour system** — accent changed from blue (`#3b82f6`) to teal (`#06d6a0`) across all interactive states (Calculate button, active tab, focus rings, tool triggers, result values). Dark mode surfaces aligned to GitHub-dark palette (`bg: #0d1117`, `surface: #161b22`, `border: #21262d`).
+- **Calculate button** — teal background, dark text `#0a1a12`, border-radius `8px`, hover lift with teal shadow
+- **Reset button** — ghost style (transparent bg, border), teal hover (border + text), lift on hover
+- **Version badge** — teal Fira Code pill (border-radius `999px`, teal-dim background)
+- **Tool trigger buttons** — Fira Code font, `border-radius: 8px`, teal active state with dark text
+- **Light mode** — teal accent darkened to `#0a7a5c` for WCAG AA contrast compliance on white (5.2:1)
+- **Body background** — subtle static teal grid (3% dark mode, 1.5% light mode) adds depth
+- **Result row hover** — teal-tinted background `rgb(6 214 160 / 4%)` replaces grey
+
+### Fixed
+- **Mobile: header title wrapping** — "Subnet Calculator" no longer wraps to two lines on 375px viewports; h1 font-size clamped and logo shrunk at `≤480px`
+- **Mobile: tool drawer ghost state** — drawer chrome no longer visible below card when drawer is closed; `overflow: clip` on `.card` contains the absolute-positioned bottom sheet
+- **Mobile: share URL overflow** — share bar URL now truncates with ellipsis instead of wrapping mid-URL
+- **Mobile: Reverse DNS Zone wrapping** — long reverse DNS values use `overflow-wrap: anywhere` at narrow viewports
+
+### Tests
+- New `test_v290_typography` Playwright test group verifies correct font families and teal color on key elements
+- All visual regression baselines regenerated for the new teal color scheme
+```
+
+- [ ] **Step 4: Update README.md downloads table**
+
+Find the downloads table and add a row for v2.9.0:
+```markdown
+| v2.9.0 | [subnet-calculator-2.9.0.tar.gz](releases/subnet-calculator-2.9.0.tar.gz) | UI/UX overhaul: teal accent, Space Grotesk/Plus Jakarta Sans/Fira Code fonts, mobile fixes |
+```
+
+- [ ] **Step 5: Review config.md for any visual references**
+
+```bash
+grep -n "color\|font\|blue\|theme" docs/config.md
+```
+
+Update any references that mention the old visual defaults (e.g. if config.md documents the dark theme's color values).
+
+- [ ] **Step 6: Run release gate**
+
+```bash
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/templates/layout.php; do php -l "$f"; done
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpunit
+npm run lint
+```
+
+- [ ] **Step 7: Commit docs**
+
+```bash
+git add CHANGELOG.md README.md docs/
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+docs(v2.9.0): changelog, README downloads table, docs visual reference audit
+
+CHANGELOG entry for all 22 issues addressed in v2.9.0. README downloads table
+updated. Docs audited for stale colour/font references.
+EOF
+)"
+```
+
+---
+
+## Task 9: Version Bump & Release Tarball
+
+**Files:**
+- Modify: `Subnet-Calculator/includes/config.php`
+- Create: `releases/subnet-calculator-2.9.0.tar.gz`
+
+- [ ] **Step 1: Bump version to 2.9.0**
+
+In `Subnet-Calculator/includes/config.php` change:
+```php
+$app_version = '2.8.1';
+```
+to:
+```php
+$app_version = '2.9.0';
+```
+
+- [ ] **Step 2: Run full release gate**
+
+```bash
+for f in Subnet-Calculator/includes/*.php Subnet-Calculator/api/v1/*.php \
+          Subnet-Calculator/api/v1/handlers/*.php Subnet-Calculator/templates/layout.php; do
+  php -l "$f"
+done
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpunit
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+npm run lint
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+make test-docker
+# ALL must pass
+```
+
+- [ ] **Step 3: Build release tarball**
+
+```bash
+cp CHANGELOG.md Subnet-Calculator/CHANGELOG.md
+tar -czf releases/subnet-calculator-2.9.0.tar.gz -C Subnet-Calculator .
+rm Subnet-Calculator/CHANGELOG.md
+# Verify
+ls -lh releases/subnet-calculator-2.9.0.tar.gz
+# Expected: file exists, > 500KB
+```
+
+- [ ] **Step 4: Update CLAUDE.md with any new conventions discovered**
+
+```bash
+# Open CLAUDE.md and add any non-obvious pitfalls discovered during v2.9.0 work:
+# - Note that --color-btn-text must stay dark (#0a1a12) for teal buttons (not white)
+# - Note that --color-bg is used by iframe bg-override JS — do not rename
+# - Note that overflow: clip (not overflow-x: clip) is needed to contain bottom-sheet drawer
+```
+
+- [ ] **Step 5: Commit version bump and tarball**
+
+```bash
+git add Subnet-Calculator/includes/config.php releases/subnet-calculator-2.9.0.tar.gz .claude/ CLAUDE.md
+git -c user.name="Sean Mousseau" -c user.email="sean@seanmousseau.com" \
+  commit -m "$(cat <<'EOF'
+chore(v2.9.0): bump version to 2.9.0, build release tarball, update CLAUDE.md
+
+CLAUDE.md updated with v2.9.0 conventions: dark btn text for teal bg, --color-bg
+iframe API invariant, overflow:clip for drawer containment.
+EOF
+)"
+```
+
+- [ ] **Step 6: Update Memory MCP**
+
+```
+add_observations("project:subnet-calculator", [
+  "v2.9.0 released. 22 issues closed (#250-#271). Teal accent, Space Grotesk/Plus Jakarta Sans/Fira Code fonts, GitHub-dark surfaces. 4 mobile bug fixes. Visual regression baselines regenerated."
+])
+```
+
+---
+
+## Task 10: Push & PR — **REQUIRES EXPLICIT USER APPROVAL**
+
+**STOP.** Do not push or create a PR until Sean explicitly approves.
+
+Present the following to Sean for approval:
+1. Branch: `feature/v2.9.0-ui-style-guide`
+2. Commits: show `git log --oneline main..HEAD`
+3. Issues to close: #250–#271 (22 issues) + milestone #17
+4. Any unresolved items (note here if #255 or #271 need prod action)
+
+- [ ] **Step 1: Wait for explicit "push it" / "create the PR" instruction from Sean**
+
+- [ ] **Step 2: Push branch (only after approval)**
+
+```bash
+git push -u origin feature/v2.9.0-ui-style-guide
+# Verify commits landed on GitHub before proceeding
+gh api repos/seanmousseau/Subnet-Calculator/branches/feature/v2.9.0-ui-style-guide \
+  --jq '.commit.sha'
+# Compare with: git rev-parse HEAD
+```
+
+- [ ] **Step 3: Create PR (only after push confirmed)**
+
+```bash
+gh pr create \
+  --title "v2.9.0 — UI/UX & style guide adoption" \
+  --base main \
+  --body "$(cat <<'EOF'
+## Summary
+
+- **22 issues closed** (#250–#271) across 5 phases: fonts, color tokens, components, mobile bugs, polish
+- **Typography:** Space Grotesk (headings/labels), Plus Jakarta Sans (body), Fira Code (mono). JetBrains Mono removed.
+- **Colors:** Teal `#06d6a0` accent throughout; GitHub-dark surfaces (`#0d1117`/`#161b22`/`#21262d`); light-mode WCAG AA teal `#0a7a5c`
+- **Components:** Calculate button (teal, dark text, lift hover), Reset (ghost style), version badge (teal pill), tool triggers (Fira Code, teal active)
+- **Mobile fixes:** title wrapping (#263), drawer ghost state (#264), share URL ellipsis (#265), RDNS overflow (#266)
+- **Polish:** teal grid background (#267), tinted result hover (#268)
+
+## Test Plan
+- [ ] `make test-docker` passes (561+ assertions)
+- [ ] New `test_v290_typography` group passes
+- [ ] Visual regression baselines regenerated and confirmed
+- [ ] Both light and dark modes visually verified
+- [ ] Tested at 375px, 768px, 1280px, 1440px
+
+## Notes
+- #255 (logo on prod): may need Cloudflare cache purge after deployment
+- #271 (Cloudflare beacon): requires Cloudflare dashboard action — documented in issue
+
+🤖 Generated with [Claude Code](https://claude.ai/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 11: Merge & Close — **REQUIRES EXPLICIT USER APPROVAL**
+
+**STOP.** Do not merge until Sean explicitly approves the PR.
+
+- [ ] **Step 1: Wait for Sean's explicit merge approval**
+
+- [ ] **Step 2: Merge (only after approval)**
+
+```bash
+gh pr merge <PR-NUMBER> --squash --delete-branch
+# Verify merge
+gh api repos/seanmousseau/Subnet-Calculator/branches/main --jq '.commit.sha'
+```
+
+- [ ] **Step 3: Close all 22 issues**
+
+```bash
+for issue in 250 251 252 253 254 255 256 257 258 259 260 261 262 263 264 265 266 267 268 269 270 271; do
+  gh issue close $issue --repo seanmousseau/Subnet-Calculator \
+    --comment "Closed by v2.9.0 — merged in PR #<PR-NUMBER>"
+done
+```
+
+- [ ] **Step 4: Close v2.9.0 milestone**
+
+```bash
+gh api repos/seanmousseau/Subnet-Calculator/milestones/17 \
+  --method PATCH --field state="closed"
+```
+
+- [ ] **Step 5: Create GitHub release**
+
+```bash
+gh release create v2.9.0 releases/subnet-calculator-2.9.0.tar.gz \
+  --title "v2.9.0 — UI/UX & Style Guide Adoption" \
+  --notes "$(sed -n '/## \[2.9.0\]/,/## \[2.8.1\]/p' CHANGELOG.md | head -n -1)"
+```
+
+- [ ] **Step 6: Deploy to prod** (requires explicit Sean approval — separate from merge approval)
+
+```bash
+# Confirm with Sean before running
+# rsync -a --delete Subnet-Calculator/ root@192.168.80.23:/docroot/
+# Then purge Cloudflare cache
+```
+
+- [ ] **Step 7: Final Memory MCP update**
+
+```
+add_observations("project:subnet-calculator", [
+  "v2.9.0 merged and released YYYY-MM-DD. Milestone #17 closed. 22 issues #250-#271 closed. Prod deployment pending Cloudflare cache purge for logo (#255). Cloudflare beacon (#271) requires dashboard action."
+])
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Issue | Task | Covered |
+|-------|------|---------|
+| #250 accent colour | Task 3 | ✅ |
+| #251 dark surfaces | Task 3 | ✅ |
+| #252 Space Grotesk | Tasks 1, 2 | ✅ |
+| #253 Plus Jakarta Sans | Tasks 1, 2 | ✅ |
+| #254 Fira Code | Tasks 1, 2 | ✅ |
+| #255 logo verify | Task 6 | ✅ |
+| #256 Calculate button | Task 4 | ✅ |
+| #257 Reset button | Task 4 | ✅ |
+| #258 version badge | Tasks 2, 4 | ✅ |
+| #259 tab active | Task 4 | ✅ (cascade verify) |
+| #260 tool triggers | Task 4 | ✅ |
+| #261 result values | Task 3 | ✅ (cascade) |
+| #262 focus rings | Task 4 | ✅ (cascade verify) |
+| #263 mobile title | Task 5 | ✅ |
+| #264 drawer ghost | Task 5 | ✅ |
+| #265 share URL | Task 5 | ✅ |
+| #266 rdns wrap | Task 5 | ✅ |
+| #267 bg texture | Task 6 | ✅ |
+| #268 result hover | Task 6 | ✅ |
+| #269 results header | Task 2 | ✅ |
+| #270 light contrast | Task 3 | ✅ (via --color-accent-light) |
+| #271 beacon error | Task 6 | ✅ (investigate + document) |
+
+**Placeholder scan:** No TBDs, TODOs, or "similar to above" patterns found.
+
+**Type consistency:** CSS class names, token names, and file paths are consistent across all tasks.

--- a/docs/superpowers/plans/2026-04-27-v2.10.0-release.md
+++ b/docs/superpowers/plans/2026-04-27-v2.10.0-release.md
@@ -1,0 +1,1273 @@
+# v2.10.0 — Docs / Polish Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship v2.10.0 — a docs-and-polish release that retires the legacy GitHub Pages docs URL, adds discoverability (sitemap + canonical audit), introduces a dark-mode-aware print stylesheet and a Wildcard ↔ CIDR converter, and lands a PHP 8.4 compatibility / CI-matrix pass.
+
+**Architecture:** Single-branch release (`release/v2.10.0` cut from `dev`) → PR `dev → main`. Each milestone issue is implemented behind its own commit so reverts are surgical. UI work uses the `ui-ux-pro-max` skill; documentation uses the `documentation` skill. The release gate (PHPUnit, PHPStan L9 @ 512M, PHPCS, ESLint, Stylelint, Spectral, semgrep, `make test-docker`) MUST be green locally before any push or PR. **All test failures must be resolved — never dismissed as flake.**
+
+**Tech Stack:** PHP 8.1+ (target 8.4), GMP, PHPUnit 11, PHPStan L9, PHPCS PSR-12, ESLint, Stylelint, Spectral (OpenAPI 3.1), Semgrep, Playwright (Docker), MkDocs Material.
+
+**Milestone issues (GH milestone #19, v2.10.0):**
+- #284 — Update all docs links to https://docs.subnetcalculator.app/ (`documentation`)
+- #285 — Add sitemap.xml + canonical link audit for new docs domain (`enhancement`)
+- #287 — PHP 8.4 compatibility pass + CI matrix (`enhancement`)
+- #290 — OpenAPI `externalDocs.url` bump to `docs.subnetcalculator.app` (`enhancement`, pairs with #284)
+- #291 — Dark-mode print stylesheet (`enhancement`)
+- #292 — Wildcard mask ↔ CIDR converter (`enhancement`)
+
+**Outstanding issues review:**
+- `gh issue list --state open --limit 100` shows zero issues without a milestone. Nothing to triage in.
+- Open issues in v2.11.0 (#293–#296), v2.12.0 (#297–#299), v3.0.0 (#300–#302) are correctly scoped beyond this release.
+- All prior milestones (v1.x → v2.9.1) are already closed in GitHub. v2.9.2 was shipped as a tag/release without a milestone, which is fine — no cleanup required.
+
+**Stale local branches to delete (remote already pruned):**
+- `docs/v2.9.0-version-bump`
+- `feature/v2.8.0-tool-drawer`
+- `fix/logo-cache-bust`
+- `fix/v2.9.1`
+
+**Release rules (non-negotiable, from CLAUDE.md + memory):**
+1. Use `git -c user.email=sean@seanmousseau.com -c user.name="Sean Mousseau"` on every commit (or rely on existing repo config — verify with `git config user.email`).
+2. PHPStan **must** be invoked with `--memory-limit=512M`.
+3. Verify pushes via `gh api`/`gh pr` — `git push` output through the local proxy is not authoritative.
+4. **Never** open or merge a PR without explicit Sean approval. Stop and ask.
+5. **Never** justify a failing test. Either the app is wrong or the test is wrong — fix it.
+6. Update Memory MCP (`mcp__MCP_DOCKER__add_observations`) at every meaningful checkpoint.
+
+---
+
+## File Structure
+
+Files this plan will create or modify:
+
+| Path | Responsibility | Tasks |
+|---|---|---|
+| `README.md` | Replace stale `seanmousseau.github.io/Subnet-Calculator` link; add v2.10.0 row to downloads table | 1, 9 |
+| `Subnet-Calculator/templates/layout.php` | Replace footer Documentation URL | 1 |
+| `testing/scripts/playwright_test.py` | Replace asserted docs URL in `test_docs_footer_link`; add wildcard converter UI tests; add print-CSS test; bump expected version string | 1, 4, 5, 8 |
+| `Subnet-Calculator/api/openapi.yaml` | Bump `externalDocs.url`; bump `info.version` to 2.10.0 | 2, 9 |
+| `Subnet-Calculator/sitemap.xml` | New static sitemap (root + canonical) | 3 |
+| `Subnet-Calculator/.htaccess` | Ensure `sitemap.xml` is publicly served (it already is by default; verify no rule blocks it) | 3 |
+| `Subnet-Calculator/robots.txt` | Add `Sitemap: https://subnetcalculator.app/sitemap.xml` | 3 |
+| `Subnet-Calculator/assets/app.css` | Dark-mode print path (force light surfaces, dark text); responsive print typography | 4 |
+| `Subnet-Calculator/includes/functions-util.php` | New helpers `wildcard_to_cidr(string)` and `cidr_to_wildcard(string)` (pure, typed) | 5 |
+| `Subnet-Calculator/api/v1/handlers/wildcard.php` | New REST handler `GET /api/v1/wildcard?value=…` (bidirectional) | 5 |
+| `Subnet-Calculator/api/v1/index.php` | Register `wildcard` route | 5 |
+| `Subnet-Calculator/templates/layout.php` | Add Wildcard ↔ CIDR tool drawer entry | 5 |
+| `Subnet-Calculator/assets/app.js` | Wire wildcard converter UI (form, copy buttons, validation) | 5 |
+| `testing/unit/WildcardTest.php` | New PHPUnit tests for both helpers | 5 |
+| `.github/workflows/ci.yml` | New CI matrix: PHP 8.1 / 8.2 / 8.3 / 8.4 (PHPUnit + PHPStan + lint) | 6 |
+| `Subnet-Calculator/includes/config.php` | Bump `$app_version` → `2.10.0` | 9 |
+| `mkdocs.yml` | Bump `extra.version` → `"2.10.0"` | 7, 9 |
+| `docs/index.md` | Bump tarball filename to `2.10.0`; refresh feature list if new | 7, 9 |
+| `docs/wildcard.md` | New page documenting wildcard converter (UI + API) | 7 |
+| `docs/api.md` | Add `GET /api/v1/wildcard` reference | 7 |
+| `docs/print.md` | New short page describing print behaviour and dark-mode forced-light decision | 7 |
+| `CHANGELOG.md` | New `[2.10.0]` section | 7, 9 |
+| `CLAUDE.md` | Update PHPUnit count if changed; add Wildcard helper note; add PHP-8.4 CI note | 7 |
+| `releases/subnet-calculator-2.10.0.tar.gz` | Build artifact | 9 |
+
+---
+
+## Task 0: Pre-release housekeeping
+
+**Goal:** Clean working tree, fresh release branch off `dev`, stale local branches deleted, memory MCP seeded with the v2.10.0 release entity.
+
+**Files:**
+- Modify: local git state only
+
+- [ ] **Step 1: Verify clean baseline**
+
+```bash
+cd /Users/seanmousseau/dev/Subnet-Calculator
+git status --short
+git fetch --prune
+git checkout dev
+git pull --ff-only origin dev
+```
+
+Expected: branch `dev` matches `origin/dev` at commit `61efe9b` (or newer if main was synced). Untracked screenshots and `.playwright-mcp/` are present and tolerated (they are gitignored or unrelated to the release).
+
+- [ ] **Step 2: Delete stale local branches with `[gone]` upstream**
+
+```bash
+git branch -D docs/v2.9.0-version-bump feature/v2.8.0-tool-drawer fix/logo-cache-bust fix/v2.9.1
+git branch -vv
+```
+
+Expected: only `dev` and `main` remain locally. If any branch fails to delete because it has unmerged work that is not on `main`, STOP and ask Sean before forcing.
+
+- [ ] **Step 3: Verify GitHub milestone state**
+
+```bash
+gh api 'repos/seanmousseau/Subnet-Calculator/milestones?state=open' --jq '.[] | {number,title,open_issues,closed_issues}'
+gh issue list --milestone "v2.10.0" --state open --json number,title --jq '.[] | "\(.number) \(.title)"'
+```
+
+Expected: only v2.10.0–v3.0.0 are open; v2.10.0 lists exactly issues #284, #285, #287, #290, #291, #292. If the list differs, STOP and reconcile with Sean before proceeding.
+
+- [ ] **Step 4: Cut the release branch**
+
+```bash
+git checkout -b release/v2.10.0 dev
+```
+
+- [ ] **Step 5: Seed Memory MCP with the release entity**
+
+Use `mcp__MCP_DOCKER__create_entities` to create:
+
+```json
+{
+  "entities": [{
+    "name": "project:subnet-calculator:release:v2.10.0",
+    "entityType": "release",
+    "observations": [
+      "v2.10.0 release branch cut from dev at commit <SHORT_SHA> on 2026-04-27",
+      "Scope (6 issues): #284 docs links, #285 sitemap+canonical, #287 PHP 8.4 + CI matrix, #290 OpenAPI externalDocs URL, #291 dark-mode print stylesheet, #292 wildcard ↔ CIDR converter",
+      "Theme: docs/polish — no breaking changes, no schema changes, no new third-party deps in app runtime"
+    ]
+  }]
+}
+```
+
+Then `mcp__MCP_DOCKER__create_relations`:
+
+```json
+{"relations":[{"from":"project:subnet-calculator","to":"project:subnet-calculator:release:v2.10.0","relationType":"has-release"}]}
+```
+
+- [ ] **Step 6: Commit nothing yet — Task 0 is repo state only**
+
+No commit. Move to Task 1.
+
+---
+
+## Task 1: Issue #284 — Update all docs links to https://docs.subnetcalculator.app/
+
+**Files:**
+- Modify: `README.md` (line ~17)
+- Modify: `Subnet-Calculator/templates/layout.php` (footer Documentation link — search for `seanmousseau.github.io`)
+- Modify: `testing/scripts/playwright_test.py` (assertion in `test_docs_footer_link` — search for `seanmousseau.github.io`)
+
+- [ ] **Step 1: Confirm exact tracked occurrences**
+
+```bash
+git ls-files | xargs grep -ln "seanmousseau\.github\.io/Subnet-Calculator"
+```
+
+Expected: exactly three files — `README.md`, `Subnet-Calculator/templates/layout.php`, `testing/scripts/playwright_test.py`. If others appear, include them.
+
+- [ ] **Step 2: Update `README.md` link** (use Edit tool, not sed)
+
+Replace `https://seanmousseau.github.io/Subnet-Calculator/` with `https://docs.subnetcalculator.app/` in the header link block.
+
+- [ ] **Step 3: Update `Subnet-Calculator/templates/layout.php`**
+
+Replace `https://seanmousseau.github.io/Subnet-Calculator/` with `https://docs.subnetcalculator.app/`.
+
+- [ ] **Step 4: Update Playwright test expectation in `testing/scripts/playwright_test.py`**
+
+Replace the asserted URL in `test_docs_footer_link`. Find the existing assertion line (grep for `seanmousseau.github.io`) and update it to `https://docs.subnetcalculator.app/`.
+
+- [ ] **Step 5: Verify no stale references remain**
+
+```bash
+git ls-files | xargs grep -ln "seanmousseau\.github\.io/Subnet-Calculator" || echo "CLEAN"
+```
+
+Expected output: `CLEAN`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md Subnet-Calculator/templates/layout.php testing/scripts/playwright_test.py
+git commit -m "docs: update all docs links to https://docs.subnetcalculator.app/ (closes #284)"
+```
+
+- [ ] **Step 7: Memory MCP update**
+
+```
+mcp__MCP_DOCKER__add_observations on project:subnet-calculator:release:v2.10.0 →
+  "Task 1 complete: #284 closed in commit <SHORT_SHA>. README/layout.php/playwright_test.py now point at docs.subnetcalculator.app."
+```
+
+---
+
+## Task 2: Issue #290 — OpenAPI `externalDocs.url` bump
+
+**Files:**
+- Modify: `Subnet-Calculator/api/openapi.yaml` (`externalDocs.url`)
+
+- [ ] **Step 1: Locate `externalDocs` block**
+
+```bash
+grep -n "externalDocs" Subnet-Calculator/api/openapi.yaml
+```
+
+- [ ] **Step 2: Update URL with Edit tool**
+
+Set `externalDocs.url` to `https://docs.subnetcalculator.app/api/`. Keep the existing `description` field. Do NOT bump `info.version` here — that happens in Task 9.
+
+- [ ] **Step 3: Spectral lint MUST pass with zero new errors**
+
+```bash
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+
+Expected: 0 errors. The 24 pre-existing warnings remain — do not silence them in this task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Subnet-Calculator/api/openapi.yaml
+git commit -m "docs(api): bump externalDocs.url to docs.subnetcalculator.app (closes #290)"
+```
+
+- [ ] **Step 5: Memory MCP update**
+
+Add observation: `"Task 2 complete: #290 closed in commit <SHORT_SHA>. OpenAPI externalDocs now docs.subnetcalculator.app/api/."`
+
+---
+
+## Task 3: Issue #285 — sitemap.xml + canonical audit
+
+**Files:**
+- Create: `Subnet-Calculator/sitemap.xml`
+- Modify: `Subnet-Calculator/robots.txt`
+- Verify: `Subnet-Calculator/.htaccess` (no rule blocks `sitemap.xml`)
+- Verify: `Subnet-Calculator/templates/layout.php` (`<link rel="canonical">` already present and correct)
+- Test: add Playwright assertion that `/sitemap.xml` returns 200 + `application/xml`
+
+- [ ] **Step 1: Confirm canonical tag is healthy**
+
+```bash
+grep -n 'rel="canonical"' Subnet-Calculator/templates/layout.php
+grep -n '\$canonical_url' Subnet-Calculator/includes/config.php Subnet-Calculator/includes/request.php
+```
+
+Expected: tag is rendered with `$canonical_url`, computed in `request.php` against `config.php`'s `$canonical_url` default. No code changes needed unless the default is missing.
+
+- [ ] **Step 2: Audit MkDocs canonical**
+
+```bash
+grep -n "site_url" mkdocs.yml
+```
+
+Expected: `site_url: https://docs.subnetcalculator.app/` is set. MkDocs Material auto-emits `<link rel="canonical">` from `site_url`. No change needed.
+
+- [ ] **Step 3: Create `Subnet-Calculator/sitemap.xml`**
+
+Static sitemap covering app routes that produce useful content (the app is single-page, so the canonical entry plus tab-specific share URLs are appropriate). Use Write tool with this content:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://subnetcalculator.app/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://subnetcalculator.app/?tab=ipv4</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://subnetcalculator.app/?tab=ipv6</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://subnetcalculator.app/?tab=vlsm</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://docs.subnetcalculator.app/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>
+```
+
+- [ ] **Step 4: Update `Subnet-Calculator/robots.txt`**
+
+Read the current file, append (or insert at the end):
+
+```
+Sitemap: https://subnetcalculator.app/sitemap.xml
+```
+
+Use Edit tool to add the line; do not duplicate if it already exists.
+
+- [ ] **Step 5: Verify `.htaccess` does not block `sitemap.xml`**
+
+```bash
+grep -n "sitemap\|<Files\|Deny\|Require" Subnet-Calculator/.htaccess
+```
+
+Expected: no rule blocks `sitemap.xml`. The existing rules block `config.php`, `*.tar.gz`, and `data/` — none affect `sitemap.xml`. No change needed.
+
+- [ ] **Step 6: Add Playwright assertions**
+
+In `testing/scripts/playwright_test.py`, add a new test group `test_sitemap_and_robots` that:
+
+```python
+def test_sitemap_and_robots(page):
+    # /sitemap.xml returns 200 with XML body containing https://subnetcalculator.app/
+    response = page.request.get(f"{BASE_URL}/sitemap.xml")
+    assert response.status == 200, f"sitemap.xml returned {response.status}"
+    body = response.text()
+    assert "<urlset" in body and "subnetcalculator.app" in body
+    # /robots.txt advertises the sitemap
+    robots = page.request.get(f"{BASE_URL}/robots.txt").text()
+    assert "Sitemap: https://subnetcalculator.app/sitemap.xml" in robots
+```
+
+(Match the project's existing test-style conventions — group with the surrounding tests if the file is structured differently.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Subnet-Calculator/sitemap.xml Subnet-Calculator/robots.txt testing/scripts/playwright_test.py
+git commit -m "feat(seo): add sitemap.xml + canonical audit (closes #285)"
+```
+
+- [ ] **Step 8: Memory MCP update**
+
+Add observation: `"Task 3 complete: #285 closed in commit <SHORT_SHA>. /sitemap.xml + robots.txt Sitemap directive shipped; canonical tag and mkdocs site_url verified correct."`
+
+---
+
+## Task 4: Issue #291 — Dark-mode print stylesheet
+
+**Skill: invoke `ui-ux-pro-max` before designing the print path.** Ask it specifically for: "Print CSS strategy for a dark-themed web app where the user is in dark mode but printing to white paper. Goal: readable, ink-efficient, preserves brand identity (teal accent), forces light surfaces and dark ink, keeps result-table structure intact, no background fills."
+
+**Files:**
+- Modify: `Subnet-Calculator/assets/app.css` (existing `@media print` block at line ~1023)
+- Test: `testing/scripts/playwright_test.py` (extend or add `test_print_stylesheet`)
+
+- [ ] **Step 1: Invoke `ui-ux-pro-max` skill** with the brief above and capture its concrete CSS recommendations as a short comment block at the top of the new print rules.
+
+- [ ] **Step 2: Review existing print block**
+
+Read `Subnet-Calculator/assets/app.css` from line 1020 to ~1100 (or whatever the block spans). Document the current rules in a short note in your task scratch.
+
+- [ ] **Step 3: Write the failing Playwright test first**
+
+Add a `test_print_stylesheet_dark_mode` group that:
+
+```python
+def test_print_stylesheet_dark_mode(page):
+    page.goto(BASE_URL)
+    # Force dark theme
+    page.evaluate("document.documentElement.setAttribute('data-theme','dark')")
+    # Emulate print media
+    page.emulate_media(media="print")
+    # Body background must be effectively white in print emulation
+    body_bg = page.evaluate("getComputedStyle(document.body).backgroundColor")
+    assert body_bg in ("rgb(255, 255, 255)", "rgba(0, 0, 0, 0)"), \
+        f"print body bg should be white/transparent in dark mode, got {body_bg}"
+    # Card text colour must be dark (not the dark-theme white-on-navy)
+    card_color = page.evaluate(
+        "getComputedStyle(document.querySelector('main#main-content')).color"
+    )
+    # Dark text — accept anything with all RGB channels < 80
+    import re
+    m = re.match(r"rgb\((\d+), (\d+), (\d+)\)", card_color)
+    assert m, f"unexpected card color format: {card_color}"
+    r, g, b = (int(x) for x in m.groups())
+    assert max(r, g, b) < 80, f"print card color too light: {card_color}"
+```
+
+- [ ] **Step 4: Run the test, expect FAIL**
+
+```bash
+make test-docker
+```
+
+Expected: the new test fails because the existing print block does not override `data-theme="dark"` tokens.
+
+- [ ] **Step 5: Implement the print rules**
+
+Inside the existing `@media print { ... }` block in `app.css`, add (or extend) rules along the lines below. Adapt the exact selectors/tokens to match the recommendations from `ui-ux-pro-max` and the project's existing token names (verify in `app.css` — the canonical tokens are `--color-bg`, `--color-surface`, `--color-text`, `--color-border`, `--color-accent`).
+
+```css
+@media print {
+  /* Force light surfaces regardless of data-theme */
+  html[data-theme="dark"],
+  html[data-theme="dark"] body {
+    background: #ffffff !important;
+    color: #0a1a12 !important;
+  }
+  html[data-theme="dark"] main#main-content,
+  html[data-theme="dark"] .card,
+  html[data-theme="dark"] .result,
+  html[data-theme="dark"] table,
+  html[data-theme="dark"] th,
+  html[data-theme="dark"] td {
+    background: #ffffff !important;
+    color: #0a1a12 !important;
+    border-color: #cbd5e1 !important;
+  }
+  /* Keep teal accent visible on paper but at print-safe weight */
+  html[data-theme="dark"] :is(a, .badge, .accent) {
+    color: #0a8f6b !important;
+  }
+  /* Hide chrome that wastes ink */
+  html[data-theme="dark"] .theme-toggle,
+  html[data-theme="dark"] .tool-drawer,
+  html[data-theme="dark"] .copy-btn { display: none !important; }
+}
+```
+
+(Final selector list and ink-safe colour values come from the `ui-ux-pro-max` consult in Step 1 — do not skip the consult.)
+
+- [ ] **Step 6: Re-run the test, expect PASS**
+
+```bash
+make test-docker
+```
+
+Expected: `test_print_stylesheet_dark_mode` passes. If any other test breaks, fix the regression — never silence the failure.
+
+- [ ] **Step 7: Manual verification**
+
+In a browser at `https://dev-direct.seanmousseau.com/claude/subnet-calc/` (or local `php -S`), toggle dark mode → File → Print → Preview. Confirm white paper, dark ink, no missing content. Capture a screenshot to attach to the PR.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Subnet-Calculator/assets/app.css testing/scripts/playwright_test.py
+git commit -m "feat(css): dark-mode-aware print stylesheet (closes #291)"
+```
+
+- [ ] **Step 9: Memory MCP update**
+
+Add observation: `"Task 4 complete: #291 closed in commit <SHORT_SHA>. Print path forces #ffffff bg + #0a1a12 ink under data-theme=dark; teal accent dimmed to #0a8f6b for paper; verified manually + Playwright."`
+
+---
+
+## Task 5: Issue #292 — Wildcard mask ↔ CIDR converter
+
+**Skill: invoke `ui-ux-pro-max` before designing the drawer entry.** Ask it specifically for: "Bidirectional converter form for a tool drawer (mobile bottom-sheet on <481px). Single text input that accepts either a wildcard mask (e.g. `0.0.0.255`) or a CIDR (e.g. `/24` or `24`), single Convert button, two read-only result fields with Copy buttons. Match the existing tool-drawer aesthetic — Fira Code mono inputs, teal accent, rounded 8px controls. No new icons unless absolutely necessary."
+
+**Files:**
+- Create: `Subnet-Calculator/api/v1/handlers/wildcard.php`
+- Modify: `Subnet-Calculator/api/v1/index.php` (route registration)
+- Modify: `Subnet-Calculator/api/openapi.yaml` (new path `/wildcard`)
+- Modify: `Subnet-Calculator/includes/functions-util.php` (add `wildcard_to_cidr`, `cidr_to_wildcard`)
+- Modify: `Subnet-Calculator/templates/layout.php` (drawer entry)
+- Modify: `Subnet-Calculator/assets/app.js` (controller wiring)
+- Modify: `Subnet-Calculator/assets/app.css` (any new rules — minimise; reuse existing drawer classes)
+- Create: `testing/unit/WildcardTest.php` (PHPUnit)
+- Modify: `testing/scripts/playwright_test.py` (UI test group)
+
+- [ ] **Step 1: Invoke `ui-ux-pro-max`** with the brief above. Capture concrete component spec: input layout, label copy, error states, copy-button interaction.
+
+- [ ] **Step 2: Write failing PHPUnit tests first** — create `testing/unit/WildcardTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../Subnet-Calculator/includes/functions-util.php';
+
+final class WildcardTest extends TestCase
+{
+    public function testCidrToWildcardSlash24(): void
+    {
+        $this->assertSame('0.0.0.255', cidr_to_wildcard('/24'));
+    }
+
+    public function testCidrToWildcardBareNumber(): void
+    {
+        $this->assertSame('0.0.0.255', cidr_to_wildcard('24'));
+    }
+
+    public function testCidrToWildcardSlash16(): void
+    {
+        $this->assertSame('0.0.255.255', cidr_to_wildcard('/16'));
+    }
+
+    public function testCidrToWildcardSlash32(): void
+    {
+        $this->assertSame('0.0.0.0', cidr_to_wildcard('/32'));
+    }
+
+    public function testCidrToWildcardSlash0(): void
+    {
+        $this->assertSame('255.255.255.255', cidr_to_wildcard('/0'));
+    }
+
+    public function testWildcardToCidrZero255(): void
+    {
+        $this->assertSame('/24', wildcard_to_cidr('0.0.0.255'));
+    }
+
+    public function testWildcardToCidrAllZero(): void
+    {
+        $this->assertSame('/32', wildcard_to_cidr('0.0.0.0'));
+    }
+
+    public function testWildcardToCidrAllOnes(): void
+    {
+        $this->assertSame('/0', wildcard_to_cidr('255.255.255.255'));
+    }
+
+    public function testWildcardToCidrRejectsNonContiguous(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        wildcard_to_cidr('0.0.255.0');
+    }
+
+    public function testCidrToWildcardRejectsOutOfRange(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        cidr_to_wildcard('/33');
+    }
+
+    public function testWildcardToCidrRejectsBadOctet(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        wildcard_to_cidr('256.0.0.0');
+    }
+}
+```
+
+- [ ] **Step 3: Run PHPUnit, expect failures**
+
+```bash
+vendor/bin/phpunit testing/unit/WildcardTest.php
+```
+
+Expected: every test fails with "function not defined".
+
+- [ ] **Step 4: Implement helpers in `Subnet-Calculator/includes/functions-util.php`**
+
+Append:
+
+```php
+/**
+ * Convert a CIDR prefix (e.g. "/24" or "24") to its wildcard mask (e.g. "0.0.0.255").
+ *
+ * @throws InvalidArgumentException if the prefix is not 0-32.
+ */
+function cidr_to_wildcard(string $cidr): string
+{
+    $cidr = ltrim(trim($cidr), '/');
+    if (!ctype_digit($cidr)) {
+        throw new InvalidArgumentException('CIDR prefix must be numeric');
+    }
+    $prefix = (int) $cidr;
+    if ($prefix < 0 || $prefix > 32) {
+        throw new InvalidArgumentException('CIDR prefix must be between 0 and 32');
+    }
+    $netmask  = $prefix === 0 ? 0 : ((0xFFFFFFFF << (32 - $prefix)) & 0xFFFFFFFF);
+    $wildcard = (~$netmask) & 0xFFFFFFFF;
+    return long2ip((int) $wildcard);
+}
+
+/**
+ * Convert a wildcard mask (e.g. "0.0.0.255") to its CIDR prefix (e.g. "/24").
+ *
+ * Only contiguous wildcard masks (Cisco-style inverse of a netmask) are accepted.
+ *
+ * @throws InvalidArgumentException for malformed input or non-contiguous masks.
+ */
+function wildcard_to_cidr(string $wildcard): string
+{
+    $wildcard = trim($wildcard);
+    if (filter_var($wildcard, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+        throw new InvalidArgumentException('Wildcard must be a valid IPv4 dotted-quad');
+    }
+    $w = ip2long($wildcard) & 0xFFFFFFFF;
+    $netmask = (~$w) & 0xFFFFFFFF;
+    // Contiguity check: ((~mask)+1) & ~mask must be 0
+    $inv = (~$netmask) & 0xFFFFFFFF;
+    if ((($inv + 1) & $inv) !== 0) {
+        throw new InvalidArgumentException('Wildcard mask is not contiguous');
+    }
+    // Count the leading-1 bits of netmask
+    $prefix = 0;
+    for ($i = 31; $i >= 0; $i--) {
+        if (($netmask >> $i) & 1) {
+            $prefix++;
+        } else {
+            break;
+        }
+    }
+    return '/' . $prefix;
+}
+```
+
+- [ ] **Step 5: Run PHPUnit, expect PASS**
+
+```bash
+vendor/bin/phpunit testing/unit/WildcardTest.php
+```
+
+Expected: 11/11 pass. If any fail, fix the implementation — never the test.
+
+- [ ] **Step 6: Run PHPStan to confirm L9 cleanliness**
+
+```bash
+phpstan analyse --no-progress --memory-limit=512M
+```
+
+Expected: 0 errors. Fix any new findings before continuing.
+
+- [ ] **Step 7: Create the API handler `Subnet-Calculator/api/v1/handlers/wildcard.php`**
+
+```php
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/functions-util.php';
+
+return function (array $params): array {
+    $value = trim((string) ($params['value'] ?? ''));
+    if ($value === '') {
+        return json_err('Missing required parameter: value', 400);
+    }
+    try {
+        if (str_contains($value, '.')) {
+            $cidr     = wildcard_to_cidr($value);
+            $wildcard = $value;
+        } else {
+            $wildcard = cidr_to_wildcard($value);
+            $cidr     = '/' . ltrim($value, '/');
+        }
+    } catch (InvalidArgumentException $e) {
+        return json_err($e->getMessage(), 400);
+    }
+    return json_ok([
+        'input'    => $value,
+        'cidr'     => $cidr,
+        'wildcard' => $wildcard,
+    ]);
+};
+```
+
+(`json_ok` / `json_err` signatures: confirm exact contract by reading `Subnet-Calculator/api/v1/helpers.php` first and match peer handlers like `handlers/ipv4.php`.)
+
+- [ ] **Step 8: Register the route in `Subnet-Calculator/api/v1/index.php`**
+
+Find the existing handler registration table and add a row for `wildcard` mapping `GET /wildcard` → `handlers/wildcard.php`. Match the existing pattern exactly.
+
+- [ ] **Step 9: Add the OpenAPI spec entry in `Subnet-Calculator/api/openapi.yaml`**
+
+Add a new path `/wildcard` under `paths:`, with a `get` operation, `value` query parameter (string, required), 200 response schema with `input`/`cidr`/`wildcard` strings, and 400 error response. Follow the spec style used by `/ipv4` exactly. Run `npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml` and confirm zero errors.
+
+- [ ] **Step 10: Wire the UI** — extend `Subnet-Calculator/templates/layout.php` to add a Wildcard ↔ CIDR entry to the tool drawer. Match the existing entry markup pattern (look at the IP range or supernet entries). Then extend `Subnet-Calculator/assets/app.js` with a `wildcardConverter` controller that submits to `/api/v1/wildcard?value=…`, displays both result fields, and wires the existing copy-button helper. Use the spec from `ui-ux-pro-max` (Step 1).
+
+- [ ] **Step 11: Add Playwright UI tests** in `testing/scripts/playwright_test.py`:
+
+```python
+def test_wildcard_converter_cidr_to_wildcard(page):
+    page.goto(BASE_URL)
+    page.click("[data-tool='wildcard']")  # match drawer trigger selector
+    page.fill("#wildcard-input", "/24")
+    page.click("#wildcard-convert")
+    expect(page.locator("#wildcard-result-mask")).to_have_text("0.0.0.255")
+    expect(page.locator("#wildcard-result-cidr")).to_have_text("/24")
+
+def test_wildcard_converter_wildcard_to_cidr(page):
+    page.goto(BASE_URL)
+    page.click("[data-tool='wildcard']")
+    page.fill("#wildcard-input", "0.0.0.255")
+    page.click("#wildcard-convert")
+    expect(page.locator("#wildcard-result-mask")).to_have_text("0.0.0.255")
+    expect(page.locator("#wildcard-result-cidr")).to_have_text("/24")
+
+def test_wildcard_converter_rejects_noncontiguous(page):
+    page.goto(BASE_URL)
+    page.click("[data-tool='wildcard']")
+    page.fill("#wildcard-input", "0.0.255.0")
+    page.click("#wildcard-convert")
+    expect(page.locator(".wildcard-error")).to_contain_text("not contiguous")
+
+def test_wildcard_api_endpoint(page):
+    r = page.request.get(f"{BASE_URL}/api/v1/wildcard?value=/24")
+    assert r.status == 200
+    data = r.json()
+    assert data["data"]["wildcard"] == "0.0.0.255"
+    assert data["data"]["cidr"] == "/24"
+```
+
+(Adjust selectors to match the markup you actually wrote in Step 10.)
+
+- [ ] **Step 12: Run the full local gate**
+
+```bash
+vendor/bin/phpunit
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+npm run lint
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+make test-docker
+```
+
+Expected: every gate green. PHPUnit count rises by 11. Playwright gains 4 new test groups. Any failure is fixed in code/tests, never silenced.
+
+- [ ] **Step 13: semgrep scan**
+
+```bash
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten \
+    --config p/sql-injection --error \
+    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+```
+
+Expected: 0 findings. If any appear, fix or document.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add Subnet-Calculator/includes/functions-util.php \
+        Subnet-Calculator/api/v1/handlers/wildcard.php \
+        Subnet-Calculator/api/v1/index.php \
+        Subnet-Calculator/api/openapi.yaml \
+        Subnet-Calculator/templates/layout.php \
+        Subnet-Calculator/assets/app.js \
+        Subnet-Calculator/assets/app.css \
+        testing/unit/WildcardTest.php \
+        testing/scripts/playwright_test.py
+git commit -m "feat: wildcard mask ↔ CIDR converter (closes #292)"
+```
+
+- [ ] **Step 15: Memory MCP update**
+
+Add observation: `"Task 5 complete: #292 closed in commit <SHORT_SHA>. New helpers cidr_to_wildcard/wildcard_to_cidr in functions-util.php, GET /api/v1/wildcard handler, drawer UI entry, 11 PHPUnit + 4 Playwright tests added."`
+
+---
+
+## Task 6: Issue #287 — PHP 8.4 compatibility pass + CI matrix
+
+**Files:**
+- Create: `.github/workflows/ci.yml`
+- Modify: `README.md` (bump supported-PHP wording from "PHP 8.1+" → "PHP 8.1, 8.2, 8.3, 8.4")
+- Modify: `Subnet-Calculator/api/openapi.yaml` only if `info.description` mentions a PHP version (it does not — verify)
+- Modify: any source file flagged by PHPStan or PHPUnit when run on PHP 8.4
+
+- [ ] **Step 1: Run the full local gate on PHP 8.4 to surface deprecations**
+
+```bash
+php -v   # confirm local PHP version
+# If local is not 8.4, run via the dev server container or via a local PHP 8.4 install.
+# On the dev server (Docker container `dev_seanmousseau_com-apache-php-1`), check with:
+ssh root@192.168.80.15 "docker exec dev_seanmousseau_com-apache-php-1 php -v"
+```
+
+If no local 8.4 is available, run inside the official `php:8.4-cli` Docker image:
+
+```bash
+docker run --rm -v "$PWD":/app -w /app php:8.4-cli bash -c "php -v && php -d memory_limit=512M vendor/bin/phpunit"
+```
+
+Capture every warning/notice. Common 8.4 surprises:
+- Implicit nullable parameters (`function f(int $x = null)` → must be `?int`)
+- `E_DEPRECATED` on dynamic properties (already required by 8.2; surface here too)
+
+- [ ] **Step 2: Fix any code emitting deprecations**
+
+For each deprecation: edit the source file, re-run PHPUnit on 8.4 until clean. **Never** suppress with `@`. Do not skip tests. If a third-party `vendor/` library is the source, document it in CHANGELOG instead — but verify the issue is truly external before claiming so.
+
+- [ ] **Step 3: Author `.github/workflows/ci.yml`**
+
+Use the Write tool to create:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: gmp, mbstring, json
+          tools: composer:v2
+          coverage: none
+      - name: Composer install
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: PHPUnit
+        run: vendor/bin/phpunit
+      - name: PHPStan (level 9)
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=512M
+      - name: PHPCS (PSR-12)
+        run: vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+
+  lint:
+    name: JS / CSS / OpenAPI lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci || npm install
+      - run: npm run lint
+      - run: npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+
+- [ ] **Step 4: Update README PHP-version wording**
+
+Replace any "PHP 8.1+" line with "PHP 8.1, 8.2, 8.3, or 8.4". Confirm with `grep -n "PHP 8" README.md` before editing.
+
+- [ ] **Step 5: Verify PHPUnit + PHPStan + PHPCS still pass on local PHP**
+
+```bash
+vendor/bin/phpunit
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Push branch (after release commit & approval — see Task 10) and confirm CI matrix is green on GitHub Actions before merge**. (CI cannot run until the workflow file is on a pushed branch — capture this dependency in Task 10.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/ci.yml README.md
+# plus any source files touched in Step 2
+git commit -m "ci: add PHP 8.1-8.4 matrix; PHP 8.4 compat pass (closes #287)"
+```
+
+- [ ] **Step 8: Memory MCP update**
+
+Add observation: `"Task 6 complete: #287 closed in commit <SHORT_SHA>. New .github/workflows/ci.yml runs PHPUnit+PHPStan+PHPCS on PHP 8.1/8.2/8.3/8.4. Source fixes (if any): <list files>."`
+
+---
+
+## Task 7: Documentation refresh
+
+**Skill: invoke `documentation` for this entire task.** Brief: "v2.10.0 of Subnet Calculator. Update CHANGELOG.md, README.md, mkdocs.yml, docs/index.md, docs/api.md, and create docs/wildcard.md + docs/print.md. All version references must move from 2.9.2 → 2.10.0. Tarball filename in install snippet must update. CHANGELOG section must list six closed issues with one-line summaries each."
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md` (downloads-table row)
+- Modify: `mkdocs.yml` (`extra.version`)
+- Modify: `docs/index.md` (tarball install snippet)
+- Modify: `docs/api.md` (new wildcard endpoint reference)
+- Create: `docs/wildcard.md`
+- Create: `docs/print.md`
+- Modify: `CLAUDE.md` (record any new convention or test-count change)
+
+- [ ] **Step 1: Invoke the `documentation` skill** with the brief above. Use it to draft each doc change. Apply its output via Write/Edit.
+
+- [ ] **Step 2: `CHANGELOG.md`** — add at the top of the version list:
+
+```md
+## [2.10.0] - 2026-04-27
+
+### Added
+- **Wildcard mask ↔ CIDR converter** — new tool drawer entry and `GET /api/v1/wildcard?value=…` endpoint that converts between Cisco-style wildcard masks (e.g. `0.0.0.255`) and CIDR prefixes (e.g. `/24`). Closes #292.
+- **`/sitemap.xml`** — static sitemap published at the app root and advertised in `robots.txt`. Closes #285.
+- **CI matrix** — GitHub Actions now runs PHPUnit + PHPStan + PHPCS against PHP 8.1, 8.2, 8.3, and 8.4. Closes #287.
+
+### Changed
+- **Documentation URL** — every in-app and in-repo reference to the legacy `seanmousseau.github.io/Subnet-Calculator` URL now points at the canonical custom domain `https://docs.subnetcalculator.app/`. Closes #284.
+- **OpenAPI `externalDocs.url`** — bumped to `https://docs.subnetcalculator.app/api/`. Closes #290.
+- **Print stylesheet** — `@media print` now forces light surfaces and dark ink even when the user is viewing in dark mode, producing a readable, ink-efficient page. Closes #291.
+```
+
+- [ ] **Step 3: `README.md`** — add a row for v2.10.0 to the downloads table (match the existing row pattern, link to `releases/subnet-calculator-2.10.0.tar.gz` and the GitHub release URL).
+
+- [ ] **Step 4: `mkdocs.yml`** — bump `extra.version: "2.9.2"` → `extra.version: "2.10.0"`.
+
+- [ ] **Step 5: `docs/index.md`** — replace `subnet-calculator-2.9.2.tar.gz` with `subnet-calculator-2.10.0.tar.gz` in the install snippet.
+
+- [ ] **Step 6: `docs/api.md`** — add a `### `GET /api/v1/wildcard`` section documenting the `value` parameter, both modes (CIDR-in vs wildcard-in), the response shape, and the contiguity-error 400.
+
+- [ ] **Step 7: `docs/wildcard.md`** — new page that mirrors the structure of `docs/range.md` (UI overview → API reference → examples). Add it to `mkdocs.yml`'s `nav:` block.
+
+- [ ] **Step 8: `docs/print.md`** — new page (a few paragraphs) explaining the print behaviour, the dark-mode → forced-light decision, and how to print only a specific result card. Add to `mkdocs.yml` `nav:`.
+
+- [ ] **Step 9: `CLAUDE.md`** — update the PHPUnit count line if it changed (Task 5 added 11 unit tests). Note the new `wildcard_to_cidr` / `cidr_to_wildcard` helpers under "Key implementation details". Note the new GitHub Actions CI matrix in the Development block.
+
+- [ ] **Step 10: Verify docs accuracy end-to-end**
+
+```bash
+grep -rn "2\.9\.2" CHANGELOG.md README.md docs/ mkdocs.yml || echo "OK: no stray 2.9.2 references"
+```
+
+Expected output: `OK: no stray 2.9.2 references` (or only in historical CHANGELOG sections, which is correct).
+
+- [ ] **Step 11: MkDocs build smoke test**
+
+```bash
+cd docs && pip install -r requirements.txt --quiet && mkdocs build --strict && cd ..
+```
+
+Expected: build succeeds with `--strict` (warnings are errors). Fix any broken links.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add CHANGELOG.md README.md mkdocs.yml docs/index.md docs/api.md docs/wildcard.md docs/print.md CLAUDE.md
+git commit -m "docs: v2.10.0 changelog, wildcard + print pages, version bump prep"
+```
+
+- [ ] **Step 13: Memory MCP update**
+
+Add observation: `"Task 7 complete: docs refreshed in commit <SHORT_SHA>. CHANGELOG [2.10.0] section, mkdocs version 2.10.0, install snippet 2.10.0, new docs/wildcard.md + docs/print.md added to nav, mkdocs build --strict green."`
+
+---
+
+## Task 8: Full local release-gate run
+
+**No commits in this task.** Pure verification before version bump.
+
+- [ ] **Step 1: PHPUnit**
+
+```bash
+vendor/bin/phpunit
+```
+
+Expected: 100% pass (count includes 11 new wildcard tests). Skips remain at 14 (GMP-dependent, expected).
+
+- [ ] **Step 2: PHPStan L9 with the required memory flag**
+
+```bash
+phpstan analyse --no-progress --memory-limit=512M
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: PHPCS PSR-12**
+
+```bash
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+```
+
+Expected: warnings-only (the pre-existing line-length / side-effects warnings). Zero errors.
+
+- [ ] **Step 4: ESLint + Stylelint**
+
+```bash
+npm run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Spectral OpenAPI lint**
+
+```bash
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+
+Expected: 0 errors. Warning count must not increase from the baseline 24 (or 25 if the new wildcard path adds one warning of the same family); document any new warning in the PR.
+
+- [ ] **Step 6: Semgrep**
+
+```bash
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten \
+    --config p/sql-injection --error \
+    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+```
+
+Expected: 0 findings.
+
+- [ ] **Step 7: Playwright via Docker**
+
+```bash
+make test-docker
+```
+
+Expected: 100% pass — test-group count grows by ~6 (sitemap, print, 4× wildcard). **Any failure must be root-caused and fixed; flake is never an acceptable explanation.**
+
+- [ ] **Step 8: Visual snapshots**
+
+If any snapshot diff appears, regenerate by serving locally and re-running the snapshot generator (the project's existing `snapshot_utils.py` flow). Commit regenerated baselines as a separate logical commit.
+
+- [ ] **Step 9: Memory MCP checkpoint**
+
+Add observation: `"Task 8 complete: full local gate green for v2.10.0. PHPUnit <N> tests pass, PHPStan L9 0 errors, semgrep 0, Playwright <N> groups pass, mkdocs strict-build green."`
+
+---
+
+## Task 9: Version bump + release tarball
+
+**Files:**
+- Modify: `Subnet-Calculator/includes/config.php` (`$app_version` → `'2.10.0'`)
+- Modify: `Subnet-Calculator/api/openapi.yaml` (`info.version` → `2.10.0`)
+- Create: `releases/subnet-calculator-2.10.0.tar.gz`
+
+- [ ] **Step 1: Bump `$app_version`** in `Subnet-Calculator/includes/config.php` from `'2.9.2'` to `'2.10.0'` (Edit tool).
+
+- [ ] **Step 2: Bump `info.version`** in `Subnet-Calculator/api/openapi.yaml` to `2.10.0` (Edit tool). Re-run Spectral.
+
+- [ ] **Step 3: Build tarball**
+
+```bash
+cp CHANGELOG.md Subnet-Calculator/CHANGELOG.md
+tar -czf releases/subnet-calculator-2.10.0.tar.gz -C Subnet-Calculator .
+rm Subnet-Calculator/CHANGELOG.md
+ls -lh releases/subnet-calculator-2.10.0.tar.gz
+shasum -a 256 releases/subnet-calculator-2.10.0.tar.gz
+```
+
+Expected: tarball exists, ~900K–1MB, sha256 captured.
+
+- [ ] **Step 4: Smoke test the tarball locally**
+
+```bash
+mkdir -p /tmp/sc-2.10.0-smoke && tar -xzf releases/subnet-calculator-2.10.0.tar.gz -C /tmp/sc-2.10.0-smoke
+php -S localhost:8181 -t /tmp/sc-2.10.0-smoke &
+SMOKE_PID=$!
+sleep 1
+curl -s http://localhost:8181/api/v1/meta | head -c 200
+curl -s "http://localhost:8181/api/v1/wildcard?value=/24" | head -c 200
+kill $SMOKE_PID
+rm -rf /tmp/sc-2.10.0-smoke
+```
+
+Expected: `meta` returns `2.10.0`; `wildcard` returns `0.0.0.255`. If `meta` returns `null` or stale, re-investigate — the bundled `config.php` may not match the docroot.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Subnet-Calculator/includes/config.php \
+        Subnet-Calculator/api/openapi.yaml \
+        releases/subnet-calculator-2.10.0.tar.gz
+git commit -m "release: v2.10.0"
+```
+
+- [ ] **Step 6: Memory MCP update**
+
+Add observation: `"Task 9 complete: v2.10.0 tarball built. SHA256 <hash>. /api/v1/meta returns 2.10.0; /api/v1/wildcard returns 0.0.0.255 for /24 in smoke test."`
+
+---
+
+## Task 10: Push, PR, merge — REQUIRES EXPLICIT SEAN APPROVAL AT EACH GATE
+
+> **STOP. Do not perform Steps 2, 4, or 6 without an explicit "yes / proceed / approved" from Sean. Quoting the user message that authorised the action in your reply is required. No exceptions.**
+
+- [ ] **Step 1: Show Sean the final state**
+
+Show the diff summary, list the commits on `release/v2.10.0` since `dev`, and list the issues that will close.
+
+```bash
+git log --oneline dev..release/v2.10.0
+git diff --stat dev..release/v2.10.0
+gh issue list --milestone "v2.10.0" --state open --json number,title --jq '.[] | "#\(.number) \(.title)"'
+```
+
+- [ ] **Step 2: Ask Sean for explicit permission to push the branch**
+
+Wait for explicit approval. Only then:
+
+```bash
+git push -u origin release/v2.10.0
+```
+
+Then verify the push landed on GitHub:
+
+```bash
+gh api repos/seanmousseau/Subnet-Calculator/branches/release/v2.10.0 --jq '.commit.sha'
+```
+
+Expected: SHA matches `git rev-parse release/v2.10.0`.
+
+- [ ] **Step 3: Wait for CI matrix to go green on the pushed branch**
+
+```bash
+gh run list --branch release/v2.10.0 --limit 5
+gh run watch
+```
+
+If any check fails, fix the cause locally, push the fix as a new commit on `release/v2.10.0`, and wait for green again. Failures are root-caused, never bypassed.
+
+- [ ] **Step 4: Ask Sean for explicit permission to open the PR**
+
+On approval, open it from `release/v2.10.0 → main` (NOT `dev → main` for this release — we are using a release branch directly to keep history clean):
+
+```bash
+gh pr create --base main --head release/v2.10.0 --title "release: v2.10.0" --body "$(cat <<'EOF'
+## Summary
+
+v2.10.0 — Docs / Polish release.
+
+- Closes #284 — Update all docs links to https://docs.subnetcalculator.app/
+- Closes #285 — Add sitemap.xml + canonical link audit
+- Closes #287 — PHP 8.4 compatibility pass + CI matrix
+- Closes #290 — OpenAPI `externalDocs.url` bump
+- Closes #291 — Dark-mode print stylesheet
+- Closes #292 — Wildcard mask ↔ CIDR converter
+
+## Test plan
+- [x] PHPUnit (incl. 11 new WildcardTest cases)
+- [x] PHPStan L9 (--memory-limit=512M)
+- [x] PHPCS PSR-12 (errors=0)
+- [x] ESLint + Stylelint clean
+- [x] Spectral OpenAPI lint (errors=0)
+- [x] Semgrep clean
+- [x] Playwright `make test-docker` (incl. new sitemap, dark-mode print, and 4× wildcard tests)
+- [x] MkDocs `--strict` build green
+- [x] Tarball smoke test (/api/v1/meta returns 2.10.0; /api/v1/wildcard returns 0.0.0.255 for /24)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Verify with `gh pr view --json url,number`.
+
+- [ ] **Step 5: Wait for CodeRabbit / Optibot / any other review automation to post**
+
+Address every review comment. If any comment is a fix-required item, push to the same branch.
+
+- [ ] **Step 6: Ask Sean for explicit permission to merge**
+
+On approval:
+
+```bash
+gh pr merge --squash --delete-branch <PR_NUMBER>
+```
+
+Confirm:
+
+```bash
+gh pr view <PR_NUMBER> --json state,mergeCommit
+```
+
+- [ ] **Step 7: Sync `dev` with `main`**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout dev && git merge --ff-only main
+git push origin dev
+```
+
+- [ ] **Step 8: Memory MCP update**
+
+Add observation: `"Task 10 complete: PR #<num> merged to main as <merge_sha>. CI matrix green on PHP 8.1/8.2/8.3/8.4. dev fast-forwarded to main."`
+
+---
+
+## Task 11: Post-merge — release artifact, deploy, milestone close
+
+- [ ] **Step 1: Create the GitHub release**
+
+```bash
+gh release create v2.10.0 \
+  --title "v2.10.0" \
+  --notes-file - <<'EOF'
+v2.10.0 — Docs / Polish release.
+
+See CHANGELOG.md for details.
+
+Closes #284, #285, #287, #290, #291, #292.
+EOF
+gh release upload v2.10.0 releases/subnet-calculator-2.10.0.tar.gz
+```
+
+- [ ] **Step 2: Deploy to test server** (per CLAUDE.md)
+
+```bash
+rsync -a --delete Subnet-Calculator/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+scp testing/fixtures/iframe-test.html root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+curl -s "https://dev-direct.seanmousseau.com/testing/sc/api/v1/meta" -u "$IPAM_BASIC_USER:$IPAM_BASIC_PASS" | head -c 200
+```
+
+Expected: meta returns `2.10.0`.
+
+- [ ] **Step 3: Deploy to production** (per memory `reference_deployments`)
+
+Use the production deploy procedure from memory `reference_deployments.md`. After deploy, hit `https://subnetcalculator.app/api/v1/meta` and confirm `2.10.0`.
+
+- [ ] **Step 4: Cloudflare cache purge**
+
+```bash
+source ~/.claude/dev-secrets.env
+# (Use the existing CF purge command pattern from prior releases — see memory observation S484/833.)
+```
+
+Verify by curling `subnetcalculator.app` with `Cache-Control: no-cache` and confirming the new asset versions are served.
+
+- [ ] **Step 5: Close every v2.10.0 issue**
+
+The PR's "Closes #N" lines should auto-close issues on merge. Verify:
+
+```bash
+for n in 284 285 287 290 291 292; do
+  gh issue view $n --json state --jq ".state"
+done
+```
+
+Expected: all `CLOSED`. If any is still open, close manually:
+
+```bash
+gh issue close <N> --reason completed --comment "Shipped in v2.10.0"
+```
+
+- [ ] **Step 6: Close the v2.10.0 milestone**
+
+```bash
+gh api -X PATCH repos/seanmousseau/Subnet-Calculator/milestones/19 -f state=closed
+gh api repos/seanmousseau/Subnet-Calculator/milestones/19 --jq '{state, closed_issues, open_issues}'
+```
+
+Expected: `{state: "closed", closed_issues: 6, open_issues: 0}`.
+
+- [ ] **Step 7: Final stale-branch sweep**
+
+```bash
+git fetch --prune
+git branch -vv | grep ': gone]' || echo "no stale local branches"
+```
+
+Expected: nothing reported. If anything appears (e.g. `release/v2.10.0` after the squash-merge with `--delete-branch`), delete it locally:
+
+```bash
+git checkout dev
+git branch -D release/v2.10.0
+```
+
+- [ ] **Step 8: Memory MCP — final release-state observation**
+
+```
+mcp__MCP_DOCKER__add_observations on project:subnet-calculator:release:v2.10.0:
+- "v2.10.0 SHIPPED on 2026-04-27. Merge SHA <merge>. Tag v2.10.0. Tarball SHA256 <hash>."
+- "All 6 issues closed (#284, #285, #287, #290, #291, #292). Milestone #19 closed."
+- "Test/prod deployed; CF cache purged; /api/v1/meta returns 2.10.0 on both."
+- "New helpers: cidr_to_wildcard / wildcard_to_cidr in functions-util.php. New endpoint: GET /api/v1/wildcard. New CI matrix: PHP 8.1-8.4 in .github/workflows/ci.yml."
+
+mcp__MCP_DOCKER__add_observations on project:subnet-calculator:
+- "Current version: v2.10.0 as of 2026-04-27. PHPUnit count: <N>. Playwright groups: <N>. CI matrix now PHP 8.1-8.4."
+```
+
+---
+
+## Self-Review Checklist (run before handoff to executing skill)
+
+- [x] Every milestone issue (#284, #285, #287, #290, #291, #292) maps to at least one task.
+- [x] No "TBD", "TODO", "implement later" placeholders.
+- [x] Every code step shows actual code, not a description.
+- [x] PHPStan invocations all carry `--memory-limit=512M`.
+- [x] PRs and merges gated on explicit Sean approval (Task 10 Steps 2, 4, 6).
+- [x] Memory MCP updates after each major task.
+- [x] `ui-ux-pro-max` invoked in Tasks 4 and 5 before any UI work.
+- [x] `documentation` skill invoked in Task 7.
+- [x] Stale local branches cleaned (Task 0 Step 2 + Task 11 Step 7).
+- [x] Milestone closure scripted (Task 11 Step 6).
+- [x] All issue numbers consistent: 284, 285, 287, 290, 291, 292.
+- [x] Tarball name consistent: `subnet-calculator-2.10.0.tar.gz`.
+- [x] Function names consistent: `wildcard_to_cidr`, `cidr_to_wildcard` (used in helper, handler, tests, docs).

--- a/docs/superpowers/plans/2026-04-27-v2.11.0-release.md
+++ b/docs/superpowers/plans/2026-04-27-v2.11.0-release.md
@@ -1,0 +1,910 @@
+# Subnet-Calculator v2.11.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Use `ui-ux-pro-max` for any UI/UX/design work, `documentation` for docs writing, `mem-search` / Memory MCP throughout, and Context7 (`find-docs`) for any external library lookup.
+
+**Goal:** Ship Subnet-Calculator v2.11.0 — IPv6 VLSM planner (headline), Copy-as-Markdown / Copy-as-Cisco exports, Inverse subnet lookup, and Subnet aggregation diff tool. Closes milestone v2.11.0 (#20) and issues #293, #294, #295, #296.
+
+**Architecture:** Pure PHP utility modules under `Subnet-Calculator/includes/functions-*.php` (typed, `declare(strict_types=1)`), one handler per endpoint under `Subnet-Calculator/api/v1/handlers/`, request wiring in `request.php`, IPv6 arithmetic via GMP, UI integration in `templates/layout.php` via the existing `tool-trigger` / `tool-panel` / `data-tool` drawer pattern. JS additions to `assets/app.js` only — no build step. Tests: PHPUnit under `testing/unit/`, Playwright groups appended to `testing/scripts/playwright_test.py`. Docs: new `docs/ipv6-vlsm.md`, `docs/lookup.md`, `docs/diff.md`, `docs/exports.md`; existing pages updated.
+
+**Tech Stack:** PHP 8.2+ with GMP, vanilla CSS (custom properties), vanilla JS, PHPUnit 11, PHPStan L9, PHPCS PSR-12, Spectral (OpenAPI), Semgrep, Playwright (Python, via `make test-docker`).
+
+**Release gate (non-negotiable, see CLAUDE.md):**
+- PHPUnit clean (no failing tests, ever — never justify failures)
+- PHPStan L9 clean (`--memory-limit=512M`)
+- PHPCS PSR-12 clean
+- ESLint + Stylelint clean
+- Spectral OpenAPI lint clean
+- Semgrep `.semgrep/rules.yml + p/php + p/owasp-top-ten + p/sql-injection` 0 findings
+- `make test-docker` Playwright suite 100% pass — any flake reveals an app bug or test bug; fix it, never dismiss it
+- MkDocs strict build green
+- Tarball smoke test: extract, `php -S`, hit every new endpoint
+- **Explicit user permission required to open PR**
+- **Explicit user permission required to merge PR**
+
+---
+
+## Pre-work: Cleanup & State Verification
+
+### Task 0: Verify clean baseline + seed Memory MCP
+
+**Files:**
+- Read-only: GitHub state via `gh`, Memory MCP
+
+- [ ] **Step 1: Confirm v2.10.0 milestone is closed and all issues delivered**
+
+Run:
+```bash
+gh api repos/seanmousseau/Subnet-Calculator/milestones --jq '.[] | select(.title=="v2.10.0") | "\(.title) state=\(.state) open=\(.open_issues) closed=\(.closed_issues)"'
+gh issue list --state open --search 'milestone:v2.10.0' --json number,title
+```
+Expected: `v2.10.0 state=closed open=0 closed=6`, empty issue list. If anything is open, halt and surface to user.
+
+- [ ] **Step 2: Confirm v2.11.0 scope (4 issues) and no unmilestoned regressions**
+
+Run:
+```bash
+gh issue list --state open --search 'milestone:v2.11.0' --json number,title
+gh api 'repos/seanmousseau/Subnet-Calculator/issues?state=open&per_page=100' --jq '.[] | select(.milestone == null and .pull_request == null) | "#\(.number) \(.title)"'
+```
+Expected: #293, #294, #295, #296 only. Empty unmilestoned list. If unmilestoned issues exist, surface to user for triage decision before proceeding.
+
+- [ ] **Step 3: Confirm only `dev` and `main` branches exist (no stale branches)**
+
+Run:
+```bash
+git fetch --all --prune
+git branch -a
+```
+Expected: `dev`, `main`, `remotes/origin/dev`, `remotes/origin/main`. Anything else → surface to user; do not delete without permission.
+
+- [ ] **Step 4: Seed Memory MCP entity for the release**
+
+Use `mcp__MCP_DOCKER__create_entities` to create `project:subnet-calculator:release:v2.11.0` with observations: scope (4 issues), start date, branch name (`release/v2.11.0`), gate status `in-flight`. Create relations: `project:subnet-calculator:release:v2.11.0 --closes--> project:subnet-calculator:bug:N` etc. (skip if entity already exists; just `add_observations`). If `mcp__MCP_DOCKER__search_nodes` errors with `toLowerCase`, fall back to `read_graph` then `create_entities` directly.
+
+- [ ] **Step 5: Create release branch from `main`**
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b release/v2.11.0
+git push -u origin release/v2.11.0
+```
+
+---
+
+## Task 1: IPv6 VLSM Planner (#293, headline)
+
+**Files:**
+- Create: `Subnet-Calculator/includes/functions-vlsm6.php`
+- Create: `Subnet-Calculator/api/v1/handlers/vlsm6.php`
+- Modify: `Subnet-Calculator/api/v1/index.php` (router + meta endpoint list)
+- Modify: `Subnet-Calculator/api/openapi.yaml` (new path `/vlsm6`)
+- Modify: `Subnet-Calculator/index.php` (require new include)
+- Modify: `Subnet-Calculator/includes/request.php` (state vars + POST processing)
+- Modify: `Subnet-Calculator/templates/layout.php` (IPv6 tab — VLSM section)
+- Modify: `Subnet-Calculator/assets/app.js` (mirror IPv4 VLSM JS for IPv6: row add/remove/sort, CSV/JSON/XLSX export, copy-all, shareable URL, utilisation summary)
+- Create: `testing/unit/Vlsm6Test.php`
+- Modify: `testing/scripts/playwright_test.py` (append IPv6 VLSM groups mirroring all IPv4 VLSM groups)
+- Create: `docs/ipv6-vlsm.md`
+- Modify: `docs/vlsm.md` (link to IPv6 page), `mkdocs.yml` (nav entry)
+
+**Design (from `functions-vlsm.php` IPv4 pattern, adapted for GMP):**
+
+`vlsm6_allocate(string $network_ip, int $cidr, array $requirements): array`
+- Requirements: `[ ['name' => string, 'hosts' => string|int] ]` — hosts may be a `2^N` string for very large IPv6 sizings, or an int.
+- Sort largest-first by `hosts` (use `gmp_cmp` when comparing 2^N strings).
+- Use `gmp_init()` from `inet_pton()` hex for the parent network address.
+- For each requirement: pick the smallest prefix `/p` (where `0 < p <= 128`) such that `2^(128-p) >= hosts`. For IPv6, every address is usable (no broadcast/network reservation).
+- Align current pointer up to block boundary using `gmp_mod`/`gmp_sub`/`gmp_add`.
+- Reject when `(current + block_size) - parent_start > parent_size`.
+- Return `['allocations' => [['name', 'hosts_needed', 'subnet', 'usable']]]`. Format `usable` as `2^N` string when `>= 2^63`, else int. Format `subnet` as compressed `inet_ntop()`.
+
+- [ ] **Step 1: Write failing PHPUnit tests for `vlsm6_allocate`**
+
+Create `testing/unit/Vlsm6Test.php`:
+```php
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @requires extension gmp
+ */
+class Vlsm6Test extends TestCase
+{
+    public function testSingleRequirementFits(): void
+    {
+        $r = vlsm6_allocate('2001:db8::', 32, [['name' => 'site-a', 'hosts' => 256]]);
+        $this->assertArrayHasKey('allocations', $r);
+        $this->assertSame('site-a', $r['allocations'][0]['name']);
+        $this->assertSame('2001:db8::/120', $r['allocations'][0]['subnet']);
+        $this->assertSame(256, $r['allocations'][0]['usable']);
+    }
+
+    public function testLargestFirstAlignment(): void
+    {
+        $r = vlsm6_allocate('2001:db8::', 48, [
+            ['name' => 'small', 'hosts' => 4],
+            ['name' => 'large', 'hosts' => 65536],
+        ]);
+        $allocs = $r['allocations'];
+        $this->assertSame('large', $allocs[0]['name']);
+        $this->assertSame('2001:db8::/112', $allocs[0]['subnet']);
+        $this->assertSame('small', $allocs[1]['name']);
+        $this->assertSame('2001:db8:0:0:0:0:1::/126', $allocs[1]['subnet']);
+    }
+
+    public function testInsufficientSpaceErrors(): void
+    {
+        $r = vlsm6_allocate('2001:db8::', 126, [['name' => 'x', 'hosts' => 32]]);
+        $this->assertArrayHasKey('error', $r);
+        $this->assertStringContainsString('x', $r['error']);
+    }
+
+    public function testInvalidHostCountRejected(): void
+    {
+        $r = vlsm6_allocate('2001:db8::', 64, [['name' => 'x', 'hosts' => 0]]);
+        $this->assertArrayHasKey('error', $r);
+    }
+
+    public function testEmptyRequirementsRejected(): void
+    {
+        $r = vlsm6_allocate('2001:db8::', 64, []);
+        $this->assertArrayHasKey('error', $r);
+    }
+
+    public function testHugeAllocationReturns2NString(): void
+    {
+        $r = vlsm6_allocate('2001:db8::', 32, [['name' => 'huge', 'hosts' => '2^96']]);
+        $this->assertArrayHasKey('allocations', $r);
+        $this->assertSame('2001:db8::/32', $r['allocations'][0]['subnet']);
+        $this->assertSame('2^96', $r['allocations'][0]['usable']);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+```bash
+vendor/bin/phpunit --filter Vlsm6Test
+```
+Expected: FAIL with "Call to undefined function vlsm6_allocate" (or similar).
+
+- [ ] **Step 3: Implement `functions-vlsm6.php`**
+
+Create `Subnet-Calculator/includes/functions-vlsm6.php` implementing `vlsm6_allocate()` per the design above. Use `gmp_init()` / `gmp_add()` / `gmp_sub()` / `gmp_mod()` / `gmp_cmp()` / `gmp_pow()` / `gmp_strval()`. Convert `2^N` strings to GMP via `gmp_pow(2, $n)`. Convert IPv6 strings via `inet_pton()` → `bin2hex()` → `gmp_init($hex, 16)`. Convert back via `gmp_strval(..., 16)` → `str_pad(..., 32, '0', STR_PAD_LEFT)` → `hex2bin()` → `inet_ntop()`. Mirror the structure of `vlsm_allocate()`. Add a helper `vlsm6_format_count(GMP $size): int|string` returning `(int)gmp_strval($size)` when `< 2^31`, else `'2^N'`.
+
+Wire into `Subnet-Calculator/index.php` (alphabetical insertion in the require block, after `functions-vlsm.php`).
+
+- [ ] **Step 4: Run tests until they pass**
+
+```bash
+vendor/bin/phpunit --filter Vlsm6Test
+phpstan analyse --no-progress --memory-limit=512M Subnet-Calculator/includes/functions-vlsm6.php
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/functions-vlsm6.php
+```
+All three must be clean. Iterate until they are.
+
+- [ ] **Step 5: Commit Step 1–4**
+
+```bash
+git add Subnet-Calculator/includes/functions-vlsm6.php Subnet-Calculator/index.php testing/unit/Vlsm6Test.php
+git commit -m "feat(vlsm6): add IPv6 VLSM allocator (#293)"
+```
+
+- [ ] **Step 6: Write failing API handler test**
+
+Append to `testing/scripts/playwright_test.py`:
+```python
+async def test_vlsm6_api_endpoint(_page: Page) -> None:
+    async with httpx.AsyncClient(verify=False) as client:
+        r = await client.post(f"{BASE_URL}/api/v1/vlsm6", json={
+            "network": "2001:db8::",
+            "cidr": "32",
+            "requirements": [
+                {"name": "site-a", "hosts": 256},
+                {"name": "site-b", "hosts": 4},
+            ],
+        })
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["ok"] is True
+        allocs = data["data"]["allocations"]
+        assert len(allocs) == 2
+        names = {a["name"] for a in allocs}
+        assert names == {"site-a", "site-b"}
+```
+Register in the test runner (search for an existing `test_wildcard_api_endpoint` registration and mirror).
+
+- [ ] **Step 7: Implement `api/v1/handlers/vlsm6.php`**
+
+Mirror `vlsm.php` exactly but call `vlsm6_allocate()`, validate `cidr` 0–128, use `resolve_ipv6_input()` instead of `resolve_ipv4_input()`. Add `case 'POST /vlsm6':` to `Subnet-Calculator/api/v1/index.php` router (after the existing `POST /vlsm` case). Add `'POST /api/v1/vlsm6'` to the meta endpoint list (line ~61 area).
+
+- [ ] **Step 8: Update `api/openapi.yaml` — add `/vlsm6` path**
+
+Mirror the existing `/vlsm` path block under `paths:`. Use the same request schema structure with `cidr` as 0–128. Verify with:
+```bash
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+Expected: 0 errors. Triage warnings.
+
+- [ ] **Step 9: Run handler test, confirm pass**
+
+```bash
+make test-docker SKIP_LINT=1 PYTEST_ARGS="-k test_vlsm6_api_endpoint -v"
+```
+Expected: PASS.
+
+- [ ] **Step 10: Commit Step 6–9**
+
+```bash
+git add Subnet-Calculator/api/v1/handlers/vlsm6.php Subnet-Calculator/api/v1/index.php \
+        Subnet-Calculator/api/openapi.yaml testing/scripts/playwright_test.py
+git commit -m "feat(api): add POST /api/v1/vlsm6 endpoint (#293)"
+```
+
+- [ ] **Step 11: UI/UX design pass — invoke `ui-ux-pro-max` skill**
+
+Invoke `Skill ui-ux-pro-max` with prompt: "Design the IPv6 VLSM section UI for Subnet-Calculator. Existing IPv4 VLSM lives in `templates/layout.php` (search for `vlsm-table`). Mirror IPv4 VLSM exactly: requirement table (name + hosts inputs, +Add row), Calculate button, allocation results table with CSV/JSON/XLSX/ASCII exports, Copy All, utilisation summary card. Differences: hosts field accepts `2^N` strings; subnet column shows compressed IPv6; the calculator uses the IPv6 tab's existing CIDR/network input rather than a separate one. Output: HTML markup snippet, CSS additions (vanilla, custom properties — see app.css for tokens), and a delta diff against the IPv4 VLSM block."
+
+Save the recommendation; apply markup to `templates/layout.php` (inside the IPv6 tab `<section data-tab="ipv6">`). Apply any new CSS to `assets/app.css`. Mirror `aria-label`, `help_bubble()` calls, and tabindex conventions from IPv4 VLSM.
+
+- [ ] **Step 12: Wire request.php state + POST processing**
+
+Add to `Subnet-Calculator/includes/request.php` (mirroring the IPv4 VLSM block):
+```php
+$vlsm6_network = '';
+$vlsm6_cidr    = '';
+$vlsm6_requirements_raw = '';
+/** @var list<array{name: string, hosts_needed: int|string, subnet: string, usable: int|string}>|null $vlsm6_result */
+$vlsm6_result = null;
+$vlsm6_error  = null;
+```
+Add `$is_vlsm6 = isset($_POST['vlsm6_requirements']);` to the POST detection block, append `|| $is_vlsm6` to the `$is_action` chain, and add a processing block parsing the textarea (one `name,hosts` per line) and calling `vlsm6_allocate()`. Populate `$vlsm6_result` / `$vlsm6_error`. Handle GET shareable URLs by accepting `?vlsm6_network=...&vlsm6_cidr=...&vlsm6_requirements=...`.
+
+- [ ] **Step 13: JS — mirror IPv4 VLSM behaviours for IPv6**
+
+In `assets/app.js`, find the IPv4 VLSM module (search for `vlsm-table`, `vlsm-export-csv`, etc.). Duplicate every handler with `vlsm6-` prefixed selectors: row add/remove, hosts input validation accepting `2^N` strings, CSV/JSON/XLSX export (SheetJS), Copy All, shareable URL builder, utilisation summary calculation. Keep DRY-able helpers extracted into shared functions (e.g. `buildVlsmCsv(rows, label)` accepting both v4 and v6 row shapes).
+
+Run lint:
+```bash
+npm run lint:js
+npm run lint:css
+```
+
+- [ ] **Step 14: Write failing Playwright groups for IPv6 VLSM UI**
+
+Append the following test groups to `testing/scripts/playwright_test.py`, mirroring the IPv4 equivalents (`test_vlsm`, `test_vlsm_shareable_url`, `test_vlsm_csv_export`, `test_vlsm_json_export`, `test_vlsm_xlsx_export`, `test_vlsm_reset`, `test_vlsm_validation`, `test_vlsm_copy_all`, `test_vlsm_utilisation_summary`, `test_vlsm_keyboard_delete`):
+- `test_vlsm6` — happy path, two requirements, allocation table renders
+- `test_vlsm6_shareable_url` — GET URL auto-calculates
+- `test_vlsm6_csv_export`, `test_vlsm6_json_export`, `test_vlsm6_xlsx_export`
+- `test_vlsm6_reset`, `test_vlsm6_validation`, `test_vlsm6_copy_all`
+- `test_vlsm6_huge_count_2n_string` — request `2^96` hosts, assert `2^96` rendered
+- `test_vlsm6_keyboard_delete`
+
+Register each in the runner (see how IPv4 VLSM groups are registered — same place).
+
+- [ ] **Step 15: Run new Playwright groups, fix iteratively until green**
+
+```bash
+make test-docker SKIP_LINT=1 PYTEST_ARGS="-k vlsm6 -v"
+```
+Iterate. **No flakey tests dismissed.** A flake is either an app bug or a test bug — fix it.
+
+- [ ] **Step 16: Documentation — invoke `documentation` skill**
+
+Invoke `Skill documentation` with prompt: "Write `docs/ipv6-vlsm.md` for the new IPv6 VLSM planner. Include: introduction (IPv6 has no broadcast so every address is usable), how-to with one worked example using `2001:db8::/32` and three subnets of varying sizes, table of supported `hosts` formats (decimal int, `2^N` string), API reference (POST /api/v1/vlsm6 with curl example), and a note on shareable URLs. Match tone and structure of `docs/vlsm.md` (which exists). Be factually accurate against the just-implemented code in `functions-vlsm6.php` and `handlers/vlsm6.php`."
+
+Apply the output. Update `docs/vlsm.md` to link to the new page. Add nav entry in `mkdocs.yml` under the Calculator section (next to existing VLSM entry).
+
+- [ ] **Step 17: Verify docs build cleanly**
+
+```bash
+( cd docs && pip install -q -r requirements.txt && mkdocs build --strict )
+```
+Expected: 0 warnings.
+
+- [ ] **Step 18: Commit Step 11–17**
+
+```bash
+git add Subnet-Calculator/templates/layout.php Subnet-Calculator/includes/request.php \
+        Subnet-Calculator/assets/app.js Subnet-Calculator/assets/app.css \
+        testing/scripts/playwright_test.py docs/ipv6-vlsm.md docs/vlsm.md mkdocs.yml
+git commit -m "feat(vlsm6): IPv6 VLSM UI, JS, tests, docs (#293)"
+```
+
+- [ ] **Step 19: Add Memory MCP observation**
+
+Add observation to `project:subnet-calculator:release:v2.11.0`: "#293 IPv6 VLSM planner delivered: vlsm6_allocate() in functions-vlsm6.php; POST /api/v1/vlsm6 endpoint; UI mirrors IPv4 VLSM with 2^N host count support; 9 new Playwright groups; docs/ipv6-vlsm.md; commit `<short-sha>`."
+
+---
+
+## Task 2: Inverse Subnet Lookup (#295)
+
+**Files:**
+- Create: `Subnet-Calculator/includes/functions-lookup.php`
+- Create: `Subnet-Calculator/api/v1/handlers/lookup.php`
+- Modify: `Subnet-Calculator/api/v1/index.php` (router + meta list)
+- Modify: `Subnet-Calculator/api/openapi.yaml`
+- Modify: `Subnet-Calculator/index.php`, `Subnet-Calculator/includes/request.php`, `Subnet-Calculator/templates/layout.php`, `Subnet-Calculator/assets/app.js`
+- Create: `testing/unit/LookupTest.php`
+- Modify: `testing/scripts/playwright_test.py`
+- Create: `docs/lookup.md`, modify `mkdocs.yml`
+
+**Design:**
+
+`lookup_ips(array $cidrs, array $ips): array<array{ip: string, matches: list<string>, deepest: ?string}>`
+- Each `ip` may be IPv4 or IPv6.
+- Each `cidr` may be IPv4 or IPv6 (mixed allowed; only same-family CIDRs match an IP).
+- For each IP, find every CIDR containing it (using existing `ip2long` + bitmask for v4; GMP for v6).
+- `deepest` = the longest-prefix CIDR among matches (most specific). Null if no match.
+- Return order matches input IP order.
+- Validate: max 100 CIDRs, max 1000 IPs (configurable via `$lookup_max_*` in `config.php`).
+
+- [ ] **Step 1: Write failing PHPUnit tests**
+
+Create `testing/unit/LookupTest.php`:
+```php
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+class LookupTest extends TestCase
+{
+    public function testIpv4SingleMatch(): void
+    {
+        $r = lookup_ips(['10.0.0.0/8'], ['10.1.2.3']);
+        $this->assertSame('10.0.0.0/8', $r[0]['deepest']);
+        $this->assertSame(['10.0.0.0/8'], $r[0]['matches']);
+    }
+
+    public function testIpv4DeepestPrefixWins(): void
+    {
+        $r = lookup_ips(['10.0.0.0/8', '10.1.0.0/16', '10.1.2.0/24'], ['10.1.2.3']);
+        $this->assertSame('10.1.2.0/24', $r[0]['deepest']);
+        $this->assertCount(3, $r[0]['matches']);
+    }
+
+    public function testNoMatchReturnsNull(): void
+    {
+        $r = lookup_ips(['10.0.0.0/8'], ['8.8.8.8']);
+        $this->assertNull($r[0]['deepest']);
+        $this->assertSame([], $r[0]['matches']);
+    }
+
+    public function testIpv6Match(): void
+    {
+        $r = lookup_ips(['2001:db8::/32'], ['2001:db8::1']);
+        $this->assertSame('2001:db8::/32', $r[0]['deepest']);
+    }
+
+    public function testMixedFamiliesIsolated(): void
+    {
+        $r = lookup_ips(['10.0.0.0/8', '2001:db8::/32'], ['10.1.2.3', '2001:db8::1']);
+        $this->assertSame('10.0.0.0/8', $r[0]['deepest']);
+        $this->assertSame('2001:db8::/32', $r[1]['deepest']);
+    }
+
+    public function testInvalidIpRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        lookup_ips(['10.0.0.0/8'], ['not-an-ip']);
+    }
+
+    public function testInvalidCidrRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        lookup_ips(['not-a-cidr'], ['10.0.0.1']);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, verify all fail**
+
+```bash
+vendor/bin/phpunit --filter LookupTest
+```
+
+- [ ] **Step 3: Implement `functions-lookup.php`**
+
+Implement `lookup_ips()` plus a private `cidr_contains(string $cidr, string $ip): bool` that dispatches by `str_contains($cidr, ':')` and uses `ip2long`+bitmask for v4 / GMP for v6. Throw `InvalidArgumentException` on invalid input. Wire into `index.php`.
+
+- [ ] **Step 4: Run tests until clean (PHPUnit + PHPStan + PHPCS)**
+
+```bash
+vendor/bin/phpunit --filter LookupTest
+phpstan analyse --no-progress --memory-limit=512M Subnet-Calculator/includes/functions-lookup.php
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/functions-lookup.php
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Subnet-Calculator/includes/functions-lookup.php Subnet-Calculator/index.php testing/unit/LookupTest.php
+git commit -m "feat(lookup): add inverse subnet lookup helper (#295)"
+```
+
+- [ ] **Step 6: Implement handler `api/v1/handlers/lookup.php`**
+
+Reads `body.cidrs` (array of strings) and `body.ips` (array of strings). Validates non-empty, lengths within configured caps (use `$GLOBALS['lookup_max_cidrs'] ?? 100` and `$GLOBALS['lookup_max_ips'] ?? 1000`). Calls `lookup_ips()`, catches `InvalidArgumentException` → `json_err()`. Returns `json_ok(['results' => $r])`.
+
+Add `case 'POST /lookup':` to router and `'POST /api/v1/lookup'` to meta.
+
+- [ ] **Step 7: Add OpenAPI `/lookup` path; spectral lint**
+
+Add the new path to `openapi.yaml`. Run:
+```bash
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+
+- [ ] **Step 8: Write Playwright API + UI tests**
+
+Add to `testing/scripts/playwright_test.py`:
+- `test_lookup_api_endpoint` — POST with mixed v4/v6, assert deepest correctness
+- `test_lookup_ui` — fill CIDRs textarea, fill IPs textarea, click Lookup, assert results table
+- `test_lookup_shareable_url` — GET URL renders results
+
+- [ ] **Step 9: UI/UX — invoke `ui-ux-pro-max` skill for Lookup tool drawer**
+
+Invoke with prompt: "Design a tool drawer panel for the Subnet-Calculator IPv4 tab labelled 'IP Lookup'. Pattern: existing `range`/`tree`/`wildcard` panels in `templates/layout.php` (search `data-tool=\"range\"` for the canonical example). Inputs: 'CIDRs' textarea (one per line), 'IPs' textarea (one per line), 'Lookup' submit button. Results: a table with columns `IP | Deepest match | All matches`. Empty/no-match rows render an em-dash. Mirror existing tooltip + help_bubble use. Output: HTML markup matching project conventions and any small CSS additions."
+
+Apply to `templates/layout.php` (add `<button class="tool-trigger" data-tool="lookup">IP Lookup</button>` to the IPv4 toolbar AND to the IPv6 toolbar — lookup is dual-family). Add `<div class="tool-panel" data-tool="lookup">` for both tabs. Wire `request.php` state vars + POST processing.
+
+- [ ] **Step 10: JS handler in `assets/app.js`**
+
+Add submit handler that POSTs to `/api/v1/lookup` and renders the results table client-side; OR use the request.php server-side POST path (consistent with other tools). Pick whichever matches the existing `range`/`tree` precedent — server-side POST.
+
+- [ ] **Step 11: Run all lookup Playwright groups until green**
+
+```bash
+make test-docker SKIP_LINT=1 PYTEST_ARGS="-k lookup -v"
+```
+
+- [ ] **Step 12: Documentation — invoke `documentation` skill**
+
+Invoke with prompt: "Write `docs/lookup.md` documenting the inverse subnet lookup tool. Include intro, when to use it (IPAM batch lookups), how-to (paste CIDRs, paste IPs, click Lookup), worked example with mixed v4/v6, API reference (POST /api/v1/lookup with curl + sample JSON), caps (max 100 CIDRs, max 1000 IPs), and a note on `deepest` semantics (longest-prefix match). Match tone and structure of `docs/overlap.md`. Verify all CLI examples and JSON structures against the just-implemented handler."
+
+Add nav entry in `mkdocs.yml`.
+
+- [ ] **Step 13: Commit Step 6–12**
+
+```bash
+git add Subnet-Calculator/api/v1/handlers/lookup.php Subnet-Calculator/api/v1/index.php \
+        Subnet-Calculator/api/openapi.yaml Subnet-Calculator/templates/layout.php \
+        Subnet-Calculator/includes/request.php Subnet-Calculator/assets/app.js \
+        Subnet-Calculator/assets/app.css testing/scripts/playwright_test.py \
+        docs/lookup.md mkdocs.yml
+git commit -m "feat(lookup): inverse subnet lookup tool + API (#295)"
+```
+
+- [ ] **Step 14: Memory MCP observation** — add to release entity.
+
+---
+
+## Task 3: Subnet Aggregation Diff (#296)
+
+**Files:**
+- Create: `Subnet-Calculator/includes/functions-diff.php`
+- Create: `Subnet-Calculator/api/v1/handlers/diff.php`
+- Modify: router, openapi.yaml, index.php, request.php, layout.php, app.js
+- Create: `testing/unit/DiffTest.php`, append Playwright groups
+- Create: `docs/diff.md`, modify `mkdocs.yml`
+
+**Design:**
+
+`subnet_diff(array $before, array $after): array{added: list<string>, removed: list<string>, unchanged: list<string>, changed: list<array{from: string, to: string, reason: string}>}`
+- Normalise each input CIDR via canonical-form helper (zero host bits, lowercase IPv6, compressed). Reject invalid → `InvalidArgumentException`.
+- `unchanged` = exact intersection.
+- `removed` = before-only.
+- `added` = after-only.
+- `changed` = pairs where the network address matches but the prefix length differs (e.g., `10.0.0.0/24` → `10.0.0.0/23`); `reason` = `"prefix changed /24 → /23"`.
+- Order: `added` and `removed` returned sorted; v4 before v6.
+
+- [ ] **Step 1: Write failing PHPUnit tests** for `subnet_diff` covering: identical lists → all unchanged; pure additions; pure removals; prefix change → in `changed`; invalid CIDR → exception; mixed v4/v6 ordering.
+
+- [ ] **Step 2: Run tests, verify failure.**
+
+- [ ] **Step 3: Implement `functions-diff.php`** with private `canonicalise_cidr(string)` helper that handles both families. Wire into `index.php`.
+
+- [ ] **Step 4: PHPUnit + PHPStan + PHPCS clean.**
+
+- [ ] **Step 5: Commit lib + tests.**
+
+- [ ] **Step 6: Implement handler `api/v1/handlers/diff.php`** — accepts `body.before` / `body.after` arrays, returns the diff structure. Cap each list at 1000 entries.
+
+- [ ] **Step 7: Add OpenAPI path `/diff`; Spectral clean.**
+
+- [ ] **Step 8: Write Playwright groups** — `test_diff_api_endpoint`, `test_diff_ui`, `test_diff_shareable_url`.
+
+- [ ] **Step 9: UI/UX — invoke `ui-ux-pro-max`** for the Diff tool drawer (under IPv4 toolbar AND IPv6 toolbar — dual-family). Mirror Lookup drawer pattern. Two textareas: "Before" and "After". Result: 4 columns or 4 grouped lists (Added — green; Removed — red; Changed — amber; Unchanged — muted). Apply markup to `layout.php` + CSS to `app.css`.
+
+- [ ] **Step 10: Wire `request.php` state + POST processing.**
+
+- [ ] **Step 11: Run Playwright groups until green.**
+
+- [ ] **Step 12: Documentation — invoke `documentation`** for `docs/diff.md`. Match `docs/overlap.md` tone.
+
+- [ ] **Step 13: Commit Step 6–12.**
+
+- [ ] **Step 14: Memory MCP observation.**
+
+---
+
+## Task 4: Copy-as-Markdown / Copy-as-Cisco Exports (#294)
+
+**Files:**
+- Modify: `Subnet-Calculator/assets/app.js` (export builders + new copy buttons wiring)
+- Modify: `Subnet-Calculator/templates/layout.php` (add buttons to IPv4, IPv6, VLSM, splitter result panels)
+- Modify: `Subnet-Calculator/assets/app.css` (button group styling tweaks if needed)
+- Modify: `testing/scripts/playwright_test.py`
+- Create: `docs/exports.md`, modify `mkdocs.yml`
+
+**Design:**
+
+JS-only feature. Two builders per result type:
+- `buildMarkdown(kind, data): string` — emits a Markdown table appropriate to the result. Kinds: `ipv4`, `ipv6`, `vlsm`, `vlsm6`, `split4`, `split6`.
+- `buildCiscoConfig(kind, data): string` — emits `interface ... ip address`, `ip route`, or `access-list` snippets per `kind`. Skip kinds that don't map cleanly (e.g. binary breakdown). Be explicit in the help bubble that Cisco output is IOS-style and intentionally generic.
+
+For each kind, the existing result panel grows two new buttons next to the existing Copy All: "Copy as Markdown" and "Copy as Cisco". Both use `navigator.clipboard.writeText` with the existing fallback path.
+
+- [ ] **Step 1: Write failing Playwright groups**
+
+`test_copy_as_markdown_ipv4`, `test_copy_as_markdown_ipv6`, `test_copy_as_markdown_vlsm`, `test_copy_as_cisco_ipv4`, `test_copy_as_cisco_vlsm`. Each:
+1. Calculates a known result.
+2. Reads clipboard via Playwright (`page.evaluate("navigator.clipboard.readText()")`) — requires `--allow-clipboard-read`-equivalent permission in the existing test fixture; if the harness doesn't grant, capture via a hidden `<textarea>` populated by a test-only listener (DO NOT add production code for the test — instead intercept the writeText call with a `page.exposeFunction` route).
+3. Asserts the markdown / cisco snippet contains expected substrings (table separators for markdown; `interface` / `ip address` for Cisco).
+
+- [ ] **Step 2: Run tests, verify failure.**
+
+- [ ] **Step 3: UI/UX — invoke `ui-ux-pro-max`**
+
+Prompt: "Add 'Copy as Markdown' and 'Copy as Cisco' buttons next to existing 'Copy All' in 4 result panels of Subnet-Calculator (`templates/layout.php` — search `Copy All`). Constraints: same button styling as existing copy buttons, dropdown vs. inline buttons trade-off (current convention in this app is inline buttons — recommend that), help_bubble explaining Cisco output is IOS-style/generic, mobile reflow at 480px must not overflow. Output: HTML diff for each panel + any CSS additions."
+
+Apply.
+
+- [ ] **Step 4: Implement `buildMarkdown` and `buildCiscoConfig` in `app.js`**
+
+Pure functions, no DOM. Wire button click handlers that read result data from existing data-attributes / DOM and call the builders.
+
+- [ ] **Step 5: ESLint clean.**
+
+```bash
+npm run lint:js
+```
+
+- [ ] **Step 6: Run Playwright clipboard tests until green.**
+
+- [ ] **Step 7: Documentation — invoke `documentation`** for `docs/exports.md` covering: when to use each format, worked examples for each kind, caveat that Cisco output is generic IOS-style and may need vendor-specific tweaks.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add Subnet-Calculator/assets/app.js Subnet-Calculator/templates/layout.php \
+        Subnet-Calculator/assets/app.css testing/scripts/playwright_test.py \
+        docs/exports.md mkdocs.yml
+git commit -m "feat(exports): copy-as-markdown + copy-as-cisco exports (#294)"
+```
+
+- [ ] **Step 9: Memory MCP observation.**
+
+---
+
+## Task 5: Documentation pass — invoke `documentation` skill for accuracy sweep
+
+**Files:**
+- Modify: `docs/api.md`, `docs/index.md`, `README.md`, `CLAUDE.md`, `mkdocs.yml`
+
+- [ ] **Step 1: Update `docs/api.md`**
+
+Invoke `Skill documentation` with prompt: "Update `docs/api.md` to add full reference sections for the four new v2.11.0 endpoints: POST /api/v1/vlsm6, POST /api/v1/lookup, POST /api/v1/diff. Include curl examples, request schema, response schema, error cases, caps. Cross-reference openapi.yaml for parameter details — verify every documented field exists in the YAML. Match the structure used for existing endpoints in api.md (e.g. /vlsm)."
+
+Apply.
+
+- [ ] **Step 2: Update `README.md`**
+
+- Add v2.11.0 row to the downloads table (placeholder SHA — filled in at Task 8).
+- Update the feature list / API endpoints list near the top to mention IPv6 VLSM, lookup, diff, copy-as-* exports.
+
+- [ ] **Step 3: Update `CHANGELOG.md`**
+
+Add a `## v2.11.0 — YYYY-MM-DD` section at the top with sections "Added", "Changed", "Tests", "Docs". Be specific: list every issue closed and every endpoint added. Use Conventional Commits style headers as a guide.
+
+- [ ] **Step 4: Update `CLAUDE.md`**
+
+Bump test counts in the architecture/playwright paragraph to reflect new groups added (count actual). Add architecture notes only for non-obvious things introduced (IPv6 VLSM `2^N` count handling; `subnet_diff` canonical-form normalisation; clipboard test interception via `page.exposeFunction`). Do not duplicate code patterns that are already discoverable.
+
+- [ ] **Step 5: Update `mkdocs.yml`**
+
+Bump `extra.version` to `2.11.0`. Verify all 4 new doc pages are in nav.
+
+- [ ] **Step 6: Update `docs/index.md`**
+
+Bump tarball example to `subnet-calculator-2.11.0.tar.gz`.
+
+- [ ] **Step 7: MkDocs strict build**
+
+```bash
+( cd docs && mkdocs build --strict )
+```
+0 warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/api.md docs/index.md README.md CHANGELOG.md CLAUDE.md mkdocs.yml
+git commit -m "docs(v2.11.0): add reference + bump version"
+```
+
+---
+
+## Task 6: Full release gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Bump `$app_version` to `2.11.0`**
+
+Edit `Subnet-Calculator/includes/config.php` line 9.
+
+- [ ] **Step 2: Bump OpenAPI `info.version` to `2.11.0`**
+
+Edit `Subnet-Calculator/api/openapi.yaml` top.
+
+- [ ] **Step 3: Run full PHP gate**
+
+```bash
+composer install --no-interaction --prefer-dist
+vendor/bin/phpunit
+phpstan analyse --no-progress --memory-limit=512M
+vendor/bin/phpcs --standard=PSR12 Subnet-Calculator/includes/ Subnet-Calculator/api/
+npx --yes @stoplight/spectral-cli@6 lint Subnet-Calculator/api/openapi.yaml
+```
+ALL must be clean. **Any failure must be fixed, never justified.**
+
+- [ ] **Step 4: Run JS/CSS lint**
+
+```bash
+npm install --silent
+npm run lint
+```
+
+- [ ] **Step 5: Run Semgrep**
+
+```bash
+semgrep --config=.semgrep/rules.yml --config p/php --config p/owasp-top-ten \
+    --config p/sql-injection --error \
+    Subnet-Calculator/includes/ Subnet-Calculator/api/ Subnet-Calculator/templates/
+```
+Expected: 0 findings.
+
+- [ ] **Step 6: Run full Playwright suite via Docker**
+
+```bash
+make test-docker
+```
+**100% pass required.** If any test flakes:
+- Reproduce locally.
+- Determine: is the app racy, or is the test racy?
+- Fix the underlying problem (do not add `time.sleep` patches without understanding root cause).
+- Re-run until 3 consecutive clean runs.
+
+- [ ] **Step 7: MkDocs strict build**
+
+```bash
+( cd docs && mkdocs build --strict )
+```
+
+- [ ] **Step 8: Commit version bump**
+
+```bash
+git add Subnet-Calculator/includes/config.php Subnet-Calculator/api/openapi.yaml
+git commit -m "release: bump to v2.11.0"
+```
+
+---
+
+## Task 7: Build + smoke-test the release tarball
+
+**Files:**
+- Create: `releases/subnet-calculator-2.11.0.tar.gz`
+- Modify: `README.md` (downloads table SHA)
+
+- [ ] **Step 1: Build the tarball per CLAUDE.md procedure**
+
+```bash
+cp CHANGELOG.md Subnet-Calculator/CHANGELOG.md
+tar -czf releases/subnet-calculator-2.11.0.tar.gz -C Subnet-Calculator .
+rm Subnet-Calculator/CHANGELOG.md
+```
+
+- [ ] **Step 2: Capture SHA + size**
+
+```bash
+ls -la releases/subnet-calculator-2.11.0.tar.gz
+shasum -a 256 releases/subnet-calculator-2.11.0.tar.gz
+```
+Save both for the README + PR body.
+
+- [ ] **Step 3: Smoke test the tarball in a clean directory**
+
+```bash
+SMOKE_DIR=$(mktemp -d)
+tar -xzf releases/subnet-calculator-2.11.0.tar.gz -C "$SMOKE_DIR"
+( cd "$SMOKE_DIR" && php -S 127.0.0.1:8765 ) &
+SMOKE_PID=$!
+sleep 1
+curl -s http://127.0.0.1:8765/api/v1/ | jq '.data.endpoints | map(select(. | test("vlsm6|lookup|diff")))'
+curl -s -X POST http://127.0.0.1:8765/api/v1/vlsm6 -H 'Content-Type: application/json' \
+    -d '{"network":"2001:db8::","cidr":"32","requirements":[{"name":"a","hosts":4}]}' | jq .
+curl -s -X POST http://127.0.0.1:8765/api/v1/lookup -H 'Content-Type: application/json' \
+    -d '{"cidrs":["10.0.0.0/8"],"ips":["10.1.2.3"]}' | jq .
+curl -s -X POST http://127.0.0.1:8765/api/v1/diff -H 'Content-Type: application/json' \
+    -d '{"before":["10.0.0.0/24"],"after":["10.0.0.0/23"]}' | jq .
+kill $SMOKE_PID
+```
+All four responses must be valid JSON with `ok: true`.
+
+- [ ] **Step 4: Update README.md downloads row** with size + SHA. Commit:
+
+```bash
+git add README.md releases/subnet-calculator-2.11.0.tar.gz
+git commit -m "release: v2.11.0 tarball"
+```
+
+---
+
+## Task 8: Open PR (REQUIRES EXPLICIT USER PERMISSION)
+
+**Files:** none
+
+- [ ] **Step 1: Push the release branch**
+
+```bash
+git push origin release/v2.11.0
+```
+
+- [ ] **Step 2: HALT — request explicit user approval to open PR**
+
+Output to user: "Release branch pushed at SHA `<short-sha>`. Local gate green: PHPUnit `<n/n>`, PHPStan L9 0, PHPCS 0, ESLint/Stylelint 0, Spectral 0, Semgrep 0, Playwright `<n/n>`. Tarball `releases/subnet-calculator-2.11.0.tar.gz` (`<size>` bytes, sha256 `<hash>`). Smoke test pass on all 4 new endpoints. **May I open the PR?**"
+
+DO NOT open the PR until the user replies with explicit approval.
+
+- [ ] **Step 3 (after approval): Open PR**
+
+```bash
+gh pr create --base main --head release/v2.11.0 --title "release: v2.11.0" --body "$(cat <<'EOF'
+## Summary
+
+v2.11.0 — IPv6 VLSM headline + 3 new tools. Closes 4 milestone issues.
+
+- Closes #293 — IPv6 VLSM planner (parity with IPv4)
+- Closes #294 — Copy-as-Markdown / Copy-as-Cisco-config exports
+- Closes #295 — Inverse subnet lookup
+- Closes #296 — Subnet aggregation diff
+
+## What's new
+
+- **IPv6 VLSM planner** — full parity with IPv4 VLSM (table input, CSV/JSON/XLSX/ASCII export, Copy All, shareable URL, utilisation summary). `2^N` host counts supported via GMP. New `POST /api/v1/vlsm6`.
+- **Inverse subnet lookup** — paste CIDRs + IPs, get the deepest matching CIDR per IP. New `POST /api/v1/lookup` (caps: 100 CIDRs, 1000 IPs).
+- **Subnet aggregation diff** — paste before/after CIDR lists, get added/removed/changed/unchanged groups. Catches prefix changes (e.g. `/24 → /23`). New `POST /api/v1/diff`.
+- **Copy-as-Markdown / Copy-as-Cisco** — new buttons in IPv4, IPv6, VLSM, splitter result panels.
+- **Documentation** — new `docs/ipv6-vlsm.md`, `docs/lookup.md`, `docs/diff.md`, `docs/exports.md`. CHANGELOG, README downloads table, mkdocs.yml, install snippet, CLAUDE.md all bumped to 2.11.0.
+
+## Test plan
+
+- [x] PHPUnit `<n/n>` (GMP skips counted)
+- [x] PHPStan L9, 0 errors
+- [x] PHPCS PSR-12, 0 errors
+- [x] ESLint + Stylelint clean
+- [x] Spectral OpenAPI lint, 0 errors
+- [x] Semgrep, 0 findings
+- [x] MkDocs `--strict` build green
+- [x] Playwright E2E `make test-docker`: `<n/n>` pass, including new groups for IPv6 VLSM, lookup, diff, copy-as-*
+- [x] Tarball smoke test: `subnet-calculator-2.11.0.tar.gz` (`<size>`, sha256 `<hash>`) — all 4 new endpoints respond OK under `php -S`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for CI**
+
+```bash
+gh pr checks <pr-number> --watch
+```
+
+If CI fails on any matrix slot: investigate, fix the root cause, push, re-run. Treat all failures as real.
+
+- [ ] **Step 5: HALT — request explicit user approval to merge**
+
+Output to user: "PR `<number>` opened. CI status: `<summary>`. CodeRabbit: `<status>`. **May I merge?**"
+
+DO NOT merge until the user replies with explicit approval.
+
+- [ ] **Step 6 (after approval): Merge**
+
+```bash
+gh pr merge <pr-number> --merge --delete-branch
+```
+
+---
+
+## Task 9: Post-merge release ritual
+
+**Files:**
+- Memory MCP only (plus GitHub state)
+
+- [ ] **Step 1: Pull merged main**
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+- [ ] **Step 2: Tag release**
+
+```bash
+git tag -a v2.11.0 -m "v2.11.0"
+git push origin v2.11.0
+```
+
+- [ ] **Step 3: Create GitHub release**
+
+```bash
+gh release create v2.11.0 \
+    --title "v2.11.0" \
+    --notes-from-tag \
+    releases/subnet-calculator-2.11.0.tar.gz
+```
+
+- [ ] **Step 4: Deploy to test instance** (per CLAUDE.md):
+
+```bash
+rsync -a --delete Subnet-Calculator/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+scp testing/fixtures/iframe-test.html root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/sc/
+```
+
+Smoke-test the test instance: `curl -u $IPAM_BASIC_USER:$IPAM_BASIC_PASS https://dev-direct.seanmousseau.com/claude/sc/api/v1/ | jq .data.version` → `2.11.0`.
+
+- [ ] **Step 5: Deploy to production** (per `reference_deployments.md`):
+
+Use the documented prod deploy procedure. Verify `https://subnetcalculator.app/api/v1/` returns version 2.11.0. Purge Cloudflare cache.
+
+- [ ] **Step 6: Sync `dev` branch to `main`**
+
+```bash
+git checkout dev
+git merge --ff-only main
+git push origin dev
+```
+
+- [ ] **Step 7: Close milestone + verify all 4 issues closed**
+
+The PR's `Closes #...` lines auto-close issues on merge. Verify:
+```bash
+gh issue list --state closed --search 'milestone:v2.11.0' --json number,title
+gh api -X PATCH repos/seanmousseau/Subnet-Calculator/milestones/20 -f state=closed
+```
+
+- [ ] **Step 8: Update Memory MCP**
+
+Add final observation to `project:subnet-calculator:release:v2.11.0`: "SHIPPED. Tag v2.11.0 at merge commit `<sha>` on main. Release URL: `<url>`. Bundle SHA256: `<hash>`. Milestone #20 closed, all 4 issues closed (#293, #294, #295, #296). Test/prod deployed; CF cache purged."
+
+Update `MEMORY.md` index with `[v2.11.0 — IPv6 VLSM + 3 tools](project_v211.md)` and create `project_v211.md` summarising scope and links.
+
+- [ ] **Step 9: Final report to user**
+
+Summarise: tag, release URL, bundle SHA, deploy targets verified, milestone closed, memory updated.
+
+---
+
+## Self-Review Checklist (run before handing the plan off)
+
+- [x] Spec coverage: all 4 milestone issues mapped (Task 1 = #293; Task 2 = #295; Task 3 = #296; Task 4 = #294).
+- [x] No placeholders in code blocks; every `<n>`/`<sha>`/`<hash>`/`<url>`/`<size>`/`<short-sha>` is a runtime substitution at execution time, not a TBD.
+- [x] Type / function names consistent across tasks: `vlsm6_allocate`, `lookup_ips`, `subnet_diff`, `buildMarkdown`, `buildCiscoConfig`.
+- [x] Release gate is non-skippable; explicit user permission gates on PR open and merge are called out twice each.
+- [x] UI/UX work routes through `ui-ux-pro-max` skill in Tasks 1, 2, 3, 4.
+- [x] Documentation work routes through `documentation` skill in Tasks 1, 2, 3, 4, 5.
+- [x] Memory MCP updates after every task.
+- [x] No flake dismissal — explicit instruction to root-cause every failure.


### PR DESCRIPTION
Brings `docs/superpowers/plans/` to full coverage. The v2.9.0 style-guide, v2.10.0, v2.11.0, and the v2.8.x documentation-improvements plans were left untracked at their original release time; every v2.12.0+ plan is already in tree. Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive release plans outlining upcoming features and improvements.

* **Upcoming Features Preview**
  * v2.9.0: Enhanced UI/UX design with new typography and refined mobile layouts.
  * v2.10.0: Wildcard ↔ CIDR converter and dark-mode print support.
  * v2.11.0: IPv6 VLSM planner, inverse subnet lookup, aggregation diff analysis, and Markdown/Cisco export formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Subnet-Calculator/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->